### PR TITLE
perf: reuse cached local job root path

### DIFF
--- a/docs/plans/2026-06-29-local-job-root-fspath-cache.md
+++ b/docs/plans/2026-06-29-local-job-root-fspath-cache.md
@@ -1,0 +1,23 @@
+# Local Job Follow-up Scan Root Fspath Cache
+
+## Slice
+
+Optimize the registered `local-job-followup-scan-scandir` Python path by reusing the `LocalJobContinuationStore` constructor-cached filesystem path string when scanning follow-up records.
+
+## Scope
+
+- Production path: `services/mlx-worker-python/worker/runtime/local_job_continuation.py`
+- Registered probe: `local-job-followup-scan-scandir`
+- Tests/probe remain governed by the existing registry entry in `infra/perf/pr_scoped_probes.json`.
+
+## Behavior Contract
+
+The change is behavior-preserving: `scan_followup_candidates()` must still scan exactly one directory with `os.scandir`, ignore non-JSON entries and directory entries, preserve sorted job-id processing, tolerate a missing root, and avoid following record symlinks.
+
+## Measurement Plan
+
+Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux before opening the PR. The performance decision is based on the registered probe's `elapsed_ms_mean` while keeping `scandir_calls_mean == 1`, `path_glob_calls_mean == 0`, and candidate/receipt counts unchanged.
+
+## Linux Boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -361,11 +361,11 @@ class LocalJobContinuationStore:
             if live_evidence_by_job_id is not None
             else _missing_live_evidence
         )
-        root = self.root
+        root_fspath = self._root_fspath
         try:
             record_job_ids: list[str] = []
             record_job_ids_append = record_job_ids.append
-            for entry in os.scandir(os.fspath(root)):
+            for entry in os.scandir(root_fspath):
                 name = entry.name
                 if name.endswith(".json") and entry.is_file(follow_symlinks=False):
                     # The scan has already filtered this to a .json file name.


### PR DESCRIPTION
## Summary
- Reuses the constructor-cached filesystem path string when `LocalJobContinuationStore.scan_followup_candidates()` calls `os.scandir`.
- Keeps the existing registered `local-job-followup-scan-scandir` probe as the validation source for this Python hot path.
- Adds a slice plan documenting the behavior contract, measurement plan, and Linux verification boundary.

## Plan or Spec
- `docs/plans/2026-06-29-local-job-root-fspath-cache.md`
- Registered probe: `infra/perf/pr_scoped_probes.json` entry `local-job-followup-scan-scandir` already covers `services/mlx-worker-python/worker/runtime/local_job_continuation.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...` followed by `coverage json` and `python3 scripts/changed_scope_coverage.py ...`
- Baseline/head registered probe comparison using `MELIX_LOCAL_JOB_SCAN_RECORDS=500 MELIX_LOCAL_JOB_SCAN_SAMPLES=7` with 3 runs each.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 11 passed in 0.24s.
- Changed-scope coverage: 100% (`TOTAL 2 0 100%`) for changed measurable lines.
- Probe baseline (`origin/main`, 3 x 7 samples): elapsed mean values `[17.939842, 22.820464, 20.375788]`, aggregate mean `20.378698 ms`.
- Probe head (3 x 7 samples): elapsed mean values `[19.056365, 17.910839, 21.168570]`, aggregate mean `19.378591 ms`.
- Local delta: `-1.000107 ms` (`-4.9076%`), speedup `1.051609x`.
- Invariants: `scandir_calls_mean == 1.0`, `path_glob_calls_mean == 0.0`, `candidate_count_mean == 500.0`, `receipt_count_mean == 500.0`.

## Known Gaps
- CI must run the registered PR-scoped performance workflow before merge.
- This is a Python-only slice locally validated on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed.
- [x] Registered local probe comparison shows improvement with stable scan invariants.
- [ ] GitHub Actions, including PR-scoped performance validation, completed successfully.
