### PR TITLE
perf(hub-catalog): bound cursor query parameter scan

### DIFF
--- a/docs/plans/2026-06-28-hub-catalog-cursor-param-boundary.md
+++ b/docs/plans/2026-06-28-hub-catalog-cursor-param-boundary.md
@@ -1,0 +1,25 @@
+# Hub catalog cursor parameter boundary scan
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._next_cursor_from_link(...)` and its focused regression coverage. It does not change Hub request construction, summary/card model semantics, generated protocol artifacts, or Swift runtime behavior.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance probe `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_next_cursor_probe.py`
+
+## Slice plan
+
+1. Keep the existing direct Link-header scanner and avoid reintroducing `urlparse` or `parse_qs` allocations.
+2. Replace the two-stage `?` / `&cursor=` lookup with a bounded `cursor=` scan that accepts only query-parameter boundaries (`?cursor=` or `&cursor=`) before the URL fragment.
+3. Add regression coverage showing cursor-like substrings in the path, other parameter names, and fragment are ignored.
+4. Verify with the registered focused tests, changed-scope coverage, and local registered probe on Linux, then use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+The success metric is the registered probe's `elapsed_ms_mean` for repeated `_next_cursor_from_link(...)` calls. `peak_bytes_mean` remains monitored. This is a Python-only slice and is locally verifiable on Linux; no Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -839,6 +839,15 @@ def test_next_cursor_from_link_accepts_cursor_at_query_start() -> None:
     assert hub_catalog_module._next_cursor_from_link(link_header) == "page/start"
 
 
+def test_next_cursor_from_link_skips_cursor_substrings_outside_query_parameters() -> None:
+    link_header = (
+        '<https://huggingface.co/api/models/cursor=path?mycursor=wrong&cursor=right%2Fvalue'
+        '#cursor=fragment>; rel="next"'
+    )
+
+    assert hub_catalog_module._next_cursor_from_link(link_header) == "right/value"
+
+
 def test_next_cursor_from_link_decodes_plus_space_cursor_without_percent_escape() -> None:
     link_header = '<https://huggingface.co/api/models?cursor=page+start&limit=10>; rel="next"'
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -29,6 +29,8 @@ _SIZE_HINT_MULTIPLIERS = {
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _NEXT_LINK_REL_MARKER = 'rel="next"'
+_CURSOR_QUERY_KEY = "cursor="
+_CURSOR_QUERY_KEY_LEN = len(_CURSOR_QUERY_KEY)
 _URL_HEX_DIGITS = {
     "0": 0,
     "1": 1,
@@ -362,24 +364,21 @@ def _next_cursor_from_link(link_header: str) -> str:
         if url_start < 0:
             search_start = relation_start + marker_len
             continue
-        query_start = link_header.rfind("?", url_start + 1, url_end)
-        if query_start < 0:
-            return ""
-        query_end = link_header.find("#", query_start + 1, url_end)
+        url_content_start = url_start + 1
+        query_end = link_header.find("#", url_content_start, url_end)
         if query_end < 0:
             query_end = url_end
-        value_start = query_start + 1
-        if link_header.startswith("cursor=", value_start, query_end):
-            value_start += len("cursor=")
-        else:
-            cursor_start = link_header.find("&cursor=", value_start, query_end)
-            if cursor_start < 0:
-                return ""
-            value_start = cursor_start + len("&cursor=")
-        value_end = link_header.find("&", value_start, query_end)
-        if value_end < 0:
-            value_end = query_end
-        return _unquote_plus_ascii_cursor(link_header[value_start:value_end])
+        cursor_start = link_header.find(_CURSOR_QUERY_KEY, url_content_start, query_end)
+        while cursor_start >= 0:
+            previous_char = link_header[cursor_start - 1] if cursor_start > url_content_start else ""
+            if previous_char == "?" or previous_char == "&":
+                value_start = cursor_start + _CURSOR_QUERY_KEY_LEN
+                value_end = link_header.find("&", value_start, query_end)
+                if value_end < 0:
+                    value_end = query_end
+                return _unquote_plus_ascii_cursor(link_header[value_start:value_end])
+            cursor_start = link_header.find(_CURSOR_QUERY_KEY, cursor_start + _CURSOR_QUERY_KEY_LEN, query_end)
+        return ""
 
 
 def _cursor_query_value(url: str, start: int, end: int) -> str:


### PR DESCRIPTION
## Summary
- Optimizes Hub catalog Link-header cursor extraction by scanning bounded `cursor=` query-parameter candidates directly.
- Adds a regression guard for cursor-like substrings in the URL path, other parameter names, and fragment.
- Documents the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-28-hub-catalog-cursor-param-boundary.md`
- Registered PR-scoped probe: `hub-catalog-next-cursor-fast-parse`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_extracts_encoded_next_cursor_without_full_query_parse services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_scans_segments_without_splitting_on_url_commas services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_accepts_cursor_at_query_start services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_skips_cursor_substrings_outside_query_parameters services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_decodes_plus_space_cursor_without_percent_escape services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_decodes_common_lowercase_cursor_escapes services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_preserves_utf8_and_malformed_percent_decoding services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_ignores_rel_marker_inside_previous_url services/mlx-worker-python/tests/test_hub_catalog.py::test_next_cursor_from_link_returns_empty_for_missing_or_malformed_next_cursor`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-next-cursor-fast-parse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-hub-catalog-cursor-param-boundary-20260628 --head-repo "$PWD" --output .runtime/perf/hub-catalog-cursor-param-boundary.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 9 cursor tests passed locally; full registered focused test set passed locally (`90 passed`).
- Changed-scope coverage: `TOTAL 18 0 100%`.
- Local registered probe (`hub-catalog-next-cursor-fast-parse`): old_mean=`519.059967ms`, new_mean=`486.514233ms`, delta=`-32.545734ms`, speedup=`1.066896x`, improvement=`6.270%`; peak bytes unchanged at `832`.
- PR-scoped performance CI is still required as the merge gate.

## Known Gaps
- This is Python-only and locally verified on Linux. No Swift runtime performance effect is claimed.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Local registered probe shows improved `elapsed_ms_mean`.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
