### PR TITLE
perf(coverage): reuse empty changed-line default

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-coverage-empty-path-short-circuit.md
+++ b/docs/plans/2026-05-05-changed-scope-coverage-empty-path-short-circuit.md
@@ -30,3 +30,15 @@ Register `changed-scope-coverage-empty-path-short-circuit` in the PR-scoped perf
 - Changed executable line coverage is at least 95%.
 - Local probe shows fewer source reads and lower elapsed time than `origin/main` on the same synthetic workload.
 - `git diff --check` passes.
+
+## Follow-up slice: shared empty changed-line default
+
+This follow-up keeps the same changed-scope coverage boundary and the registered
+`changed-scope-coverage-empty-path-short-circuit` /
+`changed-scope-coverage-measured-set-filter` probes. When a requested path is
+absent from the parsed diff map, `main()` now passes a module-level immutable
+empty changed-line set to `_measurable_changed_lines(...)` instead of allocating
+a fresh `set()` for every missing path. The helper accepts any set-like
+container and still returns immediately for empty changed-line inputs, preserving
+coverage semantics while reducing per-path allocation overhead in empty or
+filtered diff scopes.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 from bisect import bisect_left
-from collections.abc import Mapping
+from collections.abc import Mapping, Set
 from functools import lru_cache
 import json
 import os
@@ -26,6 +26,7 @@ _ASCII_PLUS = ord("+")
 _ASCII_MINUS = ord("-")
 _ASCII_AT = ord("@")
 _ASCII_LOWER_D = ord("d")
+_EMPTY_CHANGED_LINES: frozenset[int] = frozenset()
 
 
 def _is_diff_file_marker(line: str) -> bool:
@@ -179,7 +180,7 @@ def _filter_coverage_paths(paths: list[str], allowlist: frozenset[str] | None) -
 
 
 def _line_ranges_may_overlap(
-    changed: set[int],
+    changed: Set[int],
     executed_lines: list[int],
     missing_lines: list[int],
 ) -> bool:
@@ -215,7 +216,7 @@ def _measurable_changed_lines(
     repo_root: Path,
     coverage_payload: dict[str, object],
     rel_path: str,
-    changed: set[int],
+    changed: Set[int],
 ) -> tuple[list[int], list[int], list[int]]:
     if not changed:
         return [], [], []
@@ -313,7 +314,7 @@ def main() -> int:
             repo_root,
             coverage_payload,
             rel_path,
-            changed_lines_by_path.get(rel_path, set()),
+            changed_lines_by_path.get(rel_path, _EMPTY_CHANGED_LINES),
         )
         total_measurable += len(measurable)
         total_covered += len(covered)

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -492,7 +492,7 @@ def test_measurable_changed_lines_skips_source_read_when_no_changed_lines(monkey
 
     monkeypatch.setattr(changed_scope_coverage.Path, "read_text", fail_read_text)
 
-    for changed in (set(), {3, 4}):
+    for changed in (set(), changed_scope_coverage._EMPTY_CHANGED_LINES, {3, 4}):
         measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
             tmp_path,
             coverage_payload,


### PR DESCRIPTION
## Summary
- Reuses a module-level immutable empty changed-line set when `changed_scope_coverage.py` processes requested paths that are absent from the parsed diff map.
- Widens the internal changed-line helper type to set-like containers and adds regression coverage for the shared empty default.
- Updates the changed-scope coverage plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-05-changed-scope-coverage-empty-path-short-circuit.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 41 passed in 1.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 41 passed in 0.58s; TOTAL 3 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-empty-path-short-circuit --base-repo /tmp/melix-changed-scope-empty-get-default-base-1390703 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-changed-scope-empty-get-default-20260629 --output /tmp/changed-scope-empty-get-default-perf.json
# head verification ok; base/head probe ok

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-measured-set-filter --base-repo /tmp/melix-changed-scope-empty-get-default-base2-1392933 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-changed-scope-empty-get-default-20260629 --output /tmp/changed-scope-measured-get-default-perf.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `scripts/changed_scope_coverage.py`, `tests/test_changed_scope_coverage.py`, and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Registered probe `changed-scope-coverage-empty-path-short-circuit`:
  - `elapsed_ms_mean`: base `0.117320`, head `0.123404` ms (small noise/regression under the probe absolute warning threshold).
  - `main_empty_allowlist_elapsed_ms_mean`: base `0.487121`, head `0.414653` ms (improvement `-0.072468` ms, ~14.88% faster).
  - `source_read_calls_mean`: base/head `0.0`.
- Registered probe `changed-scope-coverage-measured-set-filter`:
  - `elapsed_ms_mean`: base `0.206075`, head `0.201688` ms (improvement `-0.004387` ms, ~2.13% faster).
  - `allowlist_parse_elapsed_ms_mean`: base `2.814083`, head `2.719101` ms.
  - `source_read_calls_mean`: base/head `0.0`.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Local Linux probes are micro-benchmark level and show small timing noise on the general empty-path elapsed metric; the directly affected empty-allowlist path improved locally.
- Full repository `make` gates were not run locally for this Python CI-helper slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no runtime observability changes; registered PR-scoped probes provide evidence.
- [x] Deferred work and known gaps are stated explicitly.
