### PR TITLE
perf: fast-path plain model load config paths

### DIFF
--- a/docs/plans/2026-06-29-model-load-trust-plain-path-fastpath.md
+++ b/docs/plans/2026-06-29-model-load-trust-plain-path-fastpath.md
@@ -1,0 +1,52 @@
+# Model Load Trust Plain Path Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to model-load trust policy config
+file detection in `services/mlx-worker-python/worker/model_load_trust.py`.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the model-load trust tests and inline config JSON
+probe, so no probe registry change is required for this slice.
+
+## Optimization
+
+The model-load trust path resolves the `config.json` path on every trust-policy
+resolution. Common catalog model paths are already plain `str` values without
+leading or trailing whitespace. This slice adds an exact-`str` fast path that
+reuses the path directly and only falls back to the existing `str(...).strip()`
+normalization for blank, padded, or non-exact values. The behavior remains
+unchanged: blank paths, whitespace-normalized paths, tilde expansion, missing
+files, non-regular paths, JSON decode errors, non-dict payloads, and custom-loader
+`auto_map` detection all keep the existing fallbacks.
+
+## Verification
+
+Run the registered focused local Linux commands from `model-load-config-json-bytes`
+in `infra/perf/pr_scoped_probes.json` before opening the PR:
+
+```bash
+python3 - <<'PY'
+import json, subprocess
+from pathlib import Path
+probe = next(
+    item for item in json.loads(Path("infra/perf/pr_scoped_probes.json").read_text())
+    if item["id"] == "model-load-config-json-bytes"
+)
+for key in ("test_command", "coverage_command", "probe_command"):
+    rc = subprocess.run(probe[key], shell=True).returncode
+    if rc:
+        raise SystemExit(rc)
+PY
+```
+
+CI PR-scoped performance remains the merge gate for the registered probe result.
+
+## Success Criteria
+
+- Focused model-load trust tests pass.
+- Changed-scope coverage for `worker.model_load_trust` stays at or above the repository threshold.
+- The registered probe reports a directionally improved config JSON hot path.
+- PR-scoped performance CI selects and completes the registered probe before merge.

--- a/services/mlx-worker-python/tests/test_model_load_trust.py
+++ b/services/mlx-worker-python/tests/test_model_load_trust.py
@@ -686,6 +686,18 @@ def test_trust_policy_treats_blank_model_path_as_absent(tmp_path: Path) -> None:
     assert policy.custom_loader_required is False
     assert policy.custom_loader_detection_source == "config_json:absent"
 
+    empty_path_model = WorkerModelCatalog.dev_text_model()
+    empty_path_model.model_path = ""
+    empty_path_policy = resolve_model_load_trust_policy(
+        empty_path_model,
+        request_policy=None,
+        runtime_kind="text",
+        runtime=RecordingTextBackend(),
+    )
+
+    assert empty_path_policy.custom_loader_required is False
+    assert empty_path_policy.custom_loader_detection_source == "config_json:absent"
+
     missing_path_model = WorkerModelCatalog.dev_text_model()
     missing_path_model.model_path = str(tmp_path / "nonexistent-subdir")
     missing_path_policy = resolve_model_load_trust_policy(

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -343,7 +343,13 @@ def _read_model_config(model_spec: common_pb2.ModelSpec) -> dict[str, Any] | Non
 
 
 def _model_config_path(model_spec: common_pb2.ModelSpec) -> tuple[str, str | os.PathLike[str]] | None:
-    model_path = str(model_spec.model_path or "").strip()
+    model_path_value = model_spec.model_path
+    if type(model_path_value) is str:
+        if not model_path_value:
+            return None
+        if not model_path_value[0].isspace() and not model_path_value[-1].isspace():
+            return _model_config_path_for_model_path(model_path_value)
+    model_path = str(model_path_value or "").strip()
     if not model_path:
         return None
     return _model_config_path_for_model_path(model_path)


### PR DESCRIPTION
## Summary
- Fast-path plain `str` model paths in `worker.model_load_trust._model_config_path` so the common config lookup avoids `str(...).strip()` normalization.
- Extend the blank-path regression test to cover the empty-string fast path.
- Add the governing plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-06-29-model-load-trust-plain-path-fastpath.md`
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Registered focused test command from model-load-config-json-bytes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...
Result: 28 passed in 0.59s

# Registered changed-scope coverage command from model-load-config-json-bytes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...
Result: 28 passed in 1.03s; TOTAL 12 0 100%

# Registered local probe command from model-load-config-json-bytes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PYPROBE' ...
Result: {"elapsed_ms_mean": 5.823963853929724, "elapsed_ms_min": 5.565175029914826, "peak_bytes_mean": 3187.4285714285716, "rejections_mean": 300.0, "samples": 7, "iterations": 300}

# Repeated local base-vs-head registered probe, 3 runs, with MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES=9 and MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS=1500
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-load-config-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/model-load-config-json-bytes-fastpath-report-{1,2,3}.json
Result: all focused test/coverage/probe stages passed in each run.

git diff --check
Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered local probe single run: `elapsed_ms_mean=5.823963853929724`, `elapsed_ms_min=5.565175029914826`, `peak_bytes_mean=3187.4285714285716`, `rejections_mean=300.0`.
- Repeated local base-vs-head probe aggregate (`samples=9`, `iterations=1500`, 3 runs):
  - `old_mean=29.357966997108804 ms`
  - `new_mean=28.378554962627174 ms`
  - `delta_ms=-0.97941203448163 ms`
  - `speedup=3.3361030570614214%`
- Individual repeated probe deltas: `-0.6968771016949589 ms`, `-0.03917878105615458 ms`, `-2.2021802206937657 ms`.
- CI PR-scoped performance must run `model-load-config-json-bytes` and is the merge gate.

## Known Gaps
- Full repository `make py-test`, Swift, and integration suites were not run locally; this is a focused Linux-verifiable Python performance slice.
- CI PR-scoped performance is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
