### PR TITLE
perf(export-diagnostics): gate private text regex

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -143,6 +143,14 @@ new known-code diagnosis at that point because duplicate codes are already
 suppressed, so the parser avoids lowercasing and marker scans across trailing
 runtime-log noise.
 
+A follow-up 2026-06-29 private-line redaction marker slice keeps the redaction
+contract unchanged while gating the private prompt/response regex behind a cheap
+leading-character marker. Runtime log lines that cannot begin one of the
+registered private-text labels (`prompt`, `private prompt template`, `response`,
+`completion`, `generated text`, `dataset row`, or `operator input`, after leading
+whitespace) skip the anchored regex; lines with a compatible leading label still
+use the same regex and redaction counters as before.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -32,6 +32,7 @@ from worker.productization.export_target_diagnostics import (
     _extend_source_lines,
     _has_identity_marker,
     _has_named_secret_marker,
+    _has_private_text_line_marker,
     _has_secret_redaction_marker,
     _split_source_lines,
 )
@@ -152,6 +153,56 @@ def test_export_target_diagnostics_identity_marker_fast_path_matches_markers(
     expected: bool,
 ) -> None:
     assert _has_identity_marker(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("plain runtime status", False),
+        ("  prompt: private customer prompt", True),
+        ("Private prompt template: hidden", True),
+        ("Response=private completion", True),
+        ("completion: private text", True),
+        ("generated text: hidden", True),
+        ("dataset row: hidden", True),
+        ("operator input: hidden", True),
+    ],
+)
+def test_export_target_diagnostics_private_line_marker_fast_path_matches_registered_prefixes(
+    text: str,
+    expected: bool,
+) -> None:
+    assert _has_private_text_line_marker(text) is expected
+
+
+def test_export_target_diagnostics_skips_private_line_regex_for_unrelated_runtime_lines(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    class FailPrivateLinePattern:
+        def search(self, _text: str) -> None:  # pragma: no cover - regression guard
+            raise AssertionError("private text regex should be skipped for unrelated runtime lines")
+
+    monkeypatch.setattr(
+        export_target_diagnostics_module,
+        "_PRIVATE_TEXT_LINE_PATTERN",
+        FailPrivateLinePattern(),
+    )
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [_SourceLine(source_path="logs/ollama-create.log", text="runtime load failed at /tmp/melix/model")],
+        bounded_bytes=4096,
+        bounded_lines=8,
+    )
+
+    assert "runtime load failed" in excerpt.text
 
 
 def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identity(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -589,7 +589,7 @@ def _redact_text(
     resolved_target_root_text: str,
     summary: _RedactionSummary,
 ) -> str:
-    if _PRIVATE_TEXT_LINE_PATTERN.search(text):
+    if _has_private_text_line_marker(text) and _PRIVATE_TEXT_LINE_PATTERN.search(text):
         summary.redacted_prompt_or_response_count += 1
         summary.redaction_count += 1
         return "<redacted-private-preview>"
@@ -641,6 +641,27 @@ def _has_secret_redaction_marker(text: str) -> bool:
         or "sk-" in text
         or "-----BEGIN " in text
     )
+
+
+def _has_private_text_line_marker(text: str) -> bool:
+    stripped = text.lstrip()
+    if not stripped:
+        return False
+    first = stripped[0]
+    if first == "p" or first == "P":
+        leading = stripped[:23].lower()
+        return leading.startswith("prompt") or leading.startswith("private prompt template")
+    if first == "r" or first == "R":
+        return stripped[:8].lower() == "response"
+    if first == "c" or first == "C":
+        return stripped[:10].lower() == "completion"
+    if first == "g" or first == "G":
+        return stripped[:14].lower() == "generated text"
+    if first == "d" or first == "D":
+        return stripped[:11].lower() == "dataset row"
+    if first == "o" or first == "O":
+        return stripped[:14].lower() == "operator input"
+    return False
 
 
 def _has_named_secret_marker(secret_text: str) -> bool:


### PR DESCRIPTION
## Summary
- Gate runtime export diagnostic private-text redaction regex behind a cheap leading-label marker.
- Add regression coverage for the marker and for skipping the anchored regex on unrelated runtime log lines.
- Update the diagnostic parser plan with the 2026-06-29 private-line redaction slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` already covers the touched parser, tests, plan, and probe script with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `59 passed`.
- Changed-scope coverage: `TOTAL 30 1 97%` (parser changed-line coverage `95.00%`).
- Local Linux registered probe baseline before change: `elapsed_ms_mean=2669.077`, `path_redaction_elapsed_ms_mean=21.870`, `diagnosis_matching_elapsed_ms_mean=1.002`, `diagnostic_latency_ms=9.347`, `peak_bytes_mean=195618.6`.
- Local Linux registered probe after change: `elapsed_ms_mean=2659.083`, `path_redaction_elapsed_ms_mean=19.949`, `diagnosis_matching_elapsed_ms_mean=0.977`, `diagnostic_latency_ms=9.001`, `peak_bytes_mean=204338.4`.
- Delta: `elapsed_ms_mean -9.995 ms` (~0.37% faster), `path_redaction_elapsed_ms_mean -1.922 ms` (~8.79% faster), `diagnosis_matching_elapsed_ms_mean -0.025 ms` (~2.49% faster). Peak bytes increased by ~8.7 KiB in this local run; runtime effect is the target metric for this slice.

## Known Gaps
- Local validation was performed on Linux for this Python slice. GitHub Actions PR-scoped performance validation is still required before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the changed path.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement in the targeted redaction metric.
- [ ] GitHub Actions and PR-scoped performance workflow are green.
