### PR TITLE
perf(dataset): fast-path structured source suffixes

### DIFF
--- a/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
+++ b/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
@@ -56,3 +56,15 @@ This slice adds exact lowercase suffix returns for `.md`, `.py`, and `.jsonl`
 after the existing text fast paths. Uppercase and mixed-case names still fall
 through to the generic lowercase path, preserving current behavior while
 avoiding generic suffix allocation/work for common generated dataset inputs.
+
+## 2026-06-29 follow-up: structured source suffix fast path
+
+This Python-only follow-up extends the lowercase structured source suffix fast
+path to `.json`, `.csv`, and `.tsv` in `_classify_source_kind_name(...)`.
+Uppercase and mixed-case structured suffixes still fall through to the generic
+lowercase path so ingest behavior remains unchanged.
+
+The registered `dataset-source-records-scandir` probe fixture now includes all
+structured ingest suffixes (`.jsonl`, `.json`, `.csv`, `.tsv`) so local Linux
+and PR-scoped CI probe classification timing covers the optimized path before
+the slice is merged.

--- a/scripts/dataset_source_records_probe.py
+++ b/scripts/dataset_source_records_probe.py
@@ -20,6 +20,9 @@ _SOURCE_KIND_SUFFIXES = (
     (".md", "markdown"),
     (".py", "code"),
     (".jsonl", "structured_data"),
+    (".json", "structured_data"),
+    (".csv", "structured_data"),
+    (".tsv", "structured_data"),
 )
 
 
@@ -109,7 +112,7 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
 
 def main() -> int:
     directory_count = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_DIRS", "250"))
-    files_per_directory = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "24"))
+    files_per_directory = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "28"))
     samples = int(os.environ.get("MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES", "11"))
     print(json.dumps(measure(directory_count=directory_count, files_per_directory=files_per_directory, samples=samples), sort_keys=True))
     return 0

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -67,8 +67,14 @@ def test_dataset_ingest_source_kind_uses_single_suffix_fast_path() -> None:
     assert _source_kind(Path("README.md")) == "markdown"
     assert _source_kind(Path("script.py")) == "code"
     assert _source_kind(Path("records.jsonl")) == "structured_data"
+    assert _source_kind(Path("records.json")) == "structured_data"
+    assert _source_kind(Path("records.csv")) == "structured_data"
+    assert _source_kind(Path("records.tsv")) == "structured_data"
     assert _source_kind(Path("script.PY")) == "code"
     assert _source_kind(Path("records.JSONL")) == "structured_data"
+    assert _source_kind(Path("records.JSON")) == "structured_data"
+    assert _source_kind(Path("records.CSV")) == "structured_data"
+    assert _source_kind(Path("records.TSV")) == "structured_data"
     assert _source_kind(Path("README")) is None
     assert _source_kind(Path("archive.tar.gz")) is None
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -767,7 +767,7 @@ def test_dataset_source_records_probe_script_emits_metrics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_DIRS", "3")
-    monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "4")
+    monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_FILES_PER_DIR", "7")
     monkeypatch.setenv("MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES", "1")
     probe_script = runpy.run_path(str(REPO_ROOT / "scripts/dataset_source_records_probe.py"))
 
@@ -780,9 +780,9 @@ def test_dataset_source_records_probe_script_emits_metrics(
     assert metrics["source_kind_elapsed_ms_p95"] >= 0.0
     assert metrics["sample_count"] == 1.0
     assert metrics["directory_count"] == 3.0
-    assert metrics["files_per_directory"] == 4.0
-    assert metrics["file_count_mean"] == 12.0
-    assert metrics["source_kind_variant_count"] == 4.0
+    assert metrics["files_per_directory"] == 7.0
+    assert metrics["file_count_mean"] == 21.0
+    assert metrics["source_kind_variant_count"] == 7.0
 
 
 def test_dataset_source_records_probe_rejects_changed_source_kind(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -618,6 +618,10 @@ def _classify_source_kind_name(name: str) -> str | None:
         return "code"
     if name[-6:] == ".jsonl":
         return "structured_data"
+    if name[-5:] == ".json":
+        return "structured_data"
+    if name[-4:] in (".csv", ".tsv"):
+        return "structured_data"
 
     dot_index = name.rfind(".")
     if dot_index < 0:


### PR DESCRIPTION
## Summary
- Fast-path lowercase structured dataset source suffixes `.json`, `.csv`, and `.tsv` in `_classify_source_kind_name(...)`.
- Expand the registered `dataset-source-records-scandir` probe fixture from 4 to 7 suffix variants so structured source classification covers `.jsonl`, `.json`, `.csv`, and `.tsv`.
- Add focused parity assertions for lowercase fast-path and uppercase fallback behavior.

## Plan or Spec
- Updated `docs/plans/2026-06-20-dataset-source-empty-check-isspace.md` with the 2026-06-29 structured source suffix fast-path slice.
- Registered PR-scoped probe: `dataset-source-records-scandir`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused selection) → 14 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...` → changed-line coverage 100%.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py` on baseline and head fixture.
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-source-structured-suffix-baseline-20260629 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-source-structured-suffix-fastpath-20260629 --output /tmp/dataset-source-records-scandir-report.json`.
- `git diff --check`.

## Coverage and Metrics
- Changed-scope coverage: 15/15 measurable changed lines covered, 100%.
- Local registered probe runner (11 samples, lower is better):
  - `source_kind_elapsed_ms_mean`: base 20.525327179877255 ms → head 20.437974091195926 ms; delta -0.08735308868132918 ms / 0.4255868270249496% faster.
  - `source_kind_elapsed_ms_p95`: base 21.163405035622418 ms → head 20.976445055566728 ms.
  - `elapsed_ms_mean`: base 13.62776218130338 ms → head 13.657965998969633 ms; delta +0.03020381766625313 ms / +0.22163446400386475%.
  - Fixture: 250 directories × 28 files, 7000 files, 7 source-kind suffix variants.

## Known Gaps
- Local validation is Linux/Python-only. GitHub Actions PR-scoped performance must complete successfully before merge.
- The overall tree traversal metric is effectively neutral/slightly noisy; the targeted classification metric improved locally.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered local probe reports metrics for base and head.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
