### PR TITLE
perf(changed-scope): fast-path singleton range checks

### DIFF
--- a/docs/plans/2026-06-29-changed-scope-singleton-range-fastpath.md
+++ b/docs/plans/2026-06-29-changed-scope-singleton-range-fastpath.md
@@ -1,0 +1,38 @@
+# Changed-scope singleton range fast path
+
+## Context
+
+`scripts/changed_scope_coverage.py` compares the changed-line set for a file
+against executed and missing line ranges from `coverage json`. Most focused
+slice diffs change only one executable line in a file. In that singleton case,
+`_line_ranges_may_overlap` can compare the one changed line directly against the
+coverage ranges instead of scanning the changed set twice with `min(changed)` and
+`max(changed)`.
+
+## Slice
+
+This Python-only slice is limited to changed-scope coverage tooling:
+
+- add a singleton changed-line fast path in `_line_ranges_may_overlap`;
+- preserve the existing empty, singleton measured-entry, sorted-list, and
+  reversed-list fallbacks;
+- register a PR-scoped performance probe for the singleton changed-line shape.
+
+## Registered probe
+
+The affected path is covered by the new registered PR-scoped probe
+`changed-scope-coverage-singleton-range-fastpath` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries. It measures many
+files with one changed line just outside large measured coverage ranges and
+reports:
+
+- `elapsed_ms_mean` (lower is better);
+- `source_read_calls_mean` (must remain `0.0`);
+- `path_count` and `measured_lines_per_path` as informational context.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and the local
+registered probe on Linux before opening the PR. The PR-scoped performance
+workflow remains the merge gate for the registered probe result in CI.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3173,6 +3173,48 @@
     ]
   },
   {
+    "id": "changed-scope-coverage-singleton-range-fastpath",
+    "name": "Changed-scope coverage singleton range fast path",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "scripts/changed_scope_coverage.py",
+      "scripts/changed_scope_coverage_singleton_probe.py",
+      "tests/test_changed_scope_coverage.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_singleton_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+    "probe_command": "bash -c 'SCRIPT=\"scripts/changed_scope_coverage_singleton_probe.py\"; for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0,
+        "warn_abs": 0.05
+      },
+      {
+        "key": "source_read_calls_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "measured_lines_per_path",
+        "unit": "count",
+        "direction": "informational"
+      },
+      {
+        "key": "path_count",
+        "unit": "count",
+        "direction": "informational"
+      }
+    ]
+  },
+  {
     "id": "changed-scope-coverage-diff-parser",
     "name": "Changed-scope coverage diff parser",
     "runner": "ubuntu-latest",

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -186,6 +186,26 @@ def _line_ranges_may_overlap(
 ) -> bool:
     if not changed:
         return False
+    if len(changed) == 1:
+        changed_line = next(iter(changed))
+        if executed_lines:
+            first_line = executed_lines[0]
+            last_line = executed_lines[-1]
+            if first_line > last_line:
+                first_line = min(executed_lines)
+                last_line = max(executed_lines)
+            if first_line <= changed_line <= last_line:
+                return True
+        if missing_lines:
+            first_line = missing_lines[0]
+            last_line = missing_lines[-1]
+            if first_line > last_line:
+                first_line = min(missing_lines)
+                last_line = max(missing_lines)
+            if first_line <= changed_line <= last_line:
+                return True
+        return False
+
     min_changed = min(changed)
     max_changed = max(changed)
     if executed_lines:

--- a/scripts/changed_scope_coverage_singleton_probe.py
+++ b/scripts/changed_scope_coverage_singleton_probe.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import statistics
+import tempfile
+import time
+
+
+def _load_changed_scope_coverage(repo_root: Path):
+    module_path = repo_root / "scripts" / "changed_scope_coverage.py"
+    spec = importlib.util.spec_from_file_location("changed_scope_coverage_singleton_probe_target", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_probe(
+    repo_root: Path,
+    *,
+    path_count: int = 800,
+    measured_lines_per_path: int = 500,
+    samples: int = 9,
+) -> dict[str, float]:
+    module = _load_changed_scope_coverage(repo_root)
+    elapsed_samples: list[float] = []
+    read_samples: list[float] = []
+
+    with tempfile.TemporaryDirectory(prefix="melix-changed-scope-singleton-probe-") as tmp:
+        root = Path(tmp)
+        rel_paths = [f"pkg/module_{index}.py" for index in range(path_count)]
+        for rel_path in rel_paths:
+            source_path = root / rel_path
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_text("covered = 1\n", encoding="utf-8")
+
+        coverage_payload = {
+            "files": {
+                rel_path: {
+                    "executed_lines": list(range(1, measured_lines_per_path + 1, 2)),
+                    "missing_lines": list(range(2, measured_lines_per_path + 1, 2)),
+                }
+                for rel_path in rel_paths
+            }
+        }
+        changed_lines = {measured_lines_per_path + 1}
+
+        original_read_text = module.Path.read_text
+        try:
+            for _ in range(samples):
+                read_calls = 0
+
+                def counted_read_text(self: Path, *args: object, **kwargs: object) -> str:
+                    nonlocal read_calls
+                    read_calls += 1
+                    return original_read_text(self, *args, **kwargs)
+
+                module.Path.read_text = counted_read_text
+                start = time.perf_counter()
+                for rel_path in rel_paths:
+                    measurable, covered, missed = module._measurable_changed_lines(
+                        root,
+                        coverage_payload,
+                        rel_path,
+                        changed_lines,
+                    )
+                    if measurable or covered or missed:
+                        raise RuntimeError("singleton changed line outside measured ranges must not produce measurable lines")
+                elapsed_samples.append((time.perf_counter() - start) * 1000.0)
+                read_samples.append(float(read_calls))
+        finally:
+            module.Path.read_text = original_read_text
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "source_read_calls_mean": statistics.fmean(read_samples),
+        "path_count": float(path_count),
+        "measured_lines_per_path": float(measured_lines_per_path),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_probe(Path.cwd()), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1815,11 +1815,12 @@ def test_scope_report_selects_changed_scope_coverage_probe() -> None:
     )
 
     selected_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 3
+    assert scope["selected_count"] == 4
     assert scope["force_all"] is False
     assert selected_ids == {
         "changed-scope-coverage-empty-path-short-circuit",
         "changed-scope-coverage-measured-set-filter",
+        "changed-scope-coverage-singleton-range-fastpath",
         "changed-scope-coverage-diff-parser",
     }
 
@@ -3804,6 +3805,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "benchmark-store-matrix-streaming",
         "changed-scope-coverage-empty-path-short-circuit",
         "changed-scope-coverage-measured-set-filter",
+        "changed-scope-coverage-singleton-range-fastpath",
         "changed-scope-coverage-diff-parser",
         "closure-audit-probe-source-short-circuit",
         "code-eval-code-block-last-match-streaming",

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -45,6 +45,17 @@ assert MEASURED_PROBE_MODULE_SPEC.loader is not None
 changed_scope_coverage_measured_probe = importlib.util.module_from_spec(MEASURED_PROBE_MODULE_SPEC)
 MEASURED_PROBE_MODULE_SPEC.loader.exec_module(changed_scope_coverage_measured_probe)
 
+SINGLETON_PROBE_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "changed_scope_coverage_singleton_probe.py"
+)
+SINGLETON_PROBE_MODULE_SPEC = importlib.util.spec_from_file_location(
+    "changed_scope_coverage_singleton_probe", SINGLETON_PROBE_MODULE_PATH
+)
+assert SINGLETON_PROBE_MODULE_SPEC is not None
+assert SINGLETON_PROBE_MODULE_SPEC.loader is not None
+changed_scope_coverage_singleton_probe = importlib.util.module_from_spec(SINGLETON_PROBE_MODULE_SPEC)
+SINGLETON_PROBE_MODULE_SPEC.loader.exec_module(changed_scope_coverage_singleton_probe)
+
 
 @pytest.fixture(autouse=True)
 def clear_probe_coverage_path_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -536,6 +547,22 @@ def test_measurable_changed_lines_checks_singletons_before_range_overlap(
     assert missed == []
 
 
+def test_line_ranges_may_overlap_single_changed_line_avoids_changed_minmax(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SingleLineSet(set[int]):
+        def __iter__(self):  # type: ignore[override]
+            yield 12
+
+    def fail_min(*args: object, **kwargs: object) -> object:  # pragma: no cover
+        raise AssertionError("singleton changed sets should avoid min(changed)")
+
+    monkeypatch.setattr(changed_scope_coverage, "min", fail_min, raising=False)
+
+    assert changed_scope_coverage._line_ranges_may_overlap(SingleLineSet({12}), [1, 10], []) is False
+    assert changed_scope_coverage._line_ranges_may_overlap(SingleLineSet({12}), [1, 12], []) is True
+
+
 def test_measurable_changed_lines_skips_empty_measured_lines(monkeypatch, tmp_path: Path) -> None:
     coverage_payload = {"files": {"foo.py": {"executed_lines": [], "missing_lines": []}}}
 
@@ -625,6 +652,18 @@ def test_changed_scope_coverage_measured_probe_emits_large_measured_metrics() ->
     assert metrics["elapsed_ms_mean"] > 0
     assert metrics["allowlist_parse_elapsed_ms_mean"] > 0
     assert metrics["allowlist_parse_count"] == 10000.0
+    assert metrics["source_read_calls_mean"] == 0.0
+
+
+def test_changed_scope_coverage_singleton_probe_emits_range_metrics() -> None:
+    metrics = changed_scope_coverage_singleton_probe.run_probe(
+        Path(__file__).resolve().parents[1], path_count=5, measured_lines_per_path=10, samples=2
+    )
+
+    assert metrics["path_count"] == 5.0
+    assert metrics["measured_lines_per_path"] == 10.0
+    assert metrics["sample_count"] == 2.0
+    assert metrics["elapsed_ms_mean"] > 0
     assert metrics["source_read_calls_mean"] == 0.0
 
 


### PR DESCRIPTION
## Summary
- Fast-path singleton changed-line range checks in `scripts/changed_scope_coverage.py` to avoid scanning the changed set with `min()`/`max()` when only one line changed.
- Register `changed-scope-coverage-singleton-range-fastpath` with focused test, coverage, and command-json probe coverage.
- Add a focused plan and probe/test coverage for the singleton range workload.

## Plan or Spec
- `docs/plans/2026-06-29-changed-scope-singleton-range-fastpath.md`

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_singleton_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_singleton_probe.py`
- Inline base-vs-head singleton probe comparison against `origin/main`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: `45 passed in 1.21s`
- Changed-scope coverage: `TOTAL 40 0 100%`
- Local head probe: `elapsed_ms_mean=0.615817882741491`, `source_read_calls_mean=0.0`, `path_count=800`, `measured_lines_per_path=500`
- Local base-vs-head comparison: `old_mean=0.6686203349899087ms`, `new_mean=0.4530139914196398ms`, `delta_ms=-0.21560634357026887ms`, `speedup=1.4759374934416685x`, source reads unchanged at `0.0`

## Known Gaps
- This is a Python tooling slice and was locally verified on Linux only.
- Registered PR-scoped performance CI is still required as the merge gate for the new probe.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered/local probe ran locally on Linux.
- [x] `git diff --check` passed.
