### PR TITLE
perf(engine): reuse empty media usage defaults

### DIFF
--- a/docs/plans/2026-06-28-engine-generate-empty-media-usage.md
+++ b/docs/plans/2026-06-28-engine-generate-empty-media-usage.md
@@ -1,0 +1,29 @@
+# Engine Generate Empty Media Usage Fast Path
+
+## Slice
+
+Optimize the Python worker generate hot path for requests that do not produce a
+media feature probe. The current implementation constructs the same zero-valued
+media usage dictionary for every request before finalization, including the
+plain text / `return_usage=false` path covered by the registered
+`engine-generate-usage-token-elision` PR-scoped performance probe.
+
+## Scope
+
+- Reuse a module-level zero media-usage mapping when no probe is present.
+- Preserve non-empty probe behavior by keeping per-call dictionaries for actual
+  media probe counters.
+- Keep the existing `engine-generate-usage-token-elision` focused tests,
+  changed-scope coverage command, and probe as the validation source.
+
+## Validation
+
+Linux local validation must run the registered probe commands for
+`engine-generate-usage-token-elision`:
+
+- focused pytest command from `infra/perf/pr_scoped_probes.json`
+- changed-scope coverage command from `infra/perf/pr_scoped_probes.json`
+- `scripts/engine_generate_usage_token_probe.py`
+
+CI validation must include the PR-scoped performance workflow and registered
+probe report before merge.

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -60,6 +60,12 @@ _PROMPT_CONTEXT_RECEIPT_METRIC_KEYS = {
     "melix.prompt_context.receipt_count": "prompt_context_receipt_count",
     "melix.prompt_context.receipts_json": "prompt_context_receipts_json",
 }
+_EMPTY_MEDIA_FEATURE_USAGE = {
+    "media_feature_cache_hits": 0,
+    "media_feature_cache_misses": 0,
+    "media_feature_encoder_calls_saved": 0,
+    "media_feature_work_saved_bytes": 0,
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,14 +184,14 @@ def _probe_counter_value(probe: object, primary_key: str, legacy_key: str) -> in
 
 
 def _media_feature_usage_from_probe(probe: object | None) -> dict[str, int]:
+    if probe is None:
+        return _EMPTY_MEDIA_FEATURE_USAGE
     usage = {
         "media_feature_cache_hits": 0,
         "media_feature_cache_misses": 0,
         "media_feature_encoder_calls_saved": 0,
         "media_feature_work_saved_bytes": 0,
     }
-    if probe is None:
-        return usage
 
     for key in usage:
         usage[key] = _probe_counter_value(


### PR DESCRIPTION
## Summary
- Reuse a module-level zero media usage mapping for the no-probe generate hot path.
- Avoid repeated allocation of the same media feature usage dictionary when `_media_feature_usage_from_probe(None)` is called for plain text/no-media requests.
- Preserve fresh per-call dictionaries for non-empty probe objects so mutable counter state is not shared.

## Plan or Spec
- `docs/plans/2026-06-28-engine-generate-empty-media-usage.md`
- Registered PR-scoped probe: `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Focused behavior/probe tests with explicit in-process sys.path setup
uv run --project services/mlx-worker-python python3 - <<'PY'
import sys
sys.path.insert(0, '.')
sys.path.insert(0, 'services/mlx-worker-python')
import pytest
raise SystemExit(pytest.main([
    '-q',
    'services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback',
    'services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count',
    'services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion_without_request_token_accumulation',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe',
    'services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics',
]))
PY
# Result: 5 passed in 0.50s

# Changed-scope coverage for the affected Python paths/tests
# Result: 11 passed in 1.02s; changed-scope coverage TOTAL 3 0 100%

# Local registered probe, reduced request count for before/after comparison
MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" \
MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS=200 \
MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES=3 \
uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# Baseline before this change: elapsed_ms_mean=23.08625599835068, fallback_elapsed_ms_mean=126.99022601979475
# After this change: elapsed_ms_mean=21.941631314499926, fallback_elapsed_ms_mean=123.86674466930951

# Local registered probe with default sample/request settings after this change
MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" \
uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# Result: elapsed_ms_mean=33.572601596824825, fallback_elapsed_ms_mean=124.4309541885741, request_count=300, samples=5

git diff --check
# Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local reduced probe comparison for `engine-generate-usage-token-elision`:
  - `elapsed_ms_mean`: `23.08625599835068 -> 21.941631314499926` (`delta_ms=-1.144624683850754`, about `4.96%` faster).
  - `fallback_elapsed_ms_mean`: `126.99022601979475 -> 123.86674466930951` (`delta_ms=-3.1234813504852355`, about `2.46%` faster).
  - Prompt token fallback calls remained `0.0` per request.
  - Request-state append calls remained `0.0` per request.
- Full registered PR-scoped performance validation is expected from GitHub Actions for the registered probe.

## Known Gaps
- CI must complete the PR-scoped performance workflow before merge.
- A direct local pytest invocation without path setup failed collection due import path resolution (`packages`/`worker` not found); the focused runs above used explicit in-process `sys.path` setup instead of unsafe `PYTHONPATH` environment overrides.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
