### PR TITLE
perf(code-eval): branch on active nonblank lines

### DIFF
--- a/docs/plans/2026-06-29-code-eval-nonblank-counter-streaming.md
+++ b/docs/plans/2026-06-29-code-eval-nonblank-counter-streaming.md
@@ -43,3 +43,13 @@ Actions PR-scoped performance remains the merge gate.
 - Changed-scope coverage for touched files remains at least 95%.
 - Registered probe shows reduced allocation pressure without a blocking elapsed
   regression.
+
+## 2026-06-29 follow-up slice: ASCII active-line branch order
+
+This follow-up keeps the same registered probe,
+`code-eval-test-count-nonblank-streaming`, and stays limited to
+`_count_nonblank_test_lines()`. The ASCII scanner now checks the active-line
+state before whitespace membership so characters after the first nonblank byte on
+common content lines skip the non-line-whitespace lookup. This is intended to
+reduce per-character dispatch cost while preserving the existing no-allocation
+streaming behavior and splitline-compatible boundary semantics.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -326,11 +326,14 @@ def _count_nonblank_test_lines(test_code: str) -> int:
         splitline_boundaries = _ASCII_SPLITLINE_BOUNDARIES
         non_line_whitespace = _ASCII_NON_LINE_WHITESPACE
         for character in test_code:
-            if character in splitline_boundaries:
+            if not line_has_content:
+                if character in splitline_boundaries:
+                    continue
+                if character not in non_line_whitespace:
+                    count += 1
+                    line_has_content = True
+            elif character in splitline_boundaries:
                 line_has_content = False
-            elif not line_has_content and character not in non_line_whitespace:
-                count += 1
-                line_has_content = True
         return count
     splitline_boundaries = _PYTHON_SPLITLINE_BOUNDARIES
     for character in test_code:


### PR DESCRIPTION
## Summary
- Reorders the ASCII fallback scanner in `worker.engine.code_eval_runner._count_nonblank_test_lines()` to branch on active-line state first.
- Preserves the existing streaming/no-splitlines behavior and splitline-compatible ASCII/Unicode fallback semantics.
- Updates the governing code-eval performance plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-29-code-eval-nonblank-counter-streaming.md`
- Registered PR-scoped probe: `code-eval-test-count-nonblank-streaming`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_syntax_error_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_short_inputs_without_splitlines services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-test-count-nonblank-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/melix_code_eval_nonblank_after_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `10 passed in 0.60s`
- Changed-scope coverage: `TOTAL 7 0 100%`
- Local registered probe (`code-eval-test-count-nonblank-streaming`, Linux):
  - base `elapsed_ms_mean=56.48638429452798`, `peak_bytes_mean=112.0`, `nonblank_line_count_mean=48000.0`
  - head `elapsed_ms_mean=50.037510144258185`, `peak_bytes_mean=112.0`, `nonblank_line_count_mean=48000.0`
  - delta `-6.448874150269795 ms`, speedup `1.1288807962601992x`
- GitHub Actions PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime validation is involved.
- The probe's memory metric is unchanged because the previous implementation already avoided line-list allocation.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe run locally with before/after metrics.
- [ ] GitHub Actions checks completed successfully.
- [ ] PR-scoped performance report completed successfully.
