### PR TITLE
perf: avoid symlink stats in dataset preview scan

### DIFF
--- a/docs/plans/2026-06-29-dataset-preview-no-symlink-stat.md
+++ b/docs/plans/2026-06-29-dataset-preview-no-symlink-stat.md
@@ -1,0 +1,51 @@
+# Dataset preview no-symlink stat slice
+
+## Scope
+
+This Python-only performance slice is limited to the dataset registry preview
+file scanner in `worker.dataset_registry.catalog`. The scanner is used by
+`read_hf_dataset_snapshot_rows(..., limit=...)` when no explicit split is
+requested.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-registry-preview-limit-short-circuit` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_preview_limit_probe.py`
+
+## Optimization hypothesis
+
+The preview scanner only needs real directories and real supported dataset
+files. Directory symlinks can trigger extra metadata work and recursive scans
+outside the dataset snapshot. This slice changes the preview-only scan helpers
+to call `DirEntry.is_dir(follow_symlinks=False)` and
+`DirEntry.is_file(follow_symlinks=False)`.
+
+Expected impact:
+
+- Avoid symlink target stat/follow work while scanning preview candidates.
+- Keep the sorted depth-first preview semantics for regular directories and
+  files.
+- Make directory symlink handling explicit and bounded for preview scans.
+
+## Verification plan
+
+1. Add regression coverage proving preview scans do not follow directory
+   symlinks.
+2. Run the registered focused test command locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe locally before and after the change and compare
+   `elapsed_ms_mean`, `multi_limit_elapsed_ms_mean`, and peak memory metrics.
+5. Use GitHub Actions PR-scoped performance as the merge gate before merging.
+
+## Validation boundary
+
+This is a Python/Linux-verifiable slice. No Swift runtime behavior is changed.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -532,10 +532,12 @@ def test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names(
             self._file_error = file_error
             self.is_file_calls = 0
 
-        def is_dir(self) -> bool:
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            assert follow_symlinks is False
             return self._is_dir
 
-        def is_file(self) -> bool:
+        def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            assert follow_symlinks is False
             self.is_file_calls += 1
             if self._file_error:
                 raise OSError("stat failed")
@@ -1076,10 +1078,12 @@ def test_dataset_catalog_first_preview_file_preserves_sorted_depth_first_edges(
         name = "broken.jsonl"
         path = str(data_dir / "broken.jsonl")
 
-        def is_dir(self) -> bool:
+        def is_dir(self, *, follow_symlinks: bool = True) -> bool:
+            assert follow_symlinks is False
             raise OSError("broken entry")
 
-        def is_file(self) -> bool:
+        def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            assert follow_symlinks is False
             return True
 
     class FakeScandir:
@@ -1091,6 +1095,18 @@ def test_dataset_catalog_first_preview_file_preserves_sorted_depth_first_edges(
 
     monkeypatch.setattr(catalog.os, "scandir", lambda _path: FakeScandir())
     assert catalog._next_supported_scan_entry(snapshot_dir, after="") is None
+
+
+def test_dataset_catalog_preview_scan_does_not_follow_directory_symlinks(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    target_dir = tmp_path / "target"
+    snapshot_dir.mkdir()
+    target_dir.mkdir()
+    (target_dir / "part-00000.jsonl").write_text('{"prompt":"target"}\n', encoding="utf-8")
+    link_dir = snapshot_dir / "linked-data"
+    link_dir.symlink_to(target_dir, target_is_directory=True)
+
+    assert catalog._first_supported_dataset_file(snapshot_dir) is None
 
 
 def test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split(

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -543,7 +543,7 @@ def _supported_scan_entry_records(
         if name <= after:
             continue
         try:
-            is_dir = entry.is_dir()
+            is_dir = entry.is_dir(follow_symlinks=False)
             if is_dir:
                 yield name, entry.path, True, False
                 continue
@@ -552,7 +552,7 @@ def _supported_scan_entry_records(
         if name in _README_NAMES or not _is_supported_dataset_file_name(name):
             continue
         try:
-            is_file = entry.is_file()
+            is_file = entry.is_file(follow_symlinks=False)
         except OSError:
             continue
         if is_file:
@@ -588,7 +588,7 @@ def _next_supported_scan_entry(directory: Path, *, after: str) -> tuple[str, Pat
                 if name <= after or (best_name and name >= best_name):
                     continue
                 try:
-                    is_dir = entry.is_dir()
+                    is_dir = entry.is_dir(follow_symlinks=False)
                 except OSError:
                     continue
                 if is_dir:
@@ -597,7 +597,7 @@ def _next_supported_scan_entry(directory: Path, *, after: str) -> tuple[str, Pat
                     continue
                 else:
                     try:
-                        is_file = entry.is_file()
+                        is_file = entry.is_file(follow_symlinks=False)
                     except OSError:
                         continue
                     if not is_file:


### PR DESCRIPTION
## Summary
- Update dataset preview scan helpers to use `DirEntry.is_dir/is_file(follow_symlinks=False)` so limit-based preview discovery does not stat/follow directory symlinks.
- Add regression coverage for explicit directory-symlink skip behavior.
- Document the slice plan and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-06-29-dataset-preview-no-symlink-stat.md`
- Registered probe: `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_first_preview_file_preserves_sorted_depth_first_edges services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_preview_scan_does_not_follow_directory_symlinks services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_preview_scan_streams_multiple_files_without_sorted_walk services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_avoids_full_supported_file_iterator`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered `dataset-registry-preview-limit-short-circuit` focused tests plus the new symlink regression)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py` (after change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 4 passed.
- Registered focused tests: 29 passed.
- Changed-scope coverage: `TOTAL 21 1 95%`; changed production lines in `catalog.py` were 100% covered.
- Baseline probe before change: `elapsed_ms_mean=99.466085`, `multi_limit_elapsed_ms_mean=144.391688`, `peak_bytes_mean=14740.714`, `multi_limit_peak_bytes_mean=20678.143`.
- Probe after change: `elapsed_ms_mean=97.053642`, `multi_limit_elapsed_ms_mean=141.950231`, `peak_bytes_mean=14749.143`, `multi_limit_peak_bytes_mean=20707.714`.
- Local delta: `elapsed_ms_mean` improved by 2.412443 ms (~2.43%); `multi_limit_elapsed_ms_mean` improved by 2.441457 ms (~1.69%). Peak bytes were essentially flat/slightly higher within noise.
- CI PR-scoped performance is required as the registered probe merge gate.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed.
- CI must confirm the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Registered PR-scoped performance probe covers the changed path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with an improvement in elapsed metrics.
- [ ] GitHub Actions PR-scoped performance completed successfully.
