### PR TITLE
perf: cache always-only tool registry selection

### DIFF
--- a/docs/plans/2026-06-29-tool-registry-always-only-registry-cache.md
+++ b/docs/plans/2026-06-29-tool-registry-always-only-registry-cache.md
@@ -1,0 +1,32 @@
+# Tool Registry Always-only Selection Registry Cache
+
+## Slice
+
+Cache the singleton always-only (`local_compute`) tool registry used by the
+agentic tool selector's fallback/`max_selected_tools=1` path.
+
+## Registered Probe
+
+The changed path is already covered by the PR-scoped `tool-registry-select-name-index-cache`
+probe in `infra/perf/pr_scoped_probes.json`:
+
+- `test_command`: focused `test_tool_registry.py` and `test_pr_scoped_performance.py` coverage for tool selection behavior and probe selection.
+- `coverage_command`: focused coverage over `worker.runtime.tool_registry` plus changed-scope coverage.
+- `probe_command`: `scripts/tool_registry_select_probe.py`, which reports always-only, whitespace-turn, selector-planning, and selection-cache timing metrics.
+
+No probe registry change is required for this slice.
+
+## Behavior
+
+No externally visible behavior changes. The fallback selection receipt remains
+unchanged, but the singleton catalog path now reuses a cached selected registry
+and metrics object instead of calling `ToolRegistry.select(("local_compute",))`
+for every always-only selection.
+
+## Validation Plan
+
+1. Run focused behavior/probe-selection tests.
+2. Run changed-scope coverage for `worker.runtime.tool_registry`.
+3. Run the registered `tool_registry_select_probe.py` locally on Linux and compare
+   with the baseline probe output captured before the change.
+4. Use GitHub Actions PR-scoped performance as the merge gate.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -731,6 +731,41 @@ def test_agentic_tool_selection_compiles_keyword_hint_rules_once_per_hint() -> N
     )
 
 
+def test_agentic_tool_selection_always_only_reuses_cached_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_select(self: ToolRegistry, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        raise AssertionError(  # pragma: no cover
+            f"always-only selection should reuse cached registry for {names!r}"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "select", fail_select)
+
+    result = select_agentic_tools_for_turn(ToolSelectionInput(max_selected_tools=1))
+
+    assert result.registry is tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selected_schema_bytes"] == (
+        tool_registry_module._ALWAYS_ONLY_TOOL_METRICS.schema_bytes
+    )
+
+
+def test_agentic_tool_selection_always_only_supports_custom_registry() -> None:
+    registry = ToolRegistry(tool_registry_module.agentic_tool_catalog_registry().tools)
+
+    result = tool_registry_module._build_always_only_tool_selection_result(
+        registry,
+        ToolSelectionInput(vector_available=True),
+    )
+
+    assert result.registry is registry.select(("local_compute",))
+    assert result.registry is not tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"}
+    ]
+
+
 def test_agentic_tool_selection_max_always_only_skips_optional_routing_scans(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -583,9 +583,13 @@ def _build_always_only_tool_selection_result(
     selection_input: ToolSelectionInput,
 ) -> ToolSelectionResult:
     selected_name = "local_compute"
-    selected_registry = registry.select((selected_name,))
+    if registry is _AGENTIC_TOOL_CATALOG_REGISTRY:
+        selected_registry = _ALWAYS_ONLY_TOOL_REGISTRY
+        selected_metrics = _ALWAYS_ONLY_TOOL_METRICS
+    else:
+        selected_registry = registry.select((selected_name,))
+        selected_metrics = selected_registry.metrics()
     registry_metrics = registry.metrics()
-    selected_metrics = selected_registry.metrics()
     return ToolSelectionResult(
         registry=selected_registry,
         receipt={
@@ -899,6 +903,8 @@ _BUILTIN_AGENTIC_TOOLS = tuple(
     tool for tool in _AGENTIC_TOOL_CATALOG_TOOLS if tool.name in _BUILTIN_TOOL_NAME_SET
 )
 _AGENTIC_TOOL_CATALOG_REGISTRY = ToolRegistry(_AGENTIC_TOOL_CATALOG_TOOLS)
+_ALWAYS_ONLY_TOOL_REGISTRY = _AGENTIC_TOOL_CATALOG_REGISTRY.select(("local_compute",))
+_ALWAYS_ONLY_TOOL_METRICS = _ALWAYS_ONLY_TOOL_REGISTRY.metrics()
 _BUILTIN_TOOL_CONFIG_REGISTRY = ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
 _BUILTIN_TOOL_CONFIG_NAMES_LIST = list(BUILTIN_AGENTIC_TOOL_NAMES)
 _BUILTIN_TOOL_CONFIG_BYTES = (


### PR DESCRIPTION
## Summary
- Cache the singleton `local_compute` registry and metrics used by always-only tool selection.
- Preserve custom-registry behavior with a fallback `ToolRegistry.select(("local_compute",))` path.
- Add regression coverage for cached singleton reuse and custom-registry fallback.

## Plan or Spec
- `docs/plans/2026-06-29-tool-registry-always-only-registry-cache.md`
- Existing registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/tool_registry.py` with focused test, coverage, and `scripts/tool_registry_select_probe.py` commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_always_only_reuses_cached_registry services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_always_only_supports_custom_registry services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_max_always_only_skips_optional_routing_scans services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_whitespace_turn_skips_keyword_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`

## Coverage and Metrics
- Focused tests: 6 passed.
- Registered coverage replay: 92 passed.
- Changed-scope coverage: `TOTAL 21 0 100%`.
- Local Linux probe baseline -> candidate:
  - `always_only_planning_elapsed_ms_mean`: 22.811251 -> 21.038936 ms (delta -1.772315 ms, 1.0842x, 7.77% faster)
  - `whitespace_turn_planning_elapsed_ms_mean`: 22.701601 -> 20.672257 ms (delta -2.029344 ms, 1.0982x, 8.94% faster)
  - `elapsed_ms_mean`: 21.256674 -> 21.152090 ms (delta -0.104584 ms, 1.0049x, 0.49% faster)

## Known Gaps
- Linux local validation covers the Python worker path only.
- The PR-scoped performance workflow is the merge gate for the registered probe report on GitHub Actions.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branch creation.
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally on Linux with improvement on the targeted always-only/whitespace path.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
