### PR TITLE
perf(stream): use positional token byte delta

### DIFF
--- a/docs/plans/2026-06-28-stream-assembler-token-byte-positional-delta.md
+++ b/docs/plans/2026-06-28-stream-assembler-token-byte-positional-delta.md
@@ -1,0 +1,44 @@
+# Stream assembler token-byte positional delta slice
+
+## Scope
+
+Optimize exactly one Python hot path in `RequestStreamAssembler.accept`: the plain
+`token_bytes` fast path that emits an `AssemblyDelta` immediately for complete
+visible byte fragments.
+
+Affected files:
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py` (existing focused coverage)
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py` (existing probe selection coverage)
+- `scripts/stream_assembler_token_bytes_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`stream-assembler-token-byte-fast-decode` in `infra/perf/pr_scoped_probes.json`.
+That registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` fields for Linux CI.
+
+## Optimization
+
+The immediate visible `token_bytes` branch constructs the returned
+`AssemblyDelta` with positional arguments instead of keyword arguments. The
+field values and parsing semantics remain unchanged; the change only avoids
+keyword-binding overhead in the registered hot path.
+
+## Verification
+
+Run the registered test command, changed-scope coverage command, and registered
+probe locally on Linux. Compare the registered probe against the pre-optimization
+baseline from the same worktree before pushing.
+
+## Success criteria
+
+- Focused stream assembler token-byte regression tests pass.
+- Changed-scope coverage remains at least 95% for touched executable files.
+- Local registered probe shows lower `elapsed_ms_mean` than the pre-optimization
+  baseline.
+- PR-scoped performance CI selects and completes
+  `stream-assembler-token-byte-fast-decode`.

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -483,7 +483,7 @@ class RequestStreamAssembler:
                 ):
                     self._assistant_parts.append(byte_delta)
                     self._raw_seen_assistant_part_count += 1
-                    return [AssemblyDelta(content_text=byte_delta, raw_text=byte_delta)]
+                    return [AssemblyDelta(byte_delta, "", byte_delta)]
         elif token_ids or token_logprobs:
             token_count = self._record_token_metadata(fragment)
             if token_bytes is not None:


### PR DESCRIPTION
## Summary
- Avoid keyword binding in the plain `token_bytes` stream-assembler fast path by constructing the immediate `AssemblyDelta` positionally.
- Keep token-byte parsing behavior and emitted `content_text` / `raw_text` values unchanged.

## Plan or Spec
- `docs/plans/2026-06-28-stream-assembler-token-byte-positional-delta.md`
- Registered PR-scoped probe: `stream-assembler-token-byte-fast-decode` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe before runtime change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
elapsed_ms_mean=665.0760725955479, peak_bytes_mean=6128411.2

# Candidate probe after runtime change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
elapsed_ms_mean=628.5035941749811, peak_bytes_mean=6128411.2

# Repeat candidate probe after runtime change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
elapsed_ms_mean=639.7843539831229, peak_bytes_mean=6128411.2

# Focused registered test command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_plain_token_metadata_keeps_fast_path_and_metrics services/mlx-worker-python/tests/test_stream_assembler.py::test_estimated_delta_token_count_matches_split_semantics_without_ascii_allocation services/mlx-worker-python/tests/test_stream_assembler.py::test_delta_token_annotation_uses_ascii_count_fast_path services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_ascii_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_decodes_complete_multibyte_without_incremental_decoder services/mlx-worker-python/tests/test_stream_assembler.py::test_token_byte_delta_preserves_split_multibyte_sequence services/mlx-worker-python/tests/test_stream_assembler.py::test_standard_qwen_pipe_tool_parser_keeps_rescue_parser_off services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_metric_gate_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_only_gates_current_path_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_still_gates_large_count_helper_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
14 passed in 1.37s

# Changed-scope coverage command (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_metric_gate_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_only_gates_current_path_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_still_gates_large_count_helper_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_token_bytes_probe.py
100 passed in 0.94s; TOTAL 1 0 100%
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 1 0 100%`).
- Local Linux registered probe baseline: `elapsed_ms_mean=665.0760725955479`, `peak_bytes_mean=6128411.2`.
- Local Linux registered probe candidate runs: `elapsed_ms_mean=628.5035941749811` and `639.7843539831229`, `peak_bytes_mean=6128411.2`.
- Best observed local delta: `-36.5724784205668 ms` (`~5.50%` faster) vs baseline; repeat candidate remained faster by `-25.2917186124250 ms` (`~3.80%`).
- Registered PR-scoped performance CI is required as the merge validation source for this probe.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR is limited to the registered Python stream-assembler probe and focused tests on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
