### PR TITLE
perf: skip local job non-json entry stats

### DIFF
--- a/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
+++ b/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
@@ -17,6 +17,10 @@ The affected path is covered by the registered PR-scoped performance probe `loca
 3. Run the registered `local-job-followup-scan-scandir` probe locally on Linux against `origin/main` and this branch.
 4. Use the PR-scoped performance workflow as the merge gate.
 
+## 2026-06-30 follow-up: suffix check before file stat
+
+This Python-only follow-up keeps the same registered `local-job-followup-scan-scandir` probe and narrows the top-level scandir filter. `scan_followup_candidates(...)` now rejects non-`.json` directory entries before calling `DirEntry.is_file(follow_symlinks=False)`, and uses direct suffix slicing rather than `str.endswith(...)` on the hot path. JSON-named directories still receive the no-follow file check and are skipped; non-record files such as `*.json.tmp` and `*.txt` avoid an unnecessary metadata query.
+
 ## Linux validation boundary
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime behavior changes are included.

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -1286,6 +1286,54 @@ def test_store_scan_followup_candidates_uses_single_scandir_without_path_glob(
     assert scandir_calls == [os.fspath(tmp_path)]
 
 
+def test_store_scan_followup_candidates_filters_suffix_before_file_stat(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = LocalJobContinuationStore(tmp_path)
+    store.save_record(
+        _record(
+            job_id="ready",
+            status="completed",
+            exit_status=0,
+            artifact_paths=("/workspace/out/ready.json",),
+        )
+    )
+
+    class FakeEntry:
+        def __init__(self, name: str, *, is_file: bool, fail_if_stat: bool = False) -> None:
+            self.name = name
+            self._is_file = is_file
+            self.fail_if_stat = fail_if_stat
+            self.stat_calls = 0
+
+        def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            assert follow_symlinks is False
+            self.stat_calls += 1
+            if self.fail_if_stat:
+                raise AssertionError(f"non-record entry should not be statted: {self.name}")
+            return self._is_file
+
+    non_json_entry = FakeEntry("ignored.json.tmp", is_file=True, fail_if_stat=True)
+    text_entry = FakeEntry("notes.txt", is_file=True, fail_if_stat=True)
+    ready_entry = FakeEntry("ready.json", is_file=True)
+    directory_entry = FakeEntry("nested.json", is_file=False)
+
+    monkeypatch.setattr(
+        local_job_continuation_module.os,
+        "scandir",
+        lambda path: iter((non_json_entry, text_entry, ready_entry, directory_entry)),
+    )
+
+    scan = store.scan_followup_candidates()
+
+    assert [candidate.record.job_id for candidate in scan.candidates] == ["ready"]
+    assert non_json_entry.stat_calls == 0
+    assert text_entry.stat_calls == 0
+    assert ready_entry.stat_calls == 1
+    assert directory_entry.stat_calls == 1
+
+
 def test_store_scan_followup_candidates_does_not_follow_record_symlinks(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -367,7 +367,9 @@ class LocalJobContinuationStore:
             record_job_ids_append = record_job_ids.append
             for entry in os.scandir(root_fspath):
                 name = entry.name
-                if name.endswith(".json") and entry.is_file(follow_symlinks=False):
+                if name[-5:] != ".json":
+                    continue
+                if entry.is_file(follow_symlinks=False):
                     # The scan has already filtered this to a .json file name.
                     # Slice directly rather than calling Path.stem or a helper for
                     # every record in large follow-up stores.


### PR DESCRIPTION
## Summary
- Optimizes `LocalJobContinuationStore.scan_followup_candidates(...)` so non-`.json` directory entries are rejected before `DirEntry.is_file(follow_symlinks=False)` metadata checks.
- Adds a regression test proving non-record entries do not take the file-stat path.
- Updates the local-job follow-up scan plan with this 2026-06-30 slice.

## Plan or Spec
- `docs/plans/2026-06-15-local-job-followup-loop-bindings.md`
- Registered PR-scoped probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_reads_json_bytes services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_uses_direct_binary_open services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_avoids_path_join_wrapper services/mlx-worker-python/tests/test_local_job_continuation.py::test_load_record_tolerates_record_deleted_between_path_resolution_and_read services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_filters_suffix_before_file_stat services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 15 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.local_job_continuation -m pytest -q ...focused local-job tests... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py` → 12 passed, changed-line coverage 100.00%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` (3 baseline samples on `origin/main`, 3 branch samples after change)
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/local_job_continuation.py` measurable changed lines `[370, 371, 372]`, covered `[370, 371, 372]`, 100.00%.
- Local Linux probe samples (`elapsed_ms_mean`, lower is better):
  - `origin/main`: 17.594718, 18.998352, 21.602499 ms; mean 19.398523 ms
  - branch: 18.511450, 20.379682, 18.130067 ms; mean 19.007066 ms
  - delta: -0.391457 ms; speedup 1.0206x (~2.02% faster)
- Shape invariants stayed constant: `candidate_count_mean=500`, `receipt_count_mean=500`, `scandir_calls_mean=1`, `path_glob_calls_mean=0`, `path_exists_calls_mean=0`.
- GitHub Actions PR-scoped performance is the final registered probe validation and merge gate.

## Known Gaps
- This is a Python-only slice validated locally on Linux. No Swift runtime effect is claimed.
- The local timing delta is modest and should be treated as directional until the registered CI probe completes.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed.
- [ ] PR checks green before merge.
