### PR TITLE
perf(export): avoid generator in diagnosis marker scan

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -159,6 +159,12 @@ for a bounded excerpt; overlapping later lines still fall through to the
 remaining lower-priority patterns, and the scan still stops once every known code
 has matched.
 
+A follow-up 2026-06-29 diagnosis marker prefilter loop slice keeps the same
+prefilter semantics while replacing the excerpt-wide marker `any(...)` generator
+with an explicit loop helper. Lines still enter the per-pattern matcher only when
+one registered diagnosis marker appears in the lowercased source text, but the
+hot scan path avoids creating a generator for every bounded excerpt line.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -764,7 +764,7 @@ def _diagnoses_from_excerpt(
             break
         text = source_lines[index].text
         lowered_text = text.lower()
-        if not any(marker in lowered_text for marker in _DIAGNOSIS_MARKERS):
+        if not _has_diagnosis_marker(lowered_text):
             continue
         for pattern in _DIAGNOSIS_PATTERNS:
             if pattern.code in seen_codes:
@@ -784,6 +784,13 @@ def _diagnoses_from_excerpt(
             )
             break
     return diagnoses
+
+
+def _has_diagnosis_marker(lowered_text: str) -> bool:
+    for marker in _DIAGNOSIS_MARKERS:
+        if marker in lowered_text:
+            return True
+    return False
 
 
 def _operator_remedies(diagnoses: list[dict[str, object]]) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Replace the runtime-export diagnostic marker prefilter's generator-backed `any(...)` with an explicit loop helper.
- Keep diagnosis matching semantics unchanged: source lines still enter pattern matching only when a registered marker is present.
- Update the runtime export diagnostic parser plan with the 2026-06-29 marker prefilter loop slice.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`.
- Registered PR-scoped probe already covers this path: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=80 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Tests: `60 passed in 1.49s`; coverage replay: `60 passed in 1.37s`.
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local Linux registered probe baseline on `origin/main` with 80 iterations / 7 samples: `diagnosis_matching_elapsed_ms_mean=2.0725552874085094`, `elapsed_ms_mean=7183.421422852137`, `peak_bytes_mean=223222.42857142858`.
- Local Linux registered probe after this slice with the same settings: `diagnosis_matching_elapsed_ms_mean=1.5939085694429065`, `elapsed_ms_mean=7142.222048590026`, `peak_bytes_mean=215313.7142857143`.
- Delta: diagnosis marker scan `-0.4786467179656029 ms` / `23.094521090633737%` faster (`1.3002974744861913x`); full probe elapsed `-41.19937426211072 ms` / `0.5735341397491439%` faster.

## Known Gaps
- Linux local validation covers the Python worker path only.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
