### PR TITLE
perf(dataset): reuse scanned file format

### DIFF
--- a/docs/plans/2026-06-28-dataset-registry-file-format-reuse.md
+++ b/docs/plans/2026-06-28-dataset-registry-file-format-reuse.md
@@ -1,0 +1,30 @@
+# Dataset Registry File Format Reuse
+
+## Scope
+
+This Python-only performance slice is limited to dataset registry snapshot file discovery in `worker.dataset_registry.catalog`. It preserves snapshot payload semantics while reusing the supported file format computed during the directory scan instead of recomputing it from each `Path` when building `DatasetFile` records.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`. The probe entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+
+## Plan
+
+1. Keep `_iter_supported_dataset_file_entries(...)` behavior stable for existing callers.
+2. Add an internal scan record iterator that carries `(path, relative_path, file_format)`.
+3. Use the scan-time `file_format` in `_dataset_files(...)` so snapshot construction avoids a second suffix/name parse per supported file.
+4. Verify with the registered focused tests, changed-scope coverage, and the registered local probe on Linux.
+5. Use GitHub Actions PR-scoped performance as the final merge gate.
+
+## Local Evidence Template
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
+```

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -223,6 +223,30 @@ def test_dataset_catalog_skips_path_construction_for_unsupported_files(
     assert constructor_calls == 2
 
 
+def test_dataset_catalog_dataset_files_reuse_scanned_file_format(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "README.md").write_text("# Dataset\n", encoding="utf-8")
+    (snapshot_dir / "train.jsonl").write_text("{}\n", encoding="utf-8")
+
+    def fail_path_format(_path: Path) -> str:
+        raise AssertionError(  # pragma: no cover - regression sentinel
+            "dataset files should reuse scan-time file format"
+        )
+
+    monkeypatch.setattr(catalog, "_dataset_file_format", fail_path_format)
+
+    files = tuple(catalog._dataset_files(snapshot_dir))
+
+    assert [(file.relative_path, file.file_format) for file in files] == [
+        ("README.md", "metadata"),
+        ("train.jsonl", "jsonl"),
+    ]
+
+
 def test_dataset_catalog_split_alias_prefix_scan_matches_legacy_delimiters() -> None:
     assert catalog._split_alias_from_candidate("train-00000-of-00001") == "train"
     assert catalog._split_alias_from_candidate("validation_shard_00000") == "validation"

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -965,7 +965,7 @@ def _build_dataset_snapshot(
 
 
 def _dataset_files(snapshot_dir: Path) -> Iterator[DatasetFile]:
-    for path, relative_path in _iter_supported_dataset_file_entries(snapshot_dir):
+    for path, relative_path, file_format in _iter_supported_dataset_file_records(snapshot_dir):
         try:
             stat_result = path.stat()
         except OSError:
@@ -973,7 +973,7 @@ def _dataset_files(snapshot_dir: Path) -> Iterator[DatasetFile]:
         yield DatasetFile(
             relative_path=relative_path,
             size_bytes=stat_result.st_size,
-            file_format=_dataset_file_format(path),
+            file_format=file_format,
         )
 
 
@@ -985,6 +985,16 @@ def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:
 def _iter_supported_dataset_file_entries(
     snapshot_dir: Path, relative_prefix: str = ""
 ) -> Iterator[tuple[Path, str]]:
+    for path, relative_path, _file_format in _iter_supported_dataset_file_records(
+        snapshot_dir,
+        relative_prefix=relative_prefix,
+    ):
+        yield path, relative_path
+
+
+def _iter_supported_dataset_file_records(
+    snapshot_dir: Path, relative_prefix: str = ""
+) -> Iterator[tuple[Path, str, str]]:
     try:
         with os.scandir(os.fspath(snapshot_dir)) as entries:
             child_entries = sorted(entries, key=lambda entry: entry.name)
@@ -995,7 +1005,7 @@ def _iter_supported_dataset_file_entries(
         relative_path = f"{relative_prefix}{name}"
         try:
             if entry.is_dir():
-                yield from _iter_supported_dataset_file_entries(
+                yield from _iter_supported_dataset_file_records(
                     Path(entry.path), f"{relative_path}/"
                 )
                 continue
@@ -1003,8 +1013,9 @@ def _iter_supported_dataset_file_entries(
                 continue
         except OSError:
             continue
-        if _dataset_file_format_name(name):
-            yield Path(entry.path), relative_path
+        file_format = _dataset_file_format_name(name)
+        if file_format:
+            yield Path(entry.path), relative_path, file_format
 
 
 def _dataset_file_format(path: Path) -> str:


### PR DESCRIPTION
## Summary
- Reuse the scan-time dataset file format when building dataset registry snapshot records.
- Keep the existing two-field `_iter_supported_dataset_file_entries(...)` API stable by adding an internal record iterator for the three-field scan data.
- Add a regression sentinel proving `_dataset_files(...)` no longer recomputes file format from `Path`.

## Plan or Spec
- Updated `docs/plans/2026-06-28-dataset-registry-file-format-reuse.md`.
- Registered probe: `dataset-registry-snapshot-inference-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-snapshot-inference-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-registry-separator-fastpath-20260628 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-registry-path-parts-once-20260628 --output /tmp/dataset_registry_file_format_reuse_perf.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 61 passed.
- Changed-scope coverage: 100% (17/17 changed measurable lines).
- Local repeated direct probe, 3 runs each with `MELIX_DATASET_REGISTRY_PROBE_SAMPLES=7`: base_mean=141.400413 ms, head_mean=137.988030 ms, delta=-3.412383 ms, speedup=2.413%.
- Registered local runner completed head verification and probe execution; one 5-sample runner comparison was noisy (base=136.917840 ms, head=138.719001 ms) but remained within the registered warning threshold. CI registered probe remains the merge gate.

## Known Gaps
- Linux local probe only validates the Python dataset registry path; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local Linux probe was run and recorded.
- [ ] GitHub Actions PR-scoped performance completed successfully.
