### PR TITLE
perf(lora): fast-path reward percentile bounds

### DIFF
--- a/docs/plans/2026-05-05-lora-reward-summary-minmax.md
+++ b/docs/plans/2026-05-05-lora-reward-summary-minmax.md
@@ -32,3 +32,7 @@ Register `lora-reward-summary-candidate-minmax` in the PR-scoped performance reg
 ## Follow-up total-cache slice
 
 The 2026-05-10 follow-up slice keeps the registered `lora-reward-summary-candidate-minmax` probe and further reduces summary aggregation overhead. `_reward_summary(...)` already maintains running candidate-group variance totals; this slice removes the now-redundant variance list append and uses the existing score list length for reward mean. The summary schema and percentile behavior stay unchanged.
+
+## Follow-up percentile-bound slice
+
+The 2026-06-29 follow-up slice keeps the registered `lora-reward-summary-candidate-minmax` probe and narrows to `_percentile_value(...)`, which is called for reward and candidate-group percentiles after the hot summary lists are sorted. The slice caches the last index once, returns directly for lower and upper percentile bounds, and avoids repeated `len(...)`, `min(...)`, and `max(...)` calls while preserving interpolation semantics and the existing summary schema.

--- a/services/mlx-worker-python/tests/test_lora_model_ops.py
+++ b/services/mlx-worker-python/tests/test_lora_model_ops.py
@@ -63,6 +63,10 @@ def test_checkpoint_order_key_uses_last_numeric_token() -> None:
 def test_alignment_percentile_uses_interpolation_and_upper_bound() -> None:
     assert lora_training_pipeline_module._percentile_value(
         [0.4, 0.7],
+        0.0,
+    ) == pytest.approx(0.4)
+    assert lora_training_pipeline_module._percentile_value(
+        [0.4, 0.7],
         0.5,
     ) == pytest.approx(0.55)
     assert lora_training_pipeline_module._percentile_value(

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -903,16 +903,16 @@ def _reward_summary(samples: list[dict[str, Any]]) -> dict[str, float | int]:
 
 
 def _percentile_value(ordered_values: list[float], percentile: float) -> float:
-    if len(ordered_values) == 1:
+    last_index = len(ordered_values) - 1
+    if last_index == 0:
         return ordered_values[0]
-    position = min(
-        len(ordered_values) - 1,
-        max(0.0, (len(ordered_values) - 1) * percentile),
-    )
+    position = last_index * percentile
+    if position <= 0.0:
+        return ordered_values[0]
+    if position >= last_index:
+        return ordered_values[last_index]
     lower_index = int(position)
-    upper_index = min(len(ordered_values) - 1, lower_index + 1)
-    if lower_index == upper_index:
-        return ordered_values[lower_index]
+    upper_index = lower_index + 1
     weight = position - lower_index
     return ordered_values[lower_index] + (
         ordered_values[upper_index] - ordered_values[lower_index]


### PR DESCRIPTION
## Summary
- Fast-path `_percentile_value(...)` lower/upper percentile bounds in the LoRA reward summary path.
- Cache the last index once to avoid repeated `len(...)`, `min(...)`, and `max(...)` calls while preserving interpolation behavior.
- Extend the focused percentile regression test with the lower-bound case.

## Plan or Spec
- `docs/plans/2026-05-05-lora-reward-summary-minmax.md` (2026-06-29 follow-up percentile-bound slice).
- Registered PR-scoped performance probe: `lora-reward-summary-candidate-minmax` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file
# outcome: 9 passed in 3.93s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_lora_model_ops.py::test_alignment_percentile_uses_interpolation_and_upper_bound services/mlx-worker-python/tests/test_lora_model_ops.py::test_reward_summary_reuses_candidate_group_minmax services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_rl_alignment_mode_contracts services/mlx-worker-python/tests/test_lora_model_ops.py::test_train_lora_supports_qlora_with_hf_valid_split_and_persists_desired_alias services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_reward_summary_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_reward_summary_probe_script_main_covers_checked_in_file && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py services/mlx-worker-python/tests/test_lora_model_ops.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_reward_summary_probe.py
# outcome: 9 passed; TOTAL 9 0 100%

# registered local probe runner
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id lora-reward-summary-candidate-minmax --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/lora-percentile-bound-probe-result.json
# outcome: test_ok=True coverage_ok=True; base elapsed_ms_mean=40.2465, head elapsed_ms_mean=39.1224

# repeated direct probe samples for stability
# base elapsed_ms_mean samples: 37.7563, 40.0820, 38.7238
# head elapsed_ms_mean samples: 35.9940, 38.0065, 37.8204
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Registered local probe runner: base `elapsed_ms_mean=40.2465`, head `elapsed_ms_mean=39.1224`, `sorted_calls_mean=0` for both.
- Repeated direct probe sample mean: old `38.8540 ms`, new `37.2736 ms`, delta `-1.5804 ms` (`~4.07%` faster).
- CI PR-scoped performance workflow is still required as the merge gate for the registered probe.

## Known Gaps
- Full repository test suite was not run locally; this is a Python-only focused performance slice.
- CI must validate the registered PR-scoped probe before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
