### PR TITLE
perf(metrics): lazily materialize discovery matches

### DIFF
--- a/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
+++ b/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
@@ -39,6 +39,15 @@ The registry entry includes focused `test_command`, `coverage_command`, and
 6. Update the registered probe workload to measure the multi-source resolution
    path instead of only the single-source helper.
 
+## Follow-up slice: lazy overlapping match materialization
+
+The next focused Python slice keeps the same registered probe and runtime
+metrics discovery boundary. It avoids creating a per-entry list for the common
+case where a runtime file matches only one exact or prefix/suffix source pattern,
+while still preserving overlapping exact, prefix, and multi-wildcard matches.
+The behavior contract remains unchanged: a single runtime directory scan chooses
+the newest matching file for each unresolved source.
+
 ## Verification plan
 
 Run the registered focused tests, changed-scope coverage command, and registered

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -106,38 +106,50 @@ def discover_latest_metrics_paths(runtime_dir: Path | None, source_names: tuple[
         latest_mtimes: dict[str, float | None] = {name: None for name in source_names}
         latest_paths_set = latest_paths.__setitem__
         latest_mtimes_set = latest_mtimes.__setitem__
+        empty_prefix_matchers = prefix_matchers_by_initial.get("", ())
         with os.scandir(os.fspath(runtime_dir.expanduser())) as entries:
             for entry in entries:
                 entry_name = entry.name
                 matched_source_name = exact_matchers.get(entry_name)
                 matched_source_names: list[str] | None = None
+                for source_name, prefix, suffix in prefix_matchers_by_initial.get(
+                    entry_name[:1], ()
+                ):
+                    if entry_name.startswith(prefix) and entry_name.endswith(suffix):
+                        if matched_source_name is None:
+                            matched_source_name = source_name
+                        elif matched_source_names is None:
+                            matched_source_names = [matched_source_name, source_name]
+                        else:
+                            matched_source_names.append(source_name)
+                if empty_prefix_matchers:
+                    for source_name, prefix, suffix in empty_prefix_matchers:
+                        if entry_name.endswith(suffix):
+                            if matched_source_name is None:
+                                matched_source_name = source_name
+                            elif matched_source_names is None:
+                                matched_source_names = [matched_source_name, source_name]
+                            else:
+                                matched_source_names.append(source_name)
+                for source_name, pattern in wildcard_matchers:
+                    if _matches_runtime_pattern(entry_name, pattern):
+                        if matched_source_name is None:
+                            matched_source_name = source_name
+                        elif matched_source_names is None:
+                            matched_source_names = [matched_source_name, source_name]
+                        else:
+                            matched_source_names.append(source_name)
                 if matched_source_name is None:
-                    for source_name, prefix, suffix in prefix_matchers_by_initial.get(
-                        entry_name[:1], ()
-                    ):
-                        if entry_name.startswith(prefix) and entry_name.endswith(suffix):
-                            if matched_source_names is None:
-                                matched_source_names = [source_name]
-                            else:
-                                matched_source_names.append(source_name)
-                    for source_name, pattern in wildcard_matchers:
-                        if _matches_runtime_pattern(entry_name, pattern):
-                            if matched_source_names is None:
-                                matched_source_names = [source_name]
-                            else:
-                                matched_source_names.append(source_name)
-                    if matched_source_names is None:
-                        continue
+                    continue
                 if not entry.is_file():
                     continue
                 mtime = entry.stat().st_mtime
-                if matched_source_name is not None:
+                if matched_source_names is None:
                     latest_mtime = latest_mtimes[matched_source_name]
                     if latest_mtime is None or mtime > latest_mtime:
                         latest_paths_set(matched_source_name, entry.path)
                         latest_mtimes_set(matched_source_name, mtime)
                     continue
-                assert matched_source_names is not None
                 for source_name in matched_source_names:
                     latest_mtime = latest_mtimes[source_name]
                     if latest_mtime is None or mtime > latest_mtime:

--- a/tests/test_melix_metrics_snapshot.py
+++ b/tests/test_melix_metrics_snapshot.py
@@ -263,12 +263,17 @@ def test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns(
     exact_noise = tmp_path / "exact-metrics-old.json"
     multi_match = tmp_path / "multi-metrics-new-latest.json"
     multi_noise = tmp_path / "multi-metrics-old.tmp"
+    suffix_match = tmp_path / "suffix-metrics.json"
+    suffix_noise = tmp_path / "suffix-metrics.tmp"
     write_metrics(exact_match, updated_at_unix_ms=1_000, values={"exact": 1})
     write_metrics(exact_noise, updated_at_unix_ms=2_000, values={"noise": 2})
     write_metrics(multi_match, updated_at_unix_ms=3_000, values={"multi": 3})
     write_metrics(multi_noise, updated_at_unix_ms=4_000, values={"noise": 4})
+    write_metrics(suffix_match, updated_at_unix_ms=5_000, values={"suffix": 5})
+    write_metrics(suffix_noise, updated_at_unix_ms=6_000, values={"noise": 6})
     os.utime(exact_match, (1, 1))
     os.utime(multi_match, (2, 2))
+    os.utime(suffix_match, (3, 3))
 
     monkeypatch.setitem(
         snapshot_cli.SOURCE_DEFINITIONS,
@@ -280,9 +285,15 @@ def test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns(
         "multi_probe",
         {"runtime_pattern": "multi*latest*.json"},
     )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "suffix_probe",
+        {"runtime_pattern": "*-metrics.json"},
+    )
 
     assert snapshot_cli.discover_latest_metrics_path(tmp_path, "exact_probe") == exact_match
     assert snapshot_cli.discover_latest_metrics_path(tmp_path, "multi_probe") == multi_match
+    assert snapshot_cli.discover_latest_metrics_path(tmp_path, "suffix_probe") == suffix_match
 
 
 def test_batched_runtime_discovery_preserves_overlapping_source_matches(
@@ -291,10 +302,19 @@ def test_batched_runtime_discovery_preserves_overlapping_source_matches(
 ) -> None:
     shared_prefix = tmp_path / "shared-metrics-latest.json"
     wildcard_match = tmp_path / "shared-metrics-extra-latest.json"
+    exact_match = tmp_path / "shared-metrics-exact.json"
+    exact_wildcard_match = tmp_path / "wild-exact-latest.json"
+    empty_overlap_match = tmp_path / "empty-only.json"
     write_metrics(shared_prefix, updated_at_unix_ms=1_000, values={"shared": 1})
     write_metrics(wildcard_match, updated_at_unix_ms=2_000, values={"wildcard": 2})
+    write_metrics(exact_match, updated_at_unix_ms=3_000, values={"exact": 3})
+    write_metrics(exact_wildcard_match, updated_at_unix_ms=4_000, values={"exact_wild": 4})
+    write_metrics(empty_overlap_match, updated_at_unix_ms=5_000, values={"empty": 5})
     os.utime(shared_prefix, (1, 1))
     os.utime(wildcard_match, (2, 2))
+    os.utime(exact_match, (3, 3))
+    os.utime(exact_wildcard_match, (4, 4))
+    os.utime(empty_overlap_match, (5, 5))
 
     monkeypatch.setitem(
         snapshot_cli.SOURCE_DEFINITIONS,
@@ -316,6 +336,36 @@ def test_batched_runtime_discovery_preserves_overlapping_source_matches(
         "shared_wildcard_b",
         {"runtime_pattern": "shared*latest*.json"},
     )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "shared_exact",
+        {"runtime_pattern": "shared-metrics-exact.json"},
+    )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "wild_exact",
+        {"runtime_pattern": "wild-exact-latest.json"},
+    )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "wild_wildcard",
+        {"runtime_pattern": "wild*latest*.json"},
+    )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "empty_exact",
+        {"runtime_pattern": "empty-only.json"},
+    )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "empty_suffix_a",
+        {"runtime_pattern": "*only.json"},
+    )
+    monkeypatch.setitem(
+        snapshot_cli.SOURCE_DEFINITIONS,
+        "empty_suffix_b",
+        {"runtime_pattern": "*-only.json"},
+    )
 
     discovered = snapshot_cli.discover_latest_metrics_paths(
         tmp_path,
@@ -324,14 +374,26 @@ def test_batched_runtime_discovery_preserves_overlapping_source_matches(
             "shared_prefix_b",
             "shared_wildcard_a",
             "shared_wildcard_b",
+            "shared_exact",
+            "wild_exact",
+            "wild_wildcard",
+            "empty_exact",
+            "empty_suffix_a",
+            "empty_suffix_b",
         ),
     )
 
     assert discovered == {
-        "shared_prefix_a": wildcard_match,
-        "shared_prefix_b": wildcard_match,
+        "shared_prefix_a": exact_match,
+        "shared_prefix_b": exact_match,
         "shared_wildcard_a": wildcard_match,
         "shared_wildcard_b": wildcard_match,
+        "shared_exact": exact_match,
+        "wild_exact": exact_wildcard_match,
+        "wild_wildcard": exact_wildcard_match,
+        "empty_exact": empty_overlap_match,
+        "empty_suffix_a": empty_overlap_match,
+        "empty_suffix_b": empty_overlap_match,
     }
 
 


