### PR TITLE
perf(export-diagnostics): inline redaction marker checks

### DIFF
--- a/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
+++ b/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
@@ -40,6 +40,16 @@ needed. The common path has many plain runtime and target-path lines, so this
 slice replaces that generator dispatch with an explicit marker helper while
 preserving the same case-sensitive marker set and downstream redaction behavior.
 
+## 2026-06-29 follow-up: named secret marker helpers
+
+This Python-only follow-up stays inside the same
+`runtime-export-diagnostic-parser` registered probe and narrows to the remaining
+marker gates in `_redact_text(...)`. After the broad secret-marker fast path,
+named-secret and identity checks still used generator dispatch over tiny constant
+tuples once a line entered secret redaction. This slice replaces those two
+remaining generator checks with explicit helpers while preserving the same
+case-normalized marker semantics and downstream regex redaction behavior.
+
 Validation remains the registered focused pytest selection, changed-scope
 coverage, and the registered local/CI probe for runtime export diagnostic
 parsing.

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -30,6 +30,8 @@ from worker.productization.export_target_diagnostics import (
     _diagnoses_from_excerpt,
     _diagnosis_metric_counts,
     _extend_source_lines,
+    _has_identity_marker,
+    _has_named_secret_marker,
     _has_secret_redaction_marker,
     _split_source_lines,
 )
@@ -118,6 +120,38 @@ def test_export_target_diagnostics_secret_marker_fast_path_matches_registered_ma
     expected: bool,
 ) -> None:
     assert _has_secret_redaction_marker(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("plain runtime status", False),
+        ("api_key=super-secret-value", True),
+        ("access_token=abc", True),
+        ("password: abc", True),
+        ("contains secret value", True),
+    ],
+)
+def test_export_target_diagnostics_named_secret_marker_fast_path_matches_markers(
+    text: str,
+    expected: bool,
+) -> None:
+    assert _has_named_secret_marker(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("plain runtime status", False),
+        ("operator_id=chenyu", True),
+        ("user_name=alice", True),
+    ],
+)
+def test_export_target_diagnostics_identity_marker_fast_path_matches_markers(
+    text: str,
+    expected: bool,
+) -> None:
+    assert _has_identity_marker(text) is expected
 
 
 def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identity(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -71,8 +71,6 @@ _IDENTITY_PATTERN = re.compile(
     r"(?i)\b(user|operator)(?:[_-]?(?:id|name))?\s*[:=]\s*['\"]?[^'\"\s,;]+['\"]?"
 )
 _SECRET_REDACTION_MARKERS = ("=", ":", "@", "sk-", "-----BEGIN ")
-_NAMED_SECRET_MARKERS = ("api", "access", "token", "password", "secret")
-_IDENTITY_MARKERS = ("user", "operator")
 
 
 @dataclass(frozen=True, slots=True)
@@ -605,7 +603,7 @@ def _redact_text(
                 lambda match: match.group(1) + _record_secret(summary),
                 text,
             )
-        if any(marker in secret_text for marker in _NAMED_SECRET_MARKERS):
+        if _has_named_secret_marker(secret_text):
             text = _NAMED_SECRET_PATTERN.sub(
                 lambda match: f"{match.group(1)}=<redacted-secret>{_record_secret_count_only(summary)}",
                 text,
@@ -617,7 +615,7 @@ def _redact_text(
             )
         if "sk-" in text:
             text = _OPENAI_KEY_PATTERN.sub(lambda _match: _record_secret(summary), text)
-        if any(marker in secret_text for marker in _IDENTITY_MARKERS):
+        if _has_identity_marker(secret_text):
             text = _IDENTITY_PATTERN.sub(
                 lambda match: _record_identity(summary, match.group(1)),
                 text,
@@ -643,6 +641,20 @@ def _has_secret_redaction_marker(text: str) -> bool:
         or "sk-" in text
         or "-----BEGIN " in text
     )
+
+
+def _has_named_secret_marker(secret_text: str) -> bool:
+    return (
+        "api" in secret_text
+        or "access" in secret_text
+        or "token" in secret_text
+        or "password" in secret_text
+        or "secret" in secret_text
+    )
+
+
+def _has_identity_marker(secret_text: str) -> bool:
+    return "user" in secret_text or "operator" in secret_text
 
 
 def _record_secret(summary: _RedactionSummary) -> str:


### PR DESCRIPTION
## Summary
- Replace the remaining named-secret and identity marker generator checks in `_redact_text(...)` with explicit helper predicates.
- Add focused marker-helper regression coverage so the redaction marker set stays behaviorally stable.
- Update the runtime export diagnostics performance plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-28-export-diagnostics-source-line-extension.md` (`2026-06-29 follow-up: named secret marker helpers`).
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# sync / branch
cd /root/.hermes/profiles/coder/workspace/worktrees/melix-pr-scope-glob-magic-find-20260629 && git fetch origin && git reset --hard origin/main
git worktree add -b perf/export-redact-marker-fastpath-20260629 /root/.hermes/profiles/coder/workspace/worktrees/melix-export-redact-marker-fastpath-20260629 origin/main

# focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# result: 50 passed in 1.52s

# registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# result: 50 passed; TOTAL 12 0 100%

# registered probe command, three base samples and three head samples
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# base elapsed_ms_mean samples: 2851.4966510003433, 2867.508077796083, 2912.892186793033
# head elapsed_ms_mean samples: 2899.962978006806, 2857.131962792482, 2838.8623990118504

# registered base-vs-head runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-pr-scope-glob-magic-find-20260629 --head-repo "$PWD" --output /tmp/runtime_export_named_marker_probe.json
# result: head verification ok; base/head probes ok

git diff --check
# result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Three-sample local direct probe mean:
  - base `elapsed_ms_mean=2877.298971863153` ms
  - head `elapsed_ms_mean=2865.3191132703796` ms
  - delta `-11.979858592773326` ms, speedup `1.0041809858236348x`
  - base `diagnostic_latency_ms=9.795986639801413` ms; head `9.135235663658628` ms; delta `-0.6607509761427846` ms
  - base `path_redaction_elapsed_ms_mean=21.729908130752545` ms; head `20.411401401118685` ms; delta `-1.3185067296338602` ms
- Registered base-vs-head runner sample:
  - base `elapsed_ms_mean=2892.3679613973945` ms; head `2864.1716187936254` ms
  - base `diagnosis_matching_elapsed_ms_mean=0.9503214037977159` ms; head `0.9419475798495114` ms
  - base `diagnostic_latency_ms=9.105838020332158` ms; head `9.270608017686754` ms (within the registered 5% warning boundary)
  - base `path_redaction_elapsed_ms_mean=19.610149401705712` ms; head `21.3577950024046` ms (single-sample noise; three-sample direct probe improved)
- CI PR-scoped performance is still required as the merge gate for the registered probe report.

## Known Gaps
- Linux local verification covers this Python-only slice. No Swift runtime validation is relevant.
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR uses the registered focused runtime-export diagnostics probe and CI as the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
