### PR TITLE
perf: fast-path ascii tool keyword matching

### DIFF
--- a/docs/plans/2026-06-30-tool-registry-ascii-keyword-lower.md
+++ b/docs/plans/2026-06-30-tool-registry-ascii-keyword-lower.md
@@ -1,0 +1,46 @@
+# Tool registry keyword lower fast path
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/runtime/tool_registry.py`, specifically
+`_keyword_tool_matches(...)` in agentic tool selection.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+## Implementation plan
+
+The built-in keyword hints matched by `_keyword_tool_matches(...)` are ASCII
+strings. The registered select probe repeatedly routes common English user turns
+through this matcher, so full Unicode `str.casefold()` is unnecessary on this
+hot path. The slice uses `str.lower()` for normalization; this preserves matching
+for the ASCII hint set, including when surrounding user text contains non-ASCII
+characters.
+
+A focused regression test keeps mixed non-ASCII input covered so ASCII hints
+continue to match inside Unicode text.
+
+## Verification plan
+
+1. Run the registered focused test command for
+   `tool-registry-select-name-index-cache` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and verify
+   touched Python scope remains at least 95% covered.
+3. Run the registered probe locally through `scripts/pr_scoped_performance_run.py`
+   against `origin/main` and this branch.
+4. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Boundary
+
+This is a Python worker slice and is fully locally verifiable on Linux. No Swift
+runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -1082,6 +1082,13 @@ def test_agentic_tool_selection_keyword_matches_reuse_bounded_cache() -> None:
     assert second_info.hits == first_info.hits + 1
 
 
+def test_agentic_tool_selection_keyword_matches_preserve_non_ascii_ascii_hint() -> None:
+    matcher = tool_registry_module._keyword_tool_matches
+    matcher.cache_clear()
+
+    assert matcher("Please SEARCH café evidence.") == ("text_search",)
+
+
 def test_agentic_tool_selection_keyword_rule_compiler_filters_empty_hints() -> None:
     rules = tool_registry_module._compile_keyword_hint_rules(
         {

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -655,7 +655,7 @@ def _keyword_tool_matches(text: str) -> tuple[str, ...]:
         return ()
     if text.isspace():
         return ()
-    normalized_text = text.casefold()
+    normalized_text = text.lower()
     boundary_text = ""
     matches: list[str] = []
     append_match = matches.append


### PR DESCRIPTION
## Summary
- Replaced `_keyword_tool_matches(...)` normalization from `casefold()` to `lower()` because the built-in keyword hints are ASCII.
- Added a focused mixed non-ASCII regression test to confirm ASCII hints still match inside Unicode user text.
- Documented the slice and registered-probe boundary in `docs/plans/2026-06-30-tool-registry-ascii-keyword-lower.md`.

## Plan or Spec
- `docs/plans/2026-06-30-tool-registry-ascii-keyword-lower.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs` → 93 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py` → 93 passed, changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/tool-registry-select-probe.json` → passed
- `git diff --check` → passed

## Coverage and Metrics
- Changed-scope coverage: 100% (2/2 measurable changed lines covered).
- Local registered probe `tool-registry-select-name-index-cache`:
  - `elapsed_ms_mean`: base 21.973950 ms → head 21.554910 ms (delta -0.419040 ms, -1.91%).
  - `selector_planning_elapsed_ms_mean`: base 35.321542 ms → head 34.050227 ms (delta -1.271315 ms, -3.60%).
  - `current_capacity_planning_elapsed_ms_mean`: base 34.125319 ms → head 33.173212 ms (delta -0.952107 ms, -2.79%).
  - `always_only_planning_elapsed_ms_mean`: base 22.202366 ms → head 20.677492 ms (delta -1.524873 ms, -6.87%).
  - `whitespace_turn_planning_elapsed_ms_mean`: base 22.013118 ms → head 20.790404 ms (delta -1.222714 ms, -5.55%).

## Known Gaps
- Linux local validation covers the Python worker slice only. No Swift runtime effect is claimed.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux and showed improvement on the targeted metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
