### PR TITLE
perf: skip lowercase fallback for dataset suffixes

### DIFF
--- a/docs/plans/2026-06-29-dataset-suffix-lower-skip.md
+++ b/docs/plans/2026-06-29-dataset-suffix-lower-skip.md
@@ -1,0 +1,19 @@
+# Dataset suffix lowercase skip performance slice
+
+## Context
+
+Dataset preview scans skip large numbers of unsupported lowercase sidecar files before yielding supported dataset files. The registered `dataset-registry-preview-limit-short-circuit` PR-scoped probe covers this path through `services/mlx-worker-python/worker/dataset_registry/catalog.py`, focused dataset-registry tests, changed-scope coverage, and the preview/limit probe commands.
+
+## Slice
+
+Avoid calling `str.lower()` for already-lowercase unsupported suffixes in dataset-file suffix classifiers. Supported lowercase suffixes still resolve through the exact dictionary lookup, mixed/uppercase supported suffixes still use the existing lowercase fallback, and unsupported lowercase sidecar files now return immediately.
+
+## Verification
+
+- Focused tests: dataset-registry preview-limit registered `test_command`.
+- Changed-scope coverage: dataset-registry preview-limit registered `coverage_command`.
+- Performance: dataset-registry preview-limit registered `probe_command`, plus local before/after sidecar-heavy samples on Linux.
+
+## Scope Boundary
+
+This is a Python-only Linux-verifiable slice. It does not change dataset traversal order, row parsing behavior, or Swift runtime behavior.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -51,7 +51,11 @@ def _is_supported_dataset_file_name(name: str) -> bool:
     if dot_index <= 0 or dot_index == len(name) - 1:
         return False
     suffix = name[dot_index:]
-    return suffix in _SUPPORTED_DATASET_SUFFIXES or suffix.lower() in _SUPPORTED_DATASET_SUFFIXES
+    if suffix in _SUPPORTED_DATASET_SUFFIXES:
+        return True
+    if suffix.islower():
+        return False
+    return suffix.lower() in _SUPPORTED_DATASET_SUFFIXES
 
 
 @dataclass(frozen=True, slots=True)
@@ -1032,6 +1036,8 @@ def _dataset_file_format_name(name: str) -> str:
     file_format = _SUPPORTED_DATASET_SUFFIXES.get(suffix)
     if file_format is not None:
         return file_format
+    if suffix.islower():
+        return ""
     return _SUPPORTED_DATASET_SUFFIXES.get(suffix.lower(), "")
 
 


### PR DESCRIPTION
## Summary
- Skip the lowercase fallback lookup for already-lowercase unsupported dataset suffixes.
- Preserve exact lowercase supported suffix handling and mixed/uppercase supported suffix fallback behavior.
- Add a focused plan for the dataset suffix classifier performance slice.

## Plan or Spec
- `docs/plans/2026-06-29-dataset-suffix-lower-skip.md`
- Registered PR-scoped probe: `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json` covers the changed `catalog.py` path with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline sidecar-heavy registered-probe variant before code change
MELIX_DATASET_PREVIEW_PROBE_SAMPLES=9 MELIX_DATASET_PREVIEW_PROBE_SIDECARS=5000 MELIX_DATASET_PREVIEW_PROBE_FILES=20000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
# exit 0; elapsed_ms_mean=54.679610; multi_limit_elapsed_ms_mean=73.250972

MELIX_DATASET_LIMIT_PROBE_SAMPLES=9 MELIX_DATASET_LIMIT_PROBE_GROUPS=300 MELIX_DATASET_LIMIT_PROBE_FILES_PER_GROUP=8 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_limit_probe.py
# exit 0; elapsed_ms_mean=1.324563895145224

# Focused post-change smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_file_format_uses_supported_suffixes services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_limit_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
# exit 0; 6 passed

# Focused post-change changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_file_format_uses_supported_suffixes services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_limit_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py
# exit 0; TOTAL 7 0 100%

# Post-change registered dataset preview command set from infra/perf/pr_scoped_probes.json
bash .runtime/run_registered_dataset_preview.sh
# exit 0; 28 passed, TOTAL 7 0 100%, probe elapsed_ms_mean=96.929219, multi_limit_elapsed_ms_mean=143.156923

# Post-change sidecar-heavy registered-probe variant
MELIX_DATASET_PREVIEW_PROBE_SAMPLES=9 MELIX_DATASET_PREVIEW_PROBE_SIDECARS=5000 MELIX_DATASET_PREVIEW_PROBE_FILES=20000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
# exit 0; elapsed_ms_mean=54.332429; multi_limit_elapsed_ms_mean=72.688401

MELIX_DATASET_LIMIT_PROBE_SAMPLES=9 MELIX_DATASET_LIMIT_PROBE_GROUPS=300 MELIX_DATASET_LIMIT_PROBE_FILES_PER_GROUP=8 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_limit_probe.py
# exit 0; elapsed_ms_mean=1.3360341027792957

python3 .runtime/compare_suffix_probe.py
# exit 0; old_mean_ms=27.83171666993035; new_mean_ms=27.273608229330016; speedup_pct=2.0052965011796102

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `services/mlx-worker-python/worker/dataset_registry/catalog.py` and registered probe/test paths.
- Registered probe command (post-change default): `elapsed_ms_mean=96.929219`, `multi_limit_elapsed_ms_mean=143.156923`, `rows_returned=1.0`, `multi_limit_dataset_files_yielded_mean=5.0`.
- Sidecar-heavy before/after preview variant: `elapsed_ms_mean 54.679610 -> 54.332429` (`-0.347181 ms`, about `0.64%` faster); `multi_limit_elapsed_ms_mean 73.250972 -> 72.688401` (`-0.562571 ms`, about `0.77%` faster).
- Focused suffix classifier micro-probe: `old_mean_ms=27.83171666993035`, `new_mean_ms=27.273608229330016`, `delta_ms=-0.5581084406003356`, `speedup_pct=2.0052965011796102` over 100,000 candidate names.
- Secondary limit probe was effectively neutral/noisy: `1.324563895145224 -> 1.3360341027792957` ms.

## Known Gaps
- Full repository gates (`make py-test`, `make integration-test`, `make swift-test`) were not run locally for this small Python-only slice.
- CI is required for the authoritative registered PR-scoped performance workflow report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe only; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