### PR DESCRIPTION
## Summary
- Optimizes `scripts/melix_metrics_snapshot.py` runtime source discovery by keeping the common single-match path scalar and only materializing a match list when an entry overlaps multiple source patterns.
- Extends overlap regression coverage for exact+prefix and exact+wildcard pattern combinations.
- Updates the governing metrics snapshot performance-slice plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md`

## Commands Run
```text
# Baseline on origin/main (/root/.hermes/profiles/coder/workspace/melix)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/melix_metrics_snapshot_discovery_probe.py
# 3 runs: elapsed_ms_mean = 10.826501, 14.874919, 11.913044

# Focused regression test
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches
# 1 passed in 0.06s

# Registered focused tests for melix-metrics-snapshot-runtime-scandir
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics
# 10 passed in 1.36s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/melix_metrics_snapshot.py scripts/melix_metrics_snapshot_discovery_probe.py tests/test_melix_metrics_snapshot.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 10 passed in 0.92s; changed-scope TOTAL 25 0 100%

# Registered local probe on this branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/melix_metrics_snapshot_discovery_probe.py
# 3 runs: elapsed_ms_mean = 10.627896, 11.078422, 10.926380

python3 -m compileall -q scripts/melix_metrics_snapshot.py scripts/melix_metrics_snapshot_discovery_probe.py
# exit 0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 25 0 100%`.
- Registered probe: `melix-metrics-snapshot-runtime-scandir` (local Linux and required in CI PR-scoped performance workflow).
- Local probe comparison across three runs:
  - `old_mean=12.538155 ms`
  - `new_mean=10.877566 ms`
  - `delta_ms=-1.660589 ms`
  - `speedup=1.152662x` (`13.24%` lower mean elapsed time)
- Observability mode: `evidence` via PR-scoped performance probe.
- Probe overhead: N/A; this changes synthetic probe-target discovery code, not production observability instrumentation.

## Known Gaps
- CI PR-scoped performance report is the merge gate; local Linux probe evidence is included above.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
