### PR TITLE
perf(tool-registry): copy cached worker config template

### DIFF
--- a/docs/plans/2026-06-05-tool-registry-worker-config-copy-binding.md
+++ b/docs/plans/2026-06-05-tool-registry-worker-config-copy-binding.md
@@ -22,12 +22,23 @@ isolation while avoiding the selection-cache dictionary lookup on the hot full
 selection path. The slice also binds the copy helper locally inside
 `built_in_tool_config()` so all return branches reuse the same fast local lookup.
 
+## Follow-up slice: worker config template copy
+
+A 2026-06-28 follow-up keeps the same protobuf isolation contract for
+`ToolRegistry.as_worker_tool_config()` but caches the built `ToolConfig` object as
+an internal template. Repeated calls now copy the cached template directly instead
+of reparsing the cached serialized bytes. The method still returns a fresh
+protobuf object every time, so caller mutations cannot affect later callers or the
+registry cache.
+
 ## Verification plan
 
-- Focused tool-registry tests, including full tuple selection copy isolation.
+- Focused tool-registry tests, including full tuple selection copy isolation and
+  direct `ToolRegistry.as_worker_tool_config()` copy isolation.
 - Registered changed-scope coverage for the tool-registry probe scope.
 - Registered local probe on Linux, comparing the pre-change and post-change
-  `full_selection_tool_config_elapsed_ms_mean` and adjacent metrics.
+  `full_selection_tool_config_elapsed_ms_mean`,
+  `partial_selection_tool_config_elapsed_ms_mean`, and adjacent metrics.
 
 ## Boundary
 

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -100,6 +100,18 @@ def test_built_in_tool_config_returns_isolated_template_copies() -> None:
     assert second_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION
 
 
+def test_tool_registry_worker_config_reuses_isolated_template_copy() -> None:
+    registry = ToolRegistry(built_in_tool_registry().tools)
+    first_config = registry.as_worker_tool_config()
+    first_config.tools.pop()
+    first_config.schema_version = "mutated"
+
+    second_config = registry.as_worker_tool_config()
+
+    assert len(second_config.tools) == len(BUILTIN_AGENTIC_TOOL_NAMES)
+    assert second_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION
+
+
 def test_built_in_tool_config_full_tuple_selection_returns_full_template_copy() -> None:
     selected_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
     selected_config.tools.pop()

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -237,6 +237,7 @@ class ToolRegistry:
         "_tools",
         "_toolset_version",
         "_worker_tool_config_bytes",
+        "_worker_tool_config_template",
     )
 
     def __init__(
@@ -270,6 +271,7 @@ class ToolRegistry:
         )
         self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
         self._worker_tool_config_bytes: bytes = b""
+        self._worker_tool_config_template: common_pb2.ToolConfig | None = None
         self._metrics = ToolRegistryMetrics(
             tool_count=len(self._tools),
             schema_bytes=sum(tool.schema_byte_count() for tool in self._tools),
@@ -426,8 +428,9 @@ class ToolRegistry:
         ]
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:
-        if self._worker_tool_config_bytes:
-            return _TOOL_CONFIG_FROM_BYTES(self._worker_tool_config_bytes)
+        cached_template = self._worker_tool_config_template
+        if cached_template is not None:
+            return _copy_tool_config(cached_template)
         config = common_pb2.ToolConfig(
             tools=[tool.as_worker_tool_definition() for tool in self._tools],
             schema_format="openai-function",
@@ -437,7 +440,8 @@ class ToolRegistry:
             parser_contract_version=self._parser_contract_version,
         )
         self._worker_tool_config_bytes = config.SerializeToString()
-        return config
+        self._worker_tool_config_template = config
+        return _copy_tool_config(config)
 
     def _validate(self) -> None:
         if not self._schema_version:


### PR DESCRIPTION
## Summary
- Cache the built `ToolConfig` protobuf inside `ToolRegistry.as_worker_tool_config()` as an internal template.
- Keep every public call isolated by returning a fresh protobuf copy, with a regression test for mutation safety.
- Document the follow-up worker-config template-copy slice in the existing tool-registry plan.

## Plan or Spec
- Updated `docs/plans/2026-06-05-tool-registry-worker-config-copy-binding.md` with the 2026-06-28 follow-up slice and verification boundary.
- Registered PR-scoped probe: `tool-registry-schema-bytes-cache` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 90 passed.
- Changed-scope coverage: 100.00% (14/14 measurable changed lines covered).
- Baseline local probe before change:
  - `built_in_tool_config_elapsed_ms_mean=58.67134319851175`
  - `full_selection_tool_config_elapsed_ms_mean=60.250132996588945`
  - `partial_selection_tool_config_elapsed_ms_mean=54.07417301321402`
  - `schema_payload_elapsed_ms_mean=150.3711250028573`
- Local probe after change:
  - `built_in_tool_config_elapsed_ms_mean=55.41975118685514`
  - `full_selection_tool_config_elapsed_ms_mean=56.21450738981366`
  - `partial_selection_tool_config_elapsed_ms_mean=52.70247099688277`
  - `schema_payload_elapsed_ms_mean=145.59631140436977`
- Directional delta:
  - full-selection worker config copy: about -4.04 ms mean (-6.70%).
  - partial-selection worker config copy: about -1.37 ms mean (-2.54%).
  - built-in worker config copy: about -3.25 ms mean (-5.54%).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- Local timings are micro-benchmark evidence; the registered GitHub Actions PR-scoped performance report remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and showed directional improvement.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
