### PR TITLE
perf(export-layout): reuse target root resolution

### DIFF
--- a/docs/plans/2026-06-24-export-artifact-layout-retention.md
+++ b/docs/plans/2026-06-24-export-artifact-layout-retention.md
@@ -81,6 +81,12 @@ materialization for `cleanup="dry-run"` metrics reports, avoiding a second
 manifest validation and retention-decision pass when no cleanup side effects are
 requested.
 
+A follow-up 2026-06-29 placeholder materialization slice keeps the symlink-escape
+guard unchanged while resolving each target root once per placeholder pass and
+reusing that resolved root for manifest rows and evidence files. This avoids
+repeated target-root resolution during layout materialization without relaxing
+per-file path normalization or target-root containment checks.
+
 ## Verification
 
 Focused verification:

--- a/services/mlx-worker-python/tests/test_export_target_layout_retention.py
+++ b/services/mlx-worker-python/tests/test_export_target_layout_retention.py
@@ -394,6 +394,42 @@ def test_export_target_layout_rejects_empty_relative_path(tmp_path: Path) -> Non
         _target_relative_path(layout, "")
 
 
+def test_materialize_placeholder_files_reuses_resolved_target_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = FIXTURE_ROOT / "ollama/export-target-manifest.json"
+    manifest, validation_report = validate_export_target_manifest_file(
+        manifest_path,
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+    layout = build_export_target_layout(tmp_path, manifest)
+    original_target_relative_path = export_target_layout_module._target_relative_path
+    resolved_roots: list[Path | None] = []
+
+    def track_resolved_root(
+        layout_arg: export_target_layout_module.ExportTargetLayout,
+        relative_path: str,
+        *,
+        resolved_root: Path | None = None,
+    ) -> Path:
+        resolved_roots.append(resolved_root)
+        return original_target_relative_path(  # type: ignore[arg-type]
+            layout_arg,
+            relative_path,
+            resolved_root=resolved_root,
+        )
+
+    monkeypatch.setattr(export_target_layout_module, "_target_relative_path", track_resolved_root)
+
+    export_target_layout_module._materialize_placeholder_files(layout, manifest)
+
+    assert resolved_roots
+    assert all(resolved_root is not None for resolved_root in resolved_roots)
+    assert len({id(resolved_root) for resolved_root in resolved_roots}) == 1
+
+
 def test_layout_metrics_report_aggregates_target_retention_counts(tmp_path: Path) -> None:
     manifest_paths = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
 

--- a/services/mlx-worker-python/worker/productization/export_target_layout.py
+++ b/services/mlx-worker-python/worker/productization/export_target_layout.py
@@ -407,16 +407,21 @@ def _materialize_placeholder_files(
     layout: ExportTargetLayout,
     manifest: export_target_manifest_pb2.ExportTargetManifest,
 ) -> None:
+    resolved_target_root = layout.target_root.resolve()
     for _section, rows in _file_sections(manifest):
         for row in rows:
-            path = _target_relative_path(layout, row.path)
+            path = _target_relative_path(layout, row.path, resolved_root=resolved_target_root)
             if path == layout.manifest_path:
                 continue
             path.parent.mkdir(parents=True, exist_ok=True)
             if not path.exists():
                 path.write_bytes(_placeholder_bytes(manifest, row))
     for field_name in _EVIDENCE_PATH_FIELDS:
-        evidence_path = _target_relative_path(layout, getattr(manifest.evidence, field_name))
+        evidence_path = _target_relative_path(
+            layout,
+            getattr(manifest.evidence, field_name),
+            resolved_root=resolved_target_root,
+        )
         evidence_path.parent.mkdir(parents=True, exist_ok=True)
         if not evidence_path.exists():
             _write_json(


### PR DESCRIPTION
## Summary
- Reuse the resolved export target root throughout placeholder materialization.
- Preserve per-file target-root containment checks, including symlink escape rejection.
- Document the 2026-06-29 layout placeholder materialization performance slice.

## Plan or Spec
- Updated `docs/plans/2026-06-24-export-artifact-layout-retention.md` with the placeholder materialization slice and unchanged symlink guard boundary.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_materialize_placeholder_files_reuses_resolved_target_root services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_materialize_export_target_layout_rejects_paths_outside_target_root`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_layout.py services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_layout_retention_report.py scripts/runtime_export_layout_retention_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 24 passed.
- Changed-scope coverage: 100% (`TOTAL 18 0 100%`).
- Registered local probe `runtime-export-layout-retention`:
  - Baseline before change: `elapsed_ms_mean=2769.3894432042725`, `peak_bytes_mean=184464.6`, `target_count=4`, `retention_decision_count=15`.
  - After change: `elapsed_ms_mean=2424.0932093933225`, `peak_bytes_mean=182927.8`, `target_count=4`, `retention_decision_count=15`.
  - Delta: `-345.29623381095 ms` mean, about `12.47%` faster locally on Linux.
- CI is required for the registered PR-scoped probe validation before merge.

## Known Gaps
- This is a Python/Linux-verifiable slice; no Swift runtime effect is claimed.
- Local probe timing may vary, so merge should wait for the PR-scoped performance workflow and all required checks.

## Evidence Checklist
- [x] Affected path has registered PR-scoped probe coverage (`runtime-export-layout-retention`).
- [x] Focused test command passed locally.
- [x] Changed-scope coverage command passed locally at or above 95%.
- [x] Registered probe command passed locally and improved the target metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
