### PR TITLE
perf(export-smoke): aggregate metrics in one pass

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -433,10 +433,13 @@ It must preserve the public `run_export_target_smoke()` validation boundary for
 external callers while avoiding an extra manifest parse on each probe iteration.
 Smoke metadata and fixture digest loops stream generated and required manifest
 file rows instead of materializing a combined tuple, preserving manifest order
-while reducing per-target allocation in the registered probe. The registered
-`runtime-export-smoke-policy` PR-scoped probe remains the evidence source for
-this Python slice and includes focused test, coverage, and `command_json` probe
-commands in `infra/perf/pr_scoped_probes.json`.
+while reducing per-target allocation in the registered probe. Smoke metrics
+report aggregation sums all receipt metrics in a single pass so the metrics
+report path avoids rebuilding an intermediate metrics list and rescanning it for
+each output field. The registered `runtime-export-smoke-policy` PR-scoped probe
+remains the evidence source for this Python slice and includes focused test,
+coverage, and `command_json` probe commands in
+`infra/perf/pr_scoped_probes.json`.
 
 Bounded generation checks must use a repository-owned prompt fixture or a
 synthetic non-private prompt, a fixed token limit, a timeout, and a preview byte

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -227,6 +227,44 @@ def test_export_target_smoke_metrics_report_reuses_validated_manifest(
     assert validation_calls == len(manifest_paths)
 
 
+def test_export_target_smoke_metrics_aggregation_is_single_pass() -> None:
+    receipts: tuple[dict[str, object], ...] = (
+        {
+            "metrics": {
+                "metadata_check_latency_ms": 1.5,
+                "load_smoke_latency_ms": 2.0,
+                "generation_smoke_latency_ms": 3.5,
+                "output_preview_byte_count": 4,
+                "timeout_count": 1,
+                "waiver_count": 0,
+            }
+        },
+        {"metrics": []},
+        {"metrics": {}},
+        {
+            "metrics": {
+                "metadata_check_latency_ms": 0.5,
+                "load_smoke_latency_ms": 1.0,
+                "generation_smoke_latency_ms": 2.5,
+                "output_preview_byte_count": 6,
+                "timeout_count": 0,
+                "waiver_count": 1,
+            }
+        },
+    )
+
+    totals = export_target_smoke._aggregate_smoke_metrics(iter(receipts))
+
+    assert totals == {
+        "metadata_check_latency_ms": 2.0,
+        "load_smoke_latency_ms": 3.0,
+        "generation_smoke_latency_ms": 6.0,
+        "output_preview_byte_count": 10,
+        "timeout_count": 1,
+        "waiver_count": 1,
+    }
+
+
 def test_export_target_smoke_manifest_file_rows_streams_generated_then_required(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -260,20 +260,47 @@ def build_smoke_metrics_report(
             errors.append(str(exc))
 
     elapsed_ms = (time.perf_counter() - started) * 1000.0
-    metrics = [receipt["metrics"] for receipt in receipts if isinstance(receipt.get("metrics"), dict)]
+    metric_totals = _aggregate_smoke_metrics(receipts)
     return {
         "schema_version": EXPORT_SMOKE_METRICS_SCHEMA_VERSION,
         "ok": not errors and all(receipt.get("status") in {"passed", "waived"} for receipt in receipts),
         "target_count": len(receipts),
         "smoke_policy_latency_ms": elapsed_ms,
-        "metadata_check_latency_ms": sum(float(metric.get("metadata_check_latency_ms", 0)) for metric in metrics),
-        "load_smoke_latency_ms": sum(float(metric.get("load_smoke_latency_ms", 0)) for metric in metrics),
-        "generation_smoke_latency_ms": sum(float(metric.get("generation_smoke_latency_ms", 0)) for metric in metrics),
-        "output_preview_byte_count": sum(int(metric.get("output_preview_byte_count", 0)) for metric in metrics),
-        "timeout_count": sum(int(metric.get("timeout_count", 0)) for metric in metrics),
-        "waiver_count": sum(int(metric.get("waiver_count", 0)) for metric in metrics),
+        "metadata_check_latency_ms": metric_totals["metadata_check_latency_ms"],
+        "load_smoke_latency_ms": metric_totals["load_smoke_latency_ms"],
+        "generation_smoke_latency_ms": metric_totals["generation_smoke_latency_ms"],
+        "output_preview_byte_count": metric_totals["output_preview_byte_count"],
+        "timeout_count": metric_totals["timeout_count"],
+        "waiver_count": metric_totals["waiver_count"],
         "errors": errors,
         "receipts": receipts,
+    }
+
+
+def _aggregate_smoke_metrics(receipts: Iterable[dict[str, object]]) -> dict[str, float | int]:
+    metadata_check_latency_ms = 0.0
+    load_smoke_latency_ms = 0.0
+    generation_smoke_latency_ms = 0.0
+    output_preview_byte_count = 0
+    timeout_count = 0
+    waiver_count = 0
+    for receipt in receipts:
+        metric = receipt.get("metrics")
+        if not isinstance(metric, dict):
+            continue
+        metadata_check_latency_ms += float(metric.get("metadata_check_latency_ms", 0))
+        load_smoke_latency_ms += float(metric.get("load_smoke_latency_ms", 0))
+        generation_smoke_latency_ms += float(metric.get("generation_smoke_latency_ms", 0))
+        output_preview_byte_count += int(metric.get("output_preview_byte_count", 0))
+        timeout_count += int(metric.get("timeout_count", 0))
+        waiver_count += int(metric.get("waiver_count", 0))
+    return {
+        "metadata_check_latency_ms": metadata_check_latency_ms,
+        "load_smoke_latency_ms": load_smoke_latency_ms,
+        "generation_smoke_latency_ms": generation_smoke_latency_ms,
+        "output_preview_byte_count": output_preview_byte_count,
+        "timeout_count": timeout_count,
+        "waiver_count": waiver_count,
     }
 
 


### PR DESCRIPTION
## Summary
- Aggregate runtime export smoke receipt metrics in a single pass instead of building an intermediate metrics list and rescanning it for each output field.
- Add a focused regression test for the single-pass metrics aggregation helper.
- Update the runtime-aware export verification plan with the metrics aggregation slice.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`

## Commands Run
```text
# Baseline registered probe on origin/main before the change
bash /tmp/runtime_export_smoke_policy_probe_command.sh
exit 0
{"elapsed_ms_mean": 3042.7277529845014, "generation_smoke_latency_ms": 0.49250287702307105, "iteration_count": 30.0, "load_smoke_latency_ms": 0.03111903788521886, "metadata_check_latency_ms": 6.92803697893396, "output_preview_byte_count": 384.0, "peak_bytes_mean": 1202536.8, "sample_count": 5.0, "target_count": 4.0, "timeout_count": 0.0, "waiver_count": 0.0}

# Registered focused test command for runtime-export-smoke-policy
bash /tmp/runtime_export_smoke_policy_test_command.sh
exit 0
15 passed in 1.36s

# Registered changed-scope coverage command for runtime-export-smoke-policy
bash /tmp/runtime_export_smoke_policy_coverage_command.sh
exit 0
15 passed in 1.63s
TOTAL 23 0 100%

# Registered probe after the change
bash /tmp/runtime_export_smoke_policy_probe_command.sh
exit 0
{"elapsed_ms_mean": 3011.4348474075086, "generation_smoke_latency_ms": 0.4826561198569834, "iteration_count": 30.0, "load_smoke_latency_ms": 0.032791984267532825, "metadata_check_latency_ms": 7.490187999792397, "output_preview_byte_count": 384.0, "peak_bytes_mean": 1203253.4, "sample_count": 5.0, "target_count": 4.0, "timeout_count": 0.0, "waiver_count": 0.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 23 0 100%` from the registered coverage command.
- Registered probe: `runtime-export-smoke-policy`.
- Local Linux probe delta: `elapsed_ms_mean` 3042.7278 ms -> 3011.4348 ms (`delta_ms=-31.2929`, `speedup=1.0284%`, ratio `1.01039x`).
- CI is required to rerun and publish the registered PR-scoped performance report for merge validation.

## Known Gaps
- Local validation is Linux/Python focused. No Swift runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
