### PR TITLE
perf(mlx-lm): decode structured result payload from stdout offset

### DIFF
--- a/docs/plans/2026-05-03-mlx-lm-structured-result-tail-parse.md
+++ b/docs/plans/2026-05-03-mlx-lm-structured-result-tail-parse.md
@@ -44,3 +44,16 @@ Register a dedicated PR-scoped performance probe for the hot path that:
 - Missing structured-result output still raises the same `ModelOperationError` code/message class.
 - Changed-scope coverage for the touched executable Python files remains at least 95%.
 - The dedicated probe shows lower `elapsed_ms_mean` and lower `peak_bytes_mean` than `origin/main` for the same synthetic workload.
+
+## 2026-06-28 JSON slice
+
+This follow-up keeps the registered `mlx-lm-structured-result-tail-parse` probe and narrows the implementation to the JSON payload boundary after the line-start marker has been found. `_extract_structured_result_payload` now reuses a module-level `json.JSONDecoder` and calls `raw_decode` at the payload start offset instead of finding the line ending and slicing the payload string before `json.loads`.
+
+The behavior contract is unchanged:
+
+- valid structured result lines still parse to the same payload dictionary
+- embedded markers that are not at line start are still ignored
+- LF, CRLF, and CR-only line endings remain accepted
+- outputs with no line-start result marker still return `None`
+
+Linux-local validation for this slice uses the registered probe commands, focused pytest, changed-scope coverage, and repeated `scripts/mlx_lm_result_tail_probe.py` runs against `origin/main` and the branch.

--- a/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops_unit.py
@@ -3091,6 +3091,7 @@ def test_run_subprocess_rejects_missing_structured_result(tmp_path: Path, monkey
 
 def test_extract_structured_result_payload_accepts_carriage_return_line_end() -> None:
     payload = {"manifest_path": "/tmp/manifest.json"}
+    later_payload = {"manifest_path": "/tmp/later-manifest.json"}
     stdout = (
         "leading noise\r\n"
         f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\r\n"
@@ -3101,9 +3102,16 @@ def test_extract_structured_result_payload_accepts_carriage_return_line_end() ->
         f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\r"
         "tail noise"
     )
+    mixed_line_endings_stdout = (
+        "leading noise\n"
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(payload)}\n"
+        f"{mlx_lm_runner_module._RESULT_PREFIX}{json.dumps(later_payload)}\r"
+        "tail noise"
+    )
 
     assert mlx_lm_runner_module._extract_structured_result_payload(stdout) == payload
     assert mlx_lm_runner_module._extract_structured_result_payload(carriage_only_stdout) == payload
+    assert mlx_lm_runner_module._extract_structured_result_payload(mixed_line_endings_stdout) == later_payload
 
 
 def test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line() -> None:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -31,6 +31,8 @@ from worker.model_ops.training_dataset_chunker import (
 from worker.model_ops.training_log_events import parse_training_log_events
 
 _RESULT_PREFIX = "__MELIX_MLX_RESULT__="
+_RESULT_PREFIX_LENGTH = len(_RESULT_PREFIX)
+_RESULT_PAYLOAD_DECODER = json.JSONDecoder()
 # Sentinel tied to mlx-lm's internal error wording. Keep the mlx-lm pin in
 # pyproject.toml tight: any upstream wording change would silently disable the
 # no-strict retry for QLoRA loads. Update both the sentinel and tests together
@@ -479,27 +481,23 @@ class MLXLMRunner:
 
 
 def _extract_structured_result_payload(stdout: str) -> dict[str, object] | None:
-    search_end = len(stdout)
-    prefix = _RESULT_PREFIX
-    prefix_length = len(prefix)
-    while True:
-        prefix_index = stdout.rfind(prefix, 0, search_end)
-        if prefix_index < 0:
-            return None
-        if prefix_index > 0:
-            previous_character = stdout[prefix_index - 1]
-            if previous_character != "\n" and previous_character != "\r":
-                search_end = prefix_index
-                continue
-        newline_index = stdout.find("\n", prefix_index)
-        if newline_index >= 0:
-            line_end = newline_index
-        else:
-            line_end = len(stdout)
-            carriage_index = stdout.find("\r", prefix_index)
-            if carriage_index >= 0:
-                line_end = carriage_index
-        return json.loads(stdout[prefix_index + prefix_length:line_end])
+    prefix_index = stdout.rfind("\n" + _RESULT_PREFIX)
+    carriage_prefix_index = stdout.rfind(
+        "\r" + _RESULT_PREFIX,
+        prefix_index + 1 if prefix_index >= 0 else 0,
+    )
+    if carriage_prefix_index > prefix_index:
+        prefix_index = carriage_prefix_index
+    if prefix_index >= 0:
+        prefix_index += 1
+    elif stdout.startswith(_RESULT_PREFIX):
+        prefix_index = 0
+    else:
+        return None
+
+    payload_start = prefix_index + _RESULT_PREFIX_LENGTH
+    payload, _ = _RESULT_PAYLOAD_DECODER.raw_decode(stdout, payload_start)
+    return payload
 
 
 def _training_info_log_line(info: dict[str, Any], *, loss_key: str) -> str:


### PR DESCRIPTION
## Summary
- Optimize MLX-LM subprocess structured-result extraction by decoding the JSON payload directly from its offset with a reusable `json.JSONDecoder`.
- Keep line-start marker filtering intact, including embedded-marker skips and LF/CRLF/CR-only behavior.
- Add a regression assertion for mixed LF/CR line endings so the latest structured result still wins.

## Plan or Spec
- `docs/plans/2026-05-03-mlx-lm-structured-result-tail-parse.md` (updated with the 2026-06-28 JSON decoding slice).

## Commands Run
```text
# Baseline on origin/main before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.124967, "peak_bytes_mean": 1767.0, ...}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.129409, "peak_bytes_mean": 1786.2, ...}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.138253, "peak_bytes_mean": 1786.2, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file
-> 8 passed in 1.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_lm_result_tail_probe.py
-> 8 passed in 1.58s; TOTAL 17 0 100%

# Registered probe on branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.114753, "peak_bytes_mean": 481.2, ...}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.083116, "peak_bytes_mean": 481.2, ...}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.132011, "peak_bytes_mean": 481.2, ...}
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
-> {"elapsed_ms_mean": 0.082216, "peak_bytes_mean": 481.2, ...}

git diff --check
-> passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Registered probe: `mlx-lm-structured-result-tail-parse` covers `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe comparison:
  - `old_mean=0.130876 ms`, `new_mean=0.103024 ms`, `delta_ms=-0.027852`, `speedup=1.270x`, `improvement=21.28%`.
  - `old_peak_bytes_mean=1779.8`, `new_peak_bytes_mean=481.2`.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally for this Python hot-path slice; CI is the broad gate.
- Local validation is Linux-only; no Swift runtime effect is involved in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
