### PR TITLE
perf(export-diagnostics): shrink matched pattern scans

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -151,6 +151,14 @@ registered private-text labels (`prompt`, `private prompt template`, `response`,
 whitespace) skip the anchored regex; lines with a compatible leading label still
 use the same regex and redaction counters as before.
 
+A follow-up 2026-06-29 diagnosis pattern loop slice keeps the diagnosis
+semantics and pattern priority unchanged while shrinking per-pattern matching.
+Each pattern now uses explicit marker and expression loops instead of
+generator-backed `any(...)` calls. Duplicate diagnosis codes are still suppressed
+for a bounded excerpt; overlapping later lines still fall through to the
+remaining lower-priority patterns, and the scan still stops once every known code
+has matched.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -392,6 +392,25 @@ def test_export_target_diagnostics_stops_after_all_known_codes_match() -> None:
     assert TrackingText.lower_calls == 0
 
 
+def test_export_target_diagnostics_preserves_overlap_priority_after_prior_match() -> None:
+    diagnoses = _diagnoses_from_excerpt(
+        [
+            _SourceLine("logs/runtime.log", "unsupported architecture arm64 required"),
+            _SourceLine(
+                "logs/runtime.log",
+                "unsupported architecture warning followed by runtime load failed",
+            ),
+        ],
+        {0: 1, 1: 2},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert [diagnosis["code"] for diagnosis in diagnoses] == [
+        CODE_UNSUPPORTED_ARCHITECTURE,
+        CODE_RUNTIME_LOAD_FAILED,
+    ]
+
+
 def test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -89,9 +89,17 @@ class _DiagnosisPattern:
     def matches(self, text: str, lowered_text: str | None = None) -> bool:
         if self.markers:
             lowered = lowered_text if lowered_text is not None else text.lower()
-            if not any(marker in lowered for marker in self.markers):
+            marker_matched = False
+            for marker in self.markers:
+                if marker in lowered:
+                    marker_matched = True
+                    break
+            if not marker_matched:
                 return False
-        return any(expression.search(text) for expression in self.expressions)
+        for expression in self.expressions:
+            if expression.search(text):
+                return True
+        return False
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- Shrinks runtime export diagnostic matching by using explicit marker/expression loops while keeping the existing seen-code short-circuit semantics.
- Adds an overlap-priority regression test to prove later overlapping lines still fall through to remaining lower-priority patterns.
- Updates the runtime export diagnostic parser plan with this diagnosis pattern-loop performance slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser`

## Commands Run
- `git diff --check` (exit 0)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` (exit 0, 67 passed)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py` (exit 0, TOTAL 7 0 100%)
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py` (exit 0)
- Branch probe after regression follow-up: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py` (exit 0)

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 7 0 100%`).
- Baseline probe (`origin/main`): `elapsed_ms_mean=2648.3500`, `diagnosis_matching_elapsed_ms_mean=0.9468652`, `diagnostic_latency_ms=11.9853`, `path_redaction_elapsed_ms_mean=19.0287`, `peak_bytes_mean=195973.6`, `diagnostic_parser_coverage=1.0`.
- Branch probe: `elapsed_ms_mean=2693.5239`, `diagnosis_matching_elapsed_ms_mean=0.7642060`, `diagnostic_latency_ms=8.4368`, `path_redaction_elapsed_ms_mean=18.8116`, `peak_bytes_mean=203178.6`, `diagnostic_parser_coverage=1.0`.
- Local delta: `diagnosis_matching_elapsed_ms_mean -0.182659 ms` (~19.29% faster); `diagnostic_latency_ms -3.5485 ms` (~29.61% faster). Overall elapsed noise is dominated by temp directory materialization outside this slice.

## Known Gaps
- Linux local validation covers the Python parser and registered probe only.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Registered probe exists with focused test, coverage, and probe commands.
- [x] Focused parser tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally on Linux with baseline/branch comparison.
- [x] GitHub Actions and the PR-scoped performance report are green.
