### PR TITLE
perf(dataset): carry preview row remaining count

### DIFF
--- a/docs/plans/2026-06-28-dataset-registry-preview-remaining-counter.md
+++ b/docs/plans/2026-06-28-dataset-registry-preview-remaining-counter.md
@@ -1,0 +1,29 @@
+# Dataset Registry Preview Remaining Counter
+
+## Scope
+
+This Python-only performance slice keeps `read_hf_dataset_snapshot_rows()` behavior unchanged while avoiding repeated `len(rows)`/`max()` work inside the limited preview read loop. The loop now carries a decrementing remaining-row counter across selected dataset files.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`. The probe entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_preview_limit_probe.py`
+
+## Plan
+
+1. Preserve the existing limited and unlimited row-reader semantics.
+2. Replace per-file `max(limit - len(rows), 0)` recomputation with a local `remaining` counter that is decremented by the number of rows read from each file.
+3. Verify with the registered focused tests, changed-scope coverage, and the registered PR-scoped performance probe on Linux.
+4. Use GitHub Actions as the final PR-scoped performance validation before merge.
+
+## Local Evidence Template
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered focused tests>
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_preview_limit_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
+```

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -453,13 +453,16 @@ def read_hf_dataset_snapshot_rows(
         selected_files = _iter_limited_preview_dataset_files(resolved_snapshot_path, limit=limit)
     else:
         selected_files = _iter_selected_dataset_files(resolved_snapshot_path, split=normalized_split)
+    remaining = limit
     for path in selected_files:
-        remaining = None if limit is None else max(limit - len(rows), 0)
-        if remaining == 0:
+        if remaining is not None and remaining <= 0:
             return rows
-        rows.extend(_read_rows_from_file(path, limit=remaining))
-        if limit is not None and len(rows) >= limit:
-            return rows
+        file_rows = _read_rows_from_file(path, limit=remaining)
+        rows.extend(file_rows)
+        if remaining is not None:
+            remaining -= len(file_rows)
+            if remaining <= 0:
+                return rows
     return rows
 
 


### PR DESCRIPTION
## Summary
- Carry a decrementing `remaining` row counter through `read_hf_dataset_snapshot_rows()` instead of recomputing `max(limit - len(rows), 0)` on each selected file.
- Add a scoped plan for the dataset registry preview remaining-counter slice.

## Plan or Spec
- `docs/plans/2026-06-28-dataset-registry-preview-remaining-counter.md`
- Registered PR-scoped probe: `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered dataset-registry-preview-limit-short-circuit focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py`
- Baseline: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` from `5a4b9cf1` baseline worktree.
- Head: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` from this branch.

## Coverage and Metrics
- Focused tests: 28 passed.
- Changed-scope coverage: 100.00% (`8/8` measurable changed lines covered).
- Local registered probe baseline (`5a4b9cf1`, default scale): `elapsed_ms_mean=101.688316`, `multi_limit_elapsed_ms_mean=144.504236`, `zero_limit_elapsed_ms_mean=0.001822`.
- Local registered probe head (`f710b5b`, default scale): `elapsed_ms_mean=96.954932`, `multi_limit_elapsed_ms_mean=143.350633`, `zero_limit_elapsed_ms_mean=0.001361`.
- Local delta: `elapsed_ms_mean -4.733384 ms` (~4.65% faster), `multi_limit_elapsed_ms_mean -1.153603 ms` (~0.80% faster), `zero_limit_elapsed_ms_mean -0.000461 ms`.
- CI PR-scoped performance workflow is required as the merge validation source.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime path is changed.
- Probe timing is synthetic and should be confirmed by the registered GitHub Actions PR-scoped performance report before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows improvement at default scale.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
