### PR TITLE
perf(export-diagnostics): stop after all known codes

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -136,6 +136,13 @@ skip the pattern loop entirely, while matching lines still use the same compiled
 regexes and matched-pattern ids as before. This reduces bounded-excerpt scans
 with many progress lines that contain no supported failure terms.
 
+A follow-up 2026-06-28 all-known-code short-circuit slice keeps the parser
+semantics unchanged while stopping diagnosis matching once every known diagnosis
+code has already been emitted for the bounded excerpt. Later lines cannot add a
+new known-code diagnosis at that point because duplicate codes are already
+suppressed, so the parser avoids lowercasing and marker scans across trailing
+runtime-log noise.
+
 Focused verification:
 
 ```bash

--- a/scripts/runtime_export_diagnostic_parser_probe.py
+++ b/scripts/runtime_export_diagnostic_parser_probe.py
@@ -18,6 +18,15 @@ for candidate in (ROOT, WORKER_ROOT):
         sys.path.insert(0, str(candidate))  # pragma: no cover - script bootstrap
 
 from worker.productization.export_target_diagnostics import (
+    CODE_DUPLICATE_TENSOR_NAME,
+    CODE_INSUFFICIENT_MEMORY,
+    CODE_INVALID_RUNTIME_PATH,
+    CODE_MISSING_BINARY,
+    CODE_MISSING_BLOB,
+    CODE_PERMISSION_DENIED,
+    CODE_RUNTIME_LOAD_FAILED,
+    CODE_RUNTIME_TIMEOUT,
+    CODE_UNSUPPORTED_ARCHITECTURE,
     _SourceLine,
     _build_redacted_excerpt,
     _diagnoses_from_excerpt,
@@ -78,31 +87,30 @@ def _path_redaction_elapsed_ms(
 
 
 def _diagnosis_matching_elapsed_ms(*, samples: int, iterations: int, line_count: int) -> float:
+    known_code_lines = [
+        (CODE_RUNTIME_LOAD_FAILED, "runtime load failed while opening model"),
+        (CODE_UNSUPPORTED_ARCHITECTURE, "unsupported architecture arm64 required"),
+        (CODE_DUPLICATE_TENSOR_NAME, "duplicate tensor name decoder.layers.0"),
+        (CODE_MISSING_BLOB, "missing blob sha256-777777 not found"),
+        (CODE_MISSING_BINARY, "runtime binary not installed: ollama"),
+        (CODE_INVALID_RUNTIME_PATH, "invalid runtime path /tmp/melix/bad-target"),
+        (CODE_RUNTIME_TIMEOUT, "generation smoke timed out after deadline exceeded"),
+        (CODE_PERMISSION_DENIED, "permission denied opening model weights"),
+        (CODE_INSUFFICIENT_MEMORY, "Metal out of memory during load"),
+    ]
     source_lines = [
-        _SourceLine(
-            source_path="logs/ollama-create.log",
-            text=f"progress line {index} loaded shard metadata without failure",
-        )
-        for index in range(line_count)
+        _SourceLine(source_path="logs/ollama-create.log", text=text)
+        for _code, text in known_code_lines
     ]
     source_lines.extend(
-        [
-            _SourceLine(
-                source_path="logs/ollama-create.log",
-                text="missing blob sha256-777777 not found",
-            ),
-            _SourceLine(
-                source_path="logs/ollama-create.log",
-                text="runtime binary not installed: ollama",
-            ),
-            _SourceLine(
-                source_path="logs/ollama-create.log",
-                text="Metal out of memory during load",
-            ),
-        ]
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text=f"late duplicate runtime load failed marker after full coverage {index}",
+        )
+        for index in range(line_count)
     )
     line_numbers = {index: index + 1 for index in range(len(source_lines))}
-    expected_codes = {"missing_blob", "missing_binary", "insufficient_memory"}
+    expected_codes = {code for code, _text in known_code_lines}
     elapsed_samples: list[float] = []
     for _sample in range(samples):
         started = time.perf_counter()
@@ -178,7 +186,7 @@ def main() -> int:
                     iterations=iterations,
                     line_count=matching_line_count,
                 ),
-                "diagnosis_matching_line_count": float(matching_line_count + 3),
+                "diagnosis_matching_line_count": float(matching_line_count + 9),
                 "diagnosis_code_count": diagnosis_code_count,
                 "iteration_count": float(iterations),
                 "sample_count": float(samples),

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -273,6 +273,40 @@ def test_export_target_diagnostics_lowercases_source_line_once_per_match_scan() 
     assert text.lower_calls == 1
 
 
+def test_export_target_diagnostics_stops_after_all_known_codes_match() -> None:
+    class TrackingText(str):
+        lower_calls = 0
+
+        def lower(self) -> str:  # pragma: no cover - must stay uncalled
+            type(self).lower_calls += 1
+            return super().lower()
+
+    source_lines = [
+        _SourceLine("logs/runtime.log", "runtime load failed while opening model"),
+        _SourceLine("logs/runtime.log", "unsupported architecture arm64 required"),
+        _SourceLine("logs/runtime.log", "duplicate tensor name decoder.layers.0"),
+        _SourceLine("logs/runtime.log", "missing blob sha256-777777 not found"),
+        _SourceLine("logs/runtime.log", "runtime binary not installed: ollama"),
+        _SourceLine("logs/runtime.log", "invalid runtime path /tmp/melix/bad-target"),
+        _SourceLine("logs/runtime.log", "generation smoke timed out after deadline exceeded"),
+        _SourceLine("logs/runtime.log", "permission denied opening model weights"),
+        _SourceLine("logs/runtime.log", "Metal out of memory during load"),
+        _SourceLine("logs/runtime.log", TrackingText("late duplicate runtime load failed marker")),
+    ]
+    line_numbers = {index: index + 1 for index in range(len(source_lines))}
+
+    diagnoses = _diagnoses_from_excerpt(
+        source_lines,
+        line_numbers,
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert {diagnosis["code"] for diagnosis in diagnoses} == set(
+        export_target_diagnostics_module._KNOWN_DIAGNOSIS_CODE_SET
+    )
+    assert TrackingText.lower_calls == 0
+
+
 def test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -717,7 +717,10 @@ def _diagnoses_from_excerpt(
 ) -> list[dict[str, object]]:
     diagnoses: list[dict[str, object]] = []
     seen_codes: set[str] = set()
+    known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
     for index, line_number in line_numbers.items():
+        if len(seen_codes) == known_code_count:
+            break
         text = source_lines[index].text
         lowered_text = text.lower()
         if not any(marker in lowered_text for marker in _DIAGNOSIS_MARKERS):


### PR DESCRIPTION
## Summary
- Stop runtime export diagnosis matching once every known diagnosis code has already been emitted for the bounded excerpt.
- Extend the registered `runtime-export-diagnostic-parser` probe so its diagnosis matching microprobe covers the all-known-code short-circuit case.
- Document the 2026-06-28 performance slice in the runtime export diagnostic parser plan.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the all-known-code short-circuit slice.
- Registered probe coverage already exists for `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`; this PR updates the supporting probe script watched by that registry entry.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_stops_after_all_known_codes_match` (RED before implementation: failed as expected)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_stops_after_all_known_codes_match services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_lowercases_source_line_once_per_match_scan services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 42 passed.
- Changed-scope coverage: 100% (`TOTAL 14 0 100`).
- Registered local probe (`runtime_export_diagnostic_parser_probe.py`): `diagnosis_matching_elapsed_ms_mean=0.94164659967646`, `diagnosis_matching_line_count=509`, `diagnostic_parser_coverage=1.0`, `diagnosis_code_count=9.0`.
- Baseline one-off equivalent microprobe on `origin/main`: `diagnosis_matching_elapsed_ms_mean=11.700599803589284`, `diagnosis_matching_line_count=509`.
- Local microprobe delta: `-10.758953203912824 ms`, speedup about `12.43x` for the all-known-code diagnosis matching case.

## Known Gaps
- Python-only slice validated locally on Linux.
- Full registered PR-scoped performance validation must complete in GitHub Actions before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Behavior regression test added for the all-known-code short-circuit.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at 100%.
- [x] Registered probe ran locally and showed improvement in the targeted microprobe.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
