### PR TITLE
perf: use splitlines in changed-scope diff parser

### DIFF
--- a/docs/plans/2026-06-29-changed-scope-parse-splitlines.md
+++ b/docs/plans/2026-06-29-changed-scope-parse-splitlines.md
@@ -1,0 +1,38 @@
+# Changed-scope diff parser splitlines slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`scripts/changed_scope_coverage.py::_parse_changed_lines()`. It keeps the
+byte-oriented parser and changed-line semantics unchanged while using
+`bytes.splitlines()` for the encoded diff line iteration instead of splitting on
+an explicit newline byte separator.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Implementation plan
+
+1. Start from a clean worktree synced to `origin/main`.
+2. Confirm the registered probe covers the changed parser path.
+3. Replace the parser's encoded diff iteration with `splitlines()` while
+   preserving the existing empty-line handling branch for blank context lines.
+4. Run focused tests and changed-scope coverage locally on Linux.
+5. Run the registered probe locally against an `origin/main` baseline worktree
+   and this branch.
+6. Use GitHub Actions PR-scoped performance as the merge gate before squash
+   merging.
+
+## Verification boundary
+
+This slice is Python-only and locally verifiable on Linux. No Swift runtime
+behavior is changed.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -92,7 +92,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     parse_hunk_new_start_from_digit = _parse_hunk_new_start_from_digit_bytes
     add_changed_line = None
     new_line: int | None = None
-    for line in diff_text.encode().split(b"\n"):
+    for line in diff_text.encode().splitlines():
         if not line:
             if add_changed_line is not None and new_line is not None:
                 new_line += 1


### PR DESCRIPTION
## Summary
- Use `bytes.splitlines()` for changed-scope diff parser line iteration while preserving blank-line handling.
- Document the focused Python performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-29-changed-scope-parse-splitlines.md`
- Registered probe: `changed-scope-coverage-diff-parser`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-diff-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-changed-scope-parse-splitlines-20260629 --head-repo "$PWD" --output /tmp/changed_scope_parse_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 45 passed.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local registered probe (`changed-scope-coverage-diff-parser`): base `elapsed_ms_mean=3.1690857528398433`, head `elapsed_ms_mean=3.1311806669691578`, delta `-0.03790508587068553 ms`, speedup `1.012105684692853x`.
- Probe invariants: `changed_line_count=7680`, `file_count=240`, `line_count=16080` for both base and head.

## Known Gaps
- Python-only slice verified locally on Linux. No Swift runtime behavior changed.
- GitHub Actions PR-scoped performance remains the required merge gate for the registered probe report.

## Evidence Checklist
- [x] Worktree started from `origin/main`.
- [x] Registered PR-scoped probe covers the touched path and includes focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% for the touched scope.
- [x] Registered probe ran locally with an improvement on the measured metric.
- [ ] GitHub Actions PR-scoped performance completed successfully.
