### PR TITLE
perf(probe-policy): fast-path default minimal policy

### DIFF
--- a/docs/plans/2026-06-28-probe-policy-default-fastpath.md
+++ b/docs/plans/2026-06-28-probe-policy-default-fastpath.md
@@ -1,0 +1,42 @@
+# Probe policy default-mode fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.probe_policy.ProbePolicy.from_value(...)` and `ProbePolicy.from_env(...)` when callers use the default `ProbeMode.MINIMAL` and pass empty, missing, or `None` probe-mode inputs.
+
+The behavior contract stays unchanged:
+
+- empty environment mappings still resolve to the default policy;
+- missing `MELIX_PROBE_MODE` values still resolve to the default policy;
+- `None` and empty string values still resolve to the default policy;
+- non-minimal default modes still use the existing default-mode policy map;
+- valid, normalized, and invalid probe-mode parsing semantics are unchanged.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json`.
+
+The probe entry has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/probe_policy.py`
+- `services/mlx-worker-python/worker/productization/probe_policy_overhead.py`
+- `services/mlx-worker-python/tests/test_probe_policy.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/probe_policy_noop_overhead_probe.py`
+
+This slice uses the existing `mode_parse_empty_call_ms_mean`, `mode_parse_none_call_ms_mean`, and `env_parse_empty_call_ms_mean` metrics as the primary local/CI performance evidence.
+
+## Implementation plan
+
+1. Keep focused probe-policy tests unchanged as behavior guards.
+2. Bind the minimal default `ProbePolicy` singleton at module load time.
+3. Return that singleton directly on the default-mode empty/none/env-missing paths, avoiding repeated default-mode dictionary lookups in the common no-configuration hot path.
+4. Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate after push.
+
+## Success criteria
+
+- Focused probe-policy tests pass.
+- Changed-scope coverage remains at or above the repository threshold for touched files.
+- The registered probe reports non-regression or improvement on default-mode empty/none/env-empty metrics.
+- Hosted `probe-policy-noop-overhead` PR-scoped CI completes successfully before merge.

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -46,10 +46,14 @@ class ProbePolicy:
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
         if env is not None and not env:
+            if default_mode is ProbeMode.MINIMAL:
+                return _MINIMAL_DEFAULT_PROBE_POLICY
             return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         values = os.environ if env is None else env
         raw_value = values.get(MELIX_PROBE_MODE_ENV, "")
         if not raw_value:
+            if default_mode is ProbeMode.MINIMAL:
+                return _MINIMAL_DEFAULT_PROBE_POLICY
             return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         return ProbePolicy.from_value(raw_value, default_mode=default_mode)
 
@@ -60,9 +64,13 @@ class ProbePolicy:
         default_mode: ProbeMode = ProbeMode.MINIMAL,
     ) -> ProbePolicy:
         if value is None:
+            if default_mode is ProbeMode.MINIMAL:
+                return _MINIMAL_DEFAULT_PROBE_POLICY
             return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
         if type(value) is str:
             if not value:
+                if default_mode is ProbeMode.MINIMAL:
+                    return _MINIMAL_DEFAULT_PROBE_POLICY
                 return _PROBE_POLICY_BY_DEFAULT_MODE[default_mode]
             policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:
@@ -103,6 +111,7 @@ _PROBE_POLICY_BY_MODE: dict[ProbeMode, ProbePolicy] = {
 _PROBE_POLICY_BY_DEFAULT_MODE: dict[ProbeMode, ProbePolicy] = {
     mode: ProbePolicy(mode=mode) for mode in ProbeMode
 }
+_MINIMAL_DEFAULT_PROBE_POLICY = _PROBE_POLICY_BY_DEFAULT_MODE[ProbeMode.MINIMAL]
 _EVIDENCE_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.EVIDENCE]
 _DEBUG_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.DEBUG]
 


### PR DESCRIPTION
## Summary
- Fast-path the default `ProbeMode.MINIMAL` policy for empty/missing env values and `None`/empty explicit values.
- Add a focused plan documenting the registered probe-policy slice and validation path.

## Plan or Spec
- `docs/plans/2026-06-28-probe-policy-default-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 18 passed in 1.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# 18 passed in 0.29s; changed-scope coverage TOTAL 9 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id probe-policy-noop-overhead --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/probe_policy_default_fastpath_probe.json
# ok; head verification passed; threshold_passed=1.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered local probe: `probe-policy-noop-overhead`.
- Local base -> head metrics:
  - `mode_parse_empty_call_ms_mean`: `0.000134821` -> `0.00013325` ms (`-0.000001571` ms).
  - `mode_parse_none_call_ms_mean`: `0.000116249` -> `0.000116895` ms (`+0.000000646` ms, within `2e-05` ms absolute tolerance).
  - `env_parse_empty_call_ms_mean`: `0.000127899` -> `0.000131337` ms (`+0.000003438` ms, within `2e-05` ms absolute tolerance).
  - `threshold_passed`: `1.0` -> `1.0`.

## Known Gaps
- Linux local validation only; GitHub Actions PR-scoped performance is the merge gate for the hosted registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
