### PR TITLE
perf(model-load): fast-path non-empty policy sources

### DIFF
--- a/docs/plans/2026-06-28-model-load-nonempty-leading-char.md
+++ b/docs/plans/2026-06-28-model-load-nonempty-leading-char.md
@@ -1,0 +1,37 @@
+# Model load trust non-empty leading-character fast path
+
+## Scope
+
+This Python-only performance slice is limited to the model-load trust policy
+source fallback helper in `services/mlx-worker-python/worker/model_load_trust.py`.
+It preserves existing behavior for empty, whitespace-only, leading-whitespace,
+and common non-empty policy source values.
+
+The affected path is covered by the registered PR-scoped probe
+`model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`. The entry
+already provides focused `test_command`, `coverage_command`, and `probe_command`
+values and selects this probe when `worker/model_load_trust.py` or its tests
+change.
+
+## Plan
+
+1. Add a focused regression guard for a leading-whitespace but non-empty policy
+   source so the helper's fallback behavior remains unchanged.
+2. Avoid whole-string whitespace scanning for the common non-empty policy source
+   path by checking the leading character first, falling back to `isspace()` only
+   when the source begins with whitespace.
+3. Run the registered focused test command, changed-scope coverage command, and
+   registered probe locally on Linux before opening the PR.
+
+## Metrics
+
+- Baseline registered probe before change on Linux:
+  `elapsed_ms_mean=6.020329135935754`, `elapsed_ms_min=5.959293979685754`,
+  `peak_bytes_mean=3251.5714285714284`, `rejections_mean=300.0`.
+- Candidate registered probe after change on Linux (3 runs):
+  `elapsed_ms_mean` values `6.383530138659158`, `5.759119446988085`,
+  `5.7851652964018285`; mean `5.975938294016356` ms. Delta vs baseline:
+  `-0.04439084191939724` ms (`~0.7373%` lower). `rejections_mean` remained
+  `300.0` for all runs and `peak_bytes_mean` remained `3251.5714285714284`.
+- Acceptance target: lower or neutral `elapsed_ms_mean` with unchanged rejection
+  count under the registered probe.

--- a/services/mlx-worker-python/tests/test_model_load_trust.py
+++ b/services/mlx-worker-python/tests/test_model_load_trust.py
@@ -38,6 +38,7 @@ def test_trust_policy_non_empty_source_fast_path_preserves_blank_fallback() -> N
 
 
 def test_requested_mode_reuses_valid_mode_membership_for_sources() -> None:
+    assert model_load_trust_module._non_empty(" request", "fallback") == " request"
     model = WorkerModelCatalog.dev_text_model()
     assert model_load_trust_module._requested_mode(model, None) == (
         common_pb2.MODEL_LOAD_TRUST_DEFAULT_SAFE,

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -393,4 +393,8 @@ def _route_name(route_class: int) -> str:
 
 
 def _non_empty(value: str, fallback: str) -> str:
-    return value if value and not value.isspace() else fallback
+    if not value:
+        return fallback
+    if not value[0].isspace():
+        return value
+    return fallback if value.isspace() else value


### PR DESCRIPTION
## Summary
- Fast-path model-load trust policy source fallback for common non-empty values by checking the leading character before whole-string whitespace scanning.
- Add a focused guard for leading-whitespace-but-non-empty source values so fallback behavior remains unchanged.

## Plan or Spec
- `docs/plans/2026-06-28-model-load-nonempty-leading-char.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_rejects_custom_loader_metadata_without_explicit_trust services/mlx-worker-python/tests/test_model_load_trust.py::test_worker_trusted_custom_loader_receipt_passes_trust_remote_code services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_common_loader_fast_path_skips_normalized_membership services/mlx-worker-python/tests/test_model_load_trust.py::test_requested_mode_reuses_valid_mode_membership_for_sources services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_with_direct_open services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_config_json_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_auto_map_detection_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_avoids_string_coercion_for_strings services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_common_string_uses_leading_character_fast_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_blank_string_behavior services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_non_string_fallback services/mlx-worker-python/tests/test_model_load_trust.py::test_route_class_runtime_kind_map_preserves_supported_defaults services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_skips_expanduser_for_plain_model_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_stats_plain_config_path_without_path_join services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_expands_tilde_model_path services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_detection_does_not_scan_model_files services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_missing_config_json_as_absent services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_blank_model_path_as_absent services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_directory_config_json_as_absent services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_treats_empty_config_json_as_absent services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reports_config_json_without_auto_map_loader services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 25 passed in 0.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py
# 25 passed in 1.02s; TOTAL 6 changed lines, 0 missed, 100% changed-scope coverage

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py
# baseline before change: {"elapsed_ms_mean": 6.020329135935754, "elapsed_ms_min": 5.959293979685754, "peak_bytes_mean": 3251.5714285714284, "rejections_mean": 300.0}
# candidate runs: elapsed_ms_mean 6.383530138659158, 5.759119446988085, 5.7851652964018285; mean 5.975938294016356; rejections_mean 300.0 for all runs

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 6 0 100%`).
- Registered probe: `model-load-config-json-bytes`.
- Baseline `elapsed_ms_mean=6.020329135935754`; candidate 3-run mean `5.975938294016356`; delta `-0.04439084191939724` ms (`~0.7373%` lower).
- `rejections_mean` unchanged at `300.0`; `peak_bytes_mean` unchanged at `3251.5714285714284`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Full repository gates were not run locally; this Linux slice ran the focused registered test, changed-scope coverage, and registered probe. GitHub Actions must provide the final registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; no new probe overhead introduced.
- [x] Deferred work and known gaps are stated explicitly.
