### PR TITLE
perf(export): fast-path diagnostic secret markers

### DIFF
--- a/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
+++ b/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
@@ -29,3 +29,17 @@ Post-change registered-probe runs after the final helper-local binding change:
 - `path_redaction_elapsed_ms_mean`: `23.047549021430314`, `23.80858139367774`, `22.933048591949046` ms; mean `23.26305966901903` ms (`-0.3763882680416582` ms).
 
 Decision: accepted for PR because the registered end-to-end elapsed metric improved, diagnosis matching and path-redaction sub-metrics improved, and the small latency/peak-memory noise remained within registered warning thresholds while behavior stayed covered by 100% changed-scope coverage.
+
+## 2026-06-28 follow-up: secret marker fast path
+
+This Python-only follow-up stays inside the same
+`runtime-export-diagnostic-parser` registered probe and narrows to
+`_redact_text(...)`. Every redacted excerpt line previously used a generator over
+`_SECRET_REDACTION_MARKERS` before deciding whether secret-specific regexes were
+needed. The common path has many plain runtime and target-path lines, so this
+slice replaces that generator dispatch with an explicit marker helper while
+preserving the same case-sensitive marker set and downstream redaction behavior.
+
+Validation remains the registered focused pytest selection, changed-scope
+coverage, and the registered local/CI probe for runtime export diagnostic
+parsing.

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -30,6 +30,7 @@ from worker.productization.export_target_diagnostics import (
     _diagnoses_from_excerpt,
     _diagnosis_metric_counts,
     _extend_source_lines,
+    _has_secret_redaction_marker,
     _split_source_lines,
 )
 from worker.productization.export_target_layout import (
@@ -99,6 +100,24 @@ def test_export_target_diagnostics_parser_matches_common_runtime_failures(
     assert receipt_path.is_file()
     assert json.loads(receipt_path.read_text(encoding="utf-8")) == receipt
     assert excerpt_path.read_text(encoding="utf-8").startswith("[logs/ollama-create.log]")
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("plain log line", False),
+        ("api_key=super-secret-value", True),
+        ("status: failed", True),
+        ("proxy=http://user:pass@example.test", True),
+        ("openai key sk-live", True),
+        ("-----BEGIN TOKEN-----abc123-----END TOKEN-----", True),
+    ],
+)
+def test_export_target_diagnostics_secret_marker_fast_path_matches_registered_markers(
+    text: str,
+    expected: bool,
+) -> None:
+    assert _has_secret_redaction_marker(text) is expected
 
 
 def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identity(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -596,7 +596,7 @@ def _redact_text(
         summary.redaction_count += 1
         return "<redacted-private-preview>"
 
-    if any(marker in text for marker in _SECRET_REDACTION_MARKERS):
+    if _has_secret_redaction_marker(text):
         secret_text = text.lower()
         if "-----begin " in secret_text:
             text = _CERTIFICATE_PATTERN.sub(lambda _match: _record_secret(summary), text)
@@ -632,6 +632,16 @@ def _redact_text(
             summary,
         ),
         text,
+    )
+
+
+def _has_secret_redaction_marker(text: str) -> bool:
+    return (
+        "=" in text
+        or ":" in text
+        or "@" in text
+        or "sk-" in text
+        or "-----BEGIN " in text
     )
 
 


### PR DESCRIPTION
## Summary
- Fast-path runtime export diagnostic secret-marker detection by replacing per-line generator membership with an explicit helper.
- Add a focused regression guard for the case-sensitive marker set used before secret-specific regexes run.

## Plan or Spec
- Updated `docs/plans/2026-06-28-export-diagnostics-source-line-extension.md` with the 2026-06-28 secret marker fast-path follow-up.
- Affected path is covered by registered PR-scoped probe `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_secret_marker_fast_path_matches_registered_markers`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-export-diagnostic-known-code-stop-20260628 --head-repo "$PWD" --output .runtime/perf/runtime-export-diagnostic-parser-secret-marker-{1,2,3}.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 41 passed.
- Changed-scope coverage: 100.00% (6/6 measurable changed lines).
- Local registered probe `runtime-export-diagnostic-parser`, 3-run mean:
  - `elapsed_ms_mean`: base 2876.295 ms, head 2873.843 ms, delta -2.452 ms.
  - `path_redaction_elapsed_ms_mean`: base 22.728 ms, head 20.834 ms, delta -1.894 ms.
  - `diagnostic_latency_ms`: base 9.093 ms, head 9.235 ms, delta +0.142 ms (within registered 5% warning threshold).
  - `peak_bytes_mean`: base 202528.4 bytes, head 203851.0 bytes, delta +1322.6 bytes (within registered 5% warning threshold).
- GitHub Actions PR-scoped performance report is required before merge.

## Known Gaps
- This is a Python-only Linux-verified slice; no Swift runtime behavior is changed.
- End-to-end elapsed probe is noisy; acceptance is based on stable improvement in the targeted path-redaction submetric plus no registered-threshold regression.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run against `origin/main` baseline and this branch.
- [ ] GitHub Actions completed successfully, including PR-scoped performance.
