### PR TITLE
perf: bind chunker message copy helper

### DIFF
--- a/docs/plans/2026-05-05-training-dataset-chunker-top-level-copy.md
+++ b/docs/plans/2026-05-05-training-dataset-chunker-top-level-copy.md
@@ -34,3 +34,9 @@ The probe builds one synthetic sample with many top-level metadata fields and lo
 - Focused tests pass.
 - Changed-scope coverage is at least 95% for touched executable Python/test/probe files.
 - Local base-vs-head probe shows reduced or neutral latency/peak memory on the synthetic many-chunk workload.
+
+## 2026-06-29 Follow-up Slice: Message Copy Binding
+
+A follow-up Python-only slice may reuse the same registered probe and focused coverage because it touches the same hot chunk emission path. The slice binds `dict.copy` once for per-chunk output-base and message-container copies, avoiding repeated bound-method lookup while preserving shallow-copy semantics for top-level payloads and independent message dict containers.
+
+Validation remains the registered `training-dataset-chunker-top-level-base-copy` test, coverage, and probe command.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -30,6 +30,9 @@ from worker.model_ops.errors import ModelOperationError
 from worker.model_ops.response_only_boundary import _ChatTemplateTokenizer
 
 
+_COPY_DICT = dict.copy
+
+
 @dataclass(frozen=True)
 class ChunkStats:
     """Aggregate chunking stats surfaced in the snapshot manifest + metrics.
@@ -317,7 +320,8 @@ def _chunk_single_turn(
 def _copy_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
     """Copy the message containers without deep-copying immutable string payloads."""
 
-    return [message.copy() for message in messages]
+    copy_dict = _COPY_DICT
+    return [copy_dict(message) for message in messages]
 
 
 def _passthrough_sample(sample: dict) -> dict:
@@ -408,10 +412,11 @@ def _chunk_sample(
     # of chunks, so rebuilding this filtered dict inside the chunk loop repeats
     # the same key scan and metadata reference assignments unnecessarily.
     output_base = {k: v for k, v in sample.items() if k != "messages"}
+    copy_dict = _COPY_DICT
     for idx, chunk in enumerate(chunked_messages):
         # Copy only the message dict containers so each chunk has an independent
         # message list without re-copying immutable string payloads.
-        out = output_base.copy()
+        out = copy_dict(output_base)
         out["messages"] = _copy_messages(chunk)
         if sample_id:
             out["id"] = f"{sample_id}#chunk-{idx}"


### PR DESCRIPTION
## Summary
- Bind `dict.copy` once in the training dataset chunker hot path for message-container and output-base copies.
- Preserve shallow top-level payload reuse and independent per-chunk message dict containers.
- Update the governing chunker performance plan with the follow-up slice and validation boundary.

## Plan or Spec
- `docs/plans/2026-05-05-training-dataset-chunker-top-level-copy.md`
- Registered PR-scoped probe already covers this path: `training-dataset-chunker-top-level-base-copy` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py`
- Baseline/head probe loop: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py` (3 runs each on `origin/main` and this branch)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 11 passed.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe (`training_dataset_chunker_top_level_copy_probe.py`):
  - old runs (ms): 25.363524, 22.258812, 24.204800; old_mean=23.942379
  - new runs (ms): 22.668433, 22.797914, 23.362477; new_mean=22.942941
  - delta_ms=-0.999437; speedup=1.043562x; improvement=4.174%
  - peak_bytes_mean unchanged at 774473.714 bytes; chunk_count=174

## Known Gaps
- Python-only slice; Linux local verification covers behavior, changed-scope coverage, and the registered probe.
- CI must run the PR-scoped performance workflow and report the registered probe before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Local registered probe shows directionally improved latency with unchanged peak bytes.
- [ ] GitHub Actions completed successfully, including the PR-scoped performance report.
