### PR TITLE
perf: reuse export diagnostic excerpt byte count

### DIFF
--- a/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
+++ b/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
@@ -53,3 +53,30 @@ case-normalized marker semantics and downstream regex redaction behavior.
 Validation remains the registered focused pytest selection, changed-scope
 coverage, and the registered local/CI probe for runtime export diagnostic
 parsing.
+
+## 2026-06-29 follow-up: excerpt byte accounting
+
+This Python-only follow-up stays inside the same
+`runtime-export-diagnostic-parser` registered probe and narrows to
+`_build_redacted_excerpt(...)`. The excerpt builder already enforces the byte
+bound incrementally before appending each rendered line. The previous tail check
+encoded the complete excerpt a second time and recomputed the same byte count;
+that was redundant once the bounded append loop had accepted or clipped the last
+line. This slice records `excerpt_byte_count` from the existing incremental
+counter while preserving the emitted excerpt text, line count, and truncation
+semantics.
+
+Validation remains the registered focused pytest selection, changed-scope
+coverage, and the registered local/CI probe for runtime export diagnostic
+parsing.
+
+Local 2026-06-29 probe decision for this byte-accounting slice:
+
+- Baseline `elapsed_ms_mean`: `5330.903970852627`, `5367.044953862205`, `5334.687961431752` ms; mean `5344.212295382195` ms.
+- Post-change `elapsed_ms_mean`: `5313.273270290146`, `5320.671012284168`, `5329.956482721692` ms; mean `5321.3002550986685` ms (`-22.91204028352695` ms, `1.0043x` faster).
+- Baseline `path_redaction_elapsed_ms_mean`: `41.330500289664734`, `41.05674671674414`, `38.63969701342285` ms; mean `40.34231467327724` ms.
+- Post-change `path_redaction_elapsed_ms_mean`: `39.35490457973044`, `38.86108529487891`, `40.44690043000238` ms; mean `39.554296768203905` ms (`-0.7880179050733318` ms, `1.0199x` faster).
+- Baseline `peak_bytes_mean`: `221628.14285714287`, `217392.7142857143`, `220683.42857142858` bytes; mean `219901.42857142855` bytes.
+- Post-change `peak_bytes_mean`: `218961.0`, `218377.85714285713`, `225139.7142857143` bytes; mean `220826.1904761905` bytes (`+924.7619047619519` bytes, within the registered warning boundary).
+
+Decision: accepted because the registered end-to-end elapsed metric and path-redaction submetric improved over three local Linux probe runs, the byte-count behavior is covered directly, and the small peak-memory movement remains within the registered warning boundary.

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -249,6 +249,29 @@ def test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identi
     assert receipt["redaction_summary"]["redacted_identity_count"] >= 1
 
 
+def test_export_target_diagnostics_excerpt_byte_count_reuses_incremental_accounting(
+    tmp_path: Path,
+) -> None:
+    target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [
+            _SourceLine("logs/runtime.log", "runtime load failed at café"),
+            _SourceLine("logs/runtime.log", "permission denied opening weights"),
+        ],
+        bounded_bytes=4096,
+        bounded_lines=8,
+    )
+
+    assert excerpt.summary.excerpt_byte_count == len(excerpt.text.encode("utf-8"))
+    assert excerpt.summary.excerpt_line_count == 2
+
+
 def test_export_target_diagnostics_resolves_target_root_once_for_many_path_redactions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -575,11 +575,7 @@ def _build_redacted_excerpt(
     text = "\n".join(output_lines)
     if text:
         text += "\n"
-    encoded_text = text.encode("utf-8")
-    if len(encoded_text) > bounded_bytes:
-        text = encoded_text[:bounded_bytes].decode("utf-8", errors="ignore")
-        summary.truncated = True
-    summary.excerpt_byte_count = len(text.encode("utf-8"))
+    summary.excerpt_byte_count = used_bytes
     summary.excerpt_line_count = len(output_lines)
     if len(source_lines) > len(output_lines):
         summary.truncated = True


### PR DESCRIPTION
## Summary
- Reuse the existing incremental byte counter when finalizing runtime export diagnostic excerpts.
- Add a focused regression test that keeps `excerpt_byte_count` aligned with emitted UTF-8 text.
- Update the runtime export diagnostics performance plan with local Linux probe evidence.

## Plan or Spec
- `docs/plans/2026-06-28-export-diagnostics-source-line-extension.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 61 passed in 0.57s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# TOTAL 7 0 100%

MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=7 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=60 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# post-change runs: elapsed_ms_mean 5313.273270290146, 5320.671012284168, 5329.956482721692

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Baseline `elapsed_ms_mean`: `5330.903970852627`, `5367.044953862205`, `5334.687961431752` ms; mean `5344.212295382195` ms.
- Post-change `elapsed_ms_mean`: `5313.273270290146`, `5320.671012284168`, `5329.956482721692` ms; mean `5321.3002550986685` ms (`-22.91204028352695` ms, `1.0043x` faster).
- Baseline `path_redaction_elapsed_ms_mean`: mean `40.34231467327724` ms; post-change mean `39.554296768203905` ms (`1.0199x` faster).
- Baseline `peak_bytes_mean`: mean `219901.42857142855` bytes; post-change mean `220826.1904761905` bytes (`+924.7619047619519` bytes, within warning boundary).
- Registered CI probe validation is required before merge: `runtime-export-diagnostic-parser` via PR-scoped performance workflow.

## Known Gaps
- Local validation is Linux-only for this Python slice; CI remains the source of truth for registered PR-scoped performance reporting.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
