### PR TITLE
perf(retrieval): bind receipt dict copies

### DIFF
--- a/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
+++ b/docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md
@@ -36,6 +36,11 @@ This follow-up adds fast paths for valid store-record projection in `project_ret
 
 The registered `retrieval-context-projection-fastpath` probe is extended with store-record projection metrics so the store bridge fast path is measured by the same PR-scoped performance gate.
 
+This follow-up keeps the receipt isolation contract but binds `dict.copy` once in
+the projection loops. The hot paths still return fresh shallow copies of
+admission/refusal receipts, while avoiding repeated bound-method lookup for each
+receipt copy.
+
 ## Verification Plan
 
 Run the registered focused test command, changed-scope coverage command, and registered probe command locally on Linux before opening the PR. The PR-scoped performance workflow remains the authoritative CI validation source after push.

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -849,6 +849,9 @@ def test_project_retrieval_store_records_projects_records_without_entry_reentry(
     assert multi_projection.user_payload == MultiAdmission.user_payload
     assert multi_projection.untrusted_context_receipts == MultiAdmission.untrusted_context_receipts
     assert multi_projection.untrusted_context_receipts[0] is not MultiAdmission.untrusted_context_receipts[0]
+    assert multi_projection.untrusted_context_receipts[1] is not MultiAdmission.untrusted_context_receipts[1]
+    MultiAdmission.untrusted_context_receipts[0]["mutated"] = "true"
+    assert "mutated" not in multi_projection.untrusted_context_receipts[0]
 
     class SeedAdmission:
         user_payload = {"retrieved_document": {"title": "Seed"}}

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -135,6 +135,7 @@ def project_retrieval_contexts(
     receipts_append = receipts.append
     user_payload_update = user_payload.update
     entry_type = RetrievalContextEntry
+    dict_copy = dict.copy
 
     for entry in entries:
         if type(entry) is entry_type:
@@ -206,7 +207,7 @@ def project_retrieval_contexts(
             admission = admit_entry(entry)
         except RetrievalContextAdmissionError as exc:
             for receipt in exc.refusal_receipts:
-                refusal_receipts_append(receipt.copy())
+                refusal_receipts_append(dict_copy(receipt))
             continue
 
         admission_payload = admission.user_payload
@@ -241,10 +242,10 @@ def project_retrieval_contexts(
             user_payload_update(admission_payload)
         admission_receipts = admission.untrusted_context_receipts
         if len(admission_receipts) == 1:
-            receipts_append(admission_receipts[0].copy())
+            receipts_append(dict_copy(admission_receipts[0]))
         else:
             for receipt in admission_receipts:
-                receipts_append(receipt.copy())
+                receipts_append(dict_copy(receipt))
 
     return RetrievalContextProjection(
         user_payload=user_payload,
@@ -286,6 +287,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
     projection_refusal_receipts_extend = projection_refusal_receipts.extend
     receipts_append = receipts.append
     user_payload_update = user_payload.update
+    dict_copy = dict.copy
 
     for record in records:
         if type(record) is not dict and not isinstance(record, Mapping):
@@ -399,7 +401,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             )
         except RetrievalContextAdmissionError as exc:
             for receipt in exc.refusal_receipts:
-                projection_refusal_receipts_append(receipt.copy())
+                projection_refusal_receipts_append(dict_copy(receipt))
             continue
 
         admission_payload = admission.user_payload
@@ -434,10 +436,10 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             user_payload_update(admission_payload)
         admission_receipts = admission.untrusted_context_receipts
         if len(admission_receipts) == 1:
-            receipts_append(admission_receipts[0].copy())
+            receipts_append(dict_copy(admission_receipts[0]))
         else:
             for receipt in admission_receipts:
-                receipts_append(receipt.copy())
+                receipts_append(dict_copy(receipt))
 
     if projection_refusal_receipts:
         store_refusal_receipts.extend(projection_refusal_receipts)


### PR DESCRIPTION
## Summary
- Bind `dict.copy` once in retrieval projection hot loops before copying admission/refusal receipts.
- Preserve shallow-copy isolation for projected receipt lists and extend the store-record regression test to assert copied receipt isolation.

## Plan or Spec
- `docs/plans/2026-06-12-retrieval-context-projection-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions
# exit 0; 2 passed in 0.22s

<registered retrieval-context-projection-fastpath test_command from infra/perf/pr_scoped_probes.json>
# exit 0; 33 passed in 0.96s

<registered retrieval-context-projection-fastpath coverage_command from infra/perf/pr_scoped_probes.json>
# exit 0; 33 passed in 0.36s; changed-scope coverage TOTAL 11 0 100%

<registered retrieval-context-projection-fastpath probe_command from infra/perf/pr_scoped_probes.json>
# exit 0; optimized_elapsed_ms_mean=0.11217776388678301; store_optimized_elapsed_ms_mean=0.1254256360906376; lookup_copy_optimized_elapsed_ms_mean=0.39056166784056195

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id retrieval-context-projection-fastpath --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/perf/retrieval-context-receipt-copy-binding-rerun.json
# exit 0; head verification 33 passed; changed-scope coverage 100%; base/head probe completed ok
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=11`, `aggregate_covered_changed_lines=11`).
- Registered local PR-scoped probe comparison (`retrieval-context-projection-fastpath`, rerun):
  - `optimized_elapsed_ms_mean`: base `0.11322304140776396` ms, head `0.11207223144343256` ms, delta `-0.0011508099643314` ms (`-1.02%`).
  - `store_optimized_elapsed_ms_mean`: base `0.13433019069322785` ms, head `0.1263842039458853` ms, delta `-0.00794598674764255` ms (`-5.92%`).
  - `lookup_copy_optimized_elapsed_ms_mean`: base `0.3714365278886232` ms, head `0.37032615428740556` ms, delta `-0.00111037360121764` ms (`-0.30%`).
- CI PR-scoped performance report is still required as the authoritative merge gate.

## Known Gaps
- Linux local validation only; no Swift/runtime effect is claimed for this Python-only slice.
- CI must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
