### PR TITLE
perf(export): scan parent path components directly

### DIFF
--- a/docs/plans/2026-06-28-export-target-manifest-parent-path-scan.md
+++ b/docs/plans/2026-06-28-export-target-manifest-parent-path-scan.md
@@ -1,0 +1,42 @@
+# Export target manifest parent path scan
+
+This Python-only performance slice is limited to export-target manifest safe
+relative path validation in `worker.productization.export_target_manifest`.
+
+## Registered probe
+
+The affected path is covered by the existing `runtime-export-manifest-validation`
+registered PR-scoped performance probe in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/export_target_manifest.py`
+- `services/mlx-worker-python/tests/test_export_target_manifest_contract.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/export_target_manifest_metrics_report.py`
+- `scripts/runtime_export_manifest_validation_probe.py`
+
+## Slice
+
+`_safe_relative_path_error()` previously used `path_value.split("/")` to detect
+exact `..` path components after the earlier empty-component guard. This slice
+replaces that list allocation with a small direct string scan that preserves the
+same component semantics.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe
+locally on Linux before opening the PR. GitHub Actions PR-scoped performance is
+the merge gate for the registered probe report.
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
+```
+
+## Expected performance signal
+
+The expected directional improvement is lower validation latency and peak
+allocation during repeated manifest validation, with unchanged schema errors and
+fixture coverage.

--- a/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
+++ b/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
@@ -11,6 +11,7 @@ import pytest
 from packages.protocol.python.workspace.v1 import export_target_manifest_pb2
 from worker.productization.export_target_manifest import (
     REQUIRED_EXPORT_TARGET_TYPES,
+    _contains_parent_path_component,
     _safe_relative_path_error,
     _validate_metrics,
     validate_export_target_manifest_file,
@@ -225,6 +226,25 @@ def test_export_target_manifest_safe_relative_path_uses_string_checks(
     assert "parent-directory" in str(target._safe_relative_path_error("artifacts/../model.gguf"))
     assert "Windows absolute" in str(target._safe_relative_path_error("C:/Models/model.gguf"))
     assert "absolute" in str(target._safe_relative_path_error("/tmp/export.bin"))
+
+
+@pytest.mark.parametrize(
+    ("path_value", "expected"),
+    [
+        ("..", True),
+        ("../model.gguf", True),
+        ("artifacts/..", True),
+        ("artifacts/../model.gguf", True),
+        ("artifacts/.../model.gguf", False),
+        ("artifacts/model..gguf", False),
+        ("artifacts/..model/model.gguf", False),
+    ],
+)
+def test_export_target_manifest_parent_path_component_scan_preserves_split_semantics(
+    path_value: str,
+    expected: bool,
+) -> None:
+    assert _contains_parent_path_component(path_value) is expected
 
 
 def test_export_target_manifest_rejects_file_row_contract_violations(

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -408,6 +408,22 @@ def _safe_relative_path_error(path_value: str) -> str | None:
         return "current-directory paths are not allowed"
     if "//" in path_value:
         return "empty path components are not allowed"
-    if ".." in path_value.split("/"):
+    if _contains_parent_path_component(path_value):
         return "empty or parent-directory path components are not allowed"
     return None
+
+
+def _contains_parent_path_component(path_value: str) -> bool:
+    if ".." not in path_value:
+        return False
+    start = 0
+    while True:
+        index = path_value.find("..", start)
+        if index < 0:
+            return False
+        before_component = index == 0 or path_value[index - 1] == "/"
+        after_index = index + 2
+        after_component = after_index == len(path_value) or path_value[after_index] == "/"
+        if before_component and after_component:
+            return True
+        start = after_index


### PR DESCRIPTION
## Summary
- Replace export-target manifest parent-directory component detection with a direct string scan for exact `..` path components.
- Add a focused regression table preserving the previous `split("/")` semantics for parent path detection.

## Plan or Spec
- `docs/plans/2026-06-28-export-target-manifest-parent-path-scan.md`
- Registered probe: `runtime-export-manifest-validation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline from origin/main (3 registered probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
# elapsed_ms_mean: 2171.44501961302, 2126.3696257956326, 2100.3894160035998

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_parent_path_component_scan_preserves_split_semantics services/mlx-worker-python/tests/test_export_target_manifest_contract.py::test_export_target_manifest_safe_relative_path_uses_string_checks
# 8 passed in 0.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 45 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
# 45 passed in 0.65s; changed-scope coverage TOTAL 18 0 100%

# Head registered probe (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
# elapsed_ms_mean: 2106.718774395995, 2113.715880201198, 2104.288282210473

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 18 0 100%`).
- Registered local probe (`runtime_export_manifest_validation_probe.py`, Linux): old_mean=2132.734687 ms, new_mean=2108.240979 ms, delta_ms=-24.493708, speedup=1.15%.
- Probe invariants: `fixture_count=4.0`, `schema_error_count=0.0`, `manifest_byte_size=21400.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
