### PR TITLE
perf: fast-path export diagnostic markers

### DIFF
--- a/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
+++ b/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
@@ -80,3 +80,31 @@ Local 2026-06-29 probe decision for this byte-accounting slice:
 - Post-change `peak_bytes_mean`: `218961.0`, `218377.85714285713`, `225139.7142857143` bytes; mean `220826.1904761905` bytes (`+924.7619047619519` bytes, within the registered warning boundary).
 
 Decision: accepted because the registered end-to-end elapsed metric and path-redaction submetric improved over three local Linux probe runs, the byte-count behavior is covered directly, and the small peak-memory movement remains within the registered warning boundary.
+
+## 2026-06-29 follow-up: diagnosis marker dispatch
+
+This Python-only follow-up stays inside the same
+`runtime-export-diagnostic-parser` registered probe and narrows to
+`_has_diagnosis_marker(...)`. The diagnosis matcher calls this gate for every
+redacted excerpt line before trying the heavier regex-backed diagnosis patterns.
+The previous implementation iterated over the `_DIAGNOSIS_MARKERS` tuple on each
+line; this slice replaces that loop with an explicit boolean chain, preserving
+the same lowercase marker semantics while avoiding per-line iterator dispatch in
+the registered diagnosis-matching submetric.
+
+Validation remains the registered focused pytest selection, changed-scope
+coverage, and the registered local/CI probe for runtime export diagnostic
+parsing.
+
+Local 2026-06-29 probe decision for this diagnosis-marker dispatch slice:
+
+- Baseline `elapsed_ms_mean`: `2637.5025729998015`, `2654.986914584879`, `2665.917513007298` ms; mean `2652.8023335306593` ms.
+- Post-change `elapsed_ms_mean`: `2667.1227828017436`, `2697.7672479930334`, `2665.6808106112294` ms; mean `2676.8569471353353` ms (`+24.05461360467598` ms, within the registered 5% warning boundary).
+- Baseline `diagnosis_matching_elapsed_ms_mean`: `0.6576695828698575`, `0.6117791985161602`, `0.6307542091235518` ms; mean `0.6334009968365232` ms.
+- Post-change `diagnosis_matching_elapsed_ms_mean`: `0.6145246094092727`, `0.6511981831863523`, `0.593486987054348` ms; mean `0.6197365932166576` ms (`-0.01366440361986554` ms, `1.0220x` faster).
+- Baseline `path_redaction_elapsed_ms_mean`: `21.92815599264577`, `18.738398794084787`, `19.31412999983877` ms; mean `19.993561595523108` ms.
+- Post-change `path_redaction_elapsed_ms_mean`: `19.627736799884588`, `19.103819190058857`, `19.20032900525257` ms; mean `19.310628331732005` ms (`-0.682933263791103` ms, `1.0354x` faster).
+- Baseline `peak_bytes_mean`: `201497.0`, `203466.4`, `203879.2` bytes; mean `202947.53333333333` bytes.
+- Post-change `peak_bytes_mean`: `204847.0`, `203285.2`, `203169.0` bytes; mean `203767.06666666665` bytes (`+819.5333333333256` bytes, within the registered 5% warning boundary).
+
+Decision: accepted because the targeted registered diagnosis-matching submetric improved over three local Linux probe runs, path redaction also improved, and the end-to-end elapsed/peak-memory movement stayed within the registered 5% warning boundary. `diagnostic_latency_ms` was noisy (`+0.5255787012477704` ms mean, `+5.96%`) and remains a CI-observed risk for this PR-scoped probe.

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -30,6 +30,7 @@ from worker.productization.export_target_diagnostics import (
     _diagnoses_from_excerpt,
     _diagnosis_metric_counts,
     _extend_source_lines,
+    _has_diagnosis_marker,
     _has_identity_marker,
     _has_named_secret_marker,
     _has_private_text_line_marker,
@@ -173,6 +174,28 @@ def test_export_target_diagnostics_private_line_marker_fast_path_matches_registe
     expected: bool,
 ) -> None:
     assert _has_private_text_line_marker(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("ordinary runtime status", False),
+        ("unsupported architecture arm64 required", True),
+        ("duplicate tensor name decoder.layers.0", True),
+        ("missing blob sha256-777777 not found", True),
+        ("runtime binary not installed: ollama", True),
+        ("invalid runtime path /tmp/melix/bad-target", True),
+        ("generation smoke timed out after deadline exceeded", True),
+        ("permission denied opening model weights", True),
+        ("Metal out of memory during load", True),
+        ("runtime load failed while opening model", True),
+    ],
+)
+def test_export_target_diagnostics_diagnosis_marker_fast_path_matches_registered_markers(
+    text: str,
+    expected: bool,
+) -> None:
+    assert _has_diagnosis_marker(text.lower()) is expected
 
 
 def test_export_target_diagnostics_skips_private_line_regex_for_unrelated_runtime_lines(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -783,10 +783,40 @@ def _diagnoses_from_excerpt(
 
 
 def _has_diagnosis_marker(lowered_text: str) -> bool:
-    for marker in _DIAGNOSIS_MARKERS:
-        if marker in lowered_text:
-            return True
-    return False
+    return (
+        "arch" in lowered_text
+        or "cpu type" in lowered_text
+        or "arm64" in lowered_text
+        or "duplicate" in lowered_text
+        or "tensor" in lowered_text
+        or "already exists" in lowered_text
+        or "blob" in lowered_text
+        or "sha256" in lowered_text
+        or "artifact" in lowered_text
+        or "missing required" in lowered_text
+        or "command" in lowered_text
+        or "binary" in lowered_text
+        or "executable" in lowered_text
+        or "installed" in lowered_text
+        or "ollama" in lowered_text
+        or "mlx_lm" in lowered_text
+        or "llama" in lowered_text
+        or "invalid" in lowered_text
+        or "path" in lowered_text
+        or "directory" in lowered_text
+        or "timed out" in lowered_text
+        or "timeout" in lowered_text
+        or "deadline" in lowered_text
+        or "permi" in lowered_text
+        or "eacces" in lowered_text
+        or "memory" in lowered_text
+        or "oom" in lowered_text
+        or "failed to load" in lowered_text
+        or "model load" in lowered_text
+        or "runtime load" in lowered_text
+        or "error loading" in lowered_text
+        or "load failed" in lowered_text
+    )
 
 
 def _operator_remedies(diagnoses: list[dict[str, object]]) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Fast-path `_has_diagnosis_marker(...)` with an explicit lowercase marker boolean chain to avoid per-line tuple iterator dispatch in runtime export diagnostic parsing.
- Add focused marker fast-path coverage for the common diagnostic codes.
- Update the runtime export diagnostics performance plan with local probe measurements and the CI-observed risk note.

## Plan or Spec
- Updated `docs/plans/2026-06-28-export-diagnostics-source-line-extension.md` with the diagnosis marker dispatch follow-up, registered probe boundary, and local metrics.
- Registered probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`, already covering the affected Python path with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 71 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...` → TOTAL 4/4 changed lines covered, 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/runtime-export-diagnostic-marker-probe-{1,2,3}.json` → passed locally on Linux for all three runs
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 4 0 100%`).
- Local registered probe, 3-run means:
  - `diagnosis_matching_elapsed_ms_mean`: base `0.6334009968365232` ms → head `0.6197365932166576` ms (`-0.01366440361986554` ms, `1.0220x` faster).
  - `path_redaction_elapsed_ms_mean`: base `19.993561595523108` ms → head `19.310628331732005` ms (`-0.682933263791103` ms, `1.0354x` faster).
  - `elapsed_ms_mean`: base `2652.8023335306593` ms → head `2676.8569471353353` ms (`+24.05461360467598` ms, within registered 5% warning boundary).
  - `peak_bytes_mean`: base `202947.53333333333` bytes → head `203767.06666666665` bytes (`+819.5333333333256` bytes, within registered 5% warning boundary).
- CI PR-scoped performance must complete successfully before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux. No Swift runtime behavior changed.
- `diagnostic_latency_ms` was noisy locally (`+0.5255787012477704` ms mean, `+5.96%`), so the registered CI probe report is the final merge gate.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Affected path has a registered PR-scoped probe with focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe ran locally on Linux with three base/head samples.
- [ ] GitHub Actions and PR-scoped performance completed successfully.
