### PR TITLE
perf: hoist runtime export manifest enum gates

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -224,7 +224,10 @@ already read for protobuf JSON parsing instead of issuing a second filesystem
 stat call on every validation. Its metrics pass should accumulate generated,
 required, and evidence byte totals while iterating each manifest file section
 once instead of materializing a combined file-row tuple solely to count evidence
-bytes.
+bytes. Repeated validation policy gates should also reuse module-level enum
+membership constants for derived-model activation modes, runtime-binary-required
+target types, load-check-required target types, and the GGUF runtime-unavailable
+waiver instead of constructing short-lived sets on every manifest validation.
 
 ### Export Plan Receipt
 

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -30,6 +30,28 @@ _TARGET_NAME_BY_TYPE = {
     value: export_target_manifest_pb2.ExportTargetType.Name(value)
     for value in _TARGET_RUNTIME_BY_TYPE
 }
+_DERIVED_MODEL_ACTIVATION_MODES = frozenset(
+    {
+        export_target_manifest_pb2.EXPORT_ACTIVATION_MODE_FUSED_DERIVED_MODEL,
+        export_target_manifest_pb2.EXPORT_ACTIVATION_MODE_ADAPTER_BACKED_RUNTIME,
+    }
+)
+_RUNTIME_BINARY_REQUIRED_TARGET_TYPES = frozenset(
+    {
+        export_target_manifest_pb2.EXPORT_TARGET_TYPE_OLLAMA,
+        export_target_manifest_pb2.EXPORT_TARGET_TYPE_MLX_RUNTIME,
+    }
+)
+_LOAD_CHECK_REQUIRED_TARGET_TYPES = frozenset(
+    {
+        export_target_manifest_pb2.EXPORT_TARGET_TYPE_MELIX_MANAGED,
+        export_target_manifest_pb2.EXPORT_TARGET_TYPE_OLLAMA,
+        export_target_manifest_pb2.EXPORT_TARGET_TYPE_MLX_RUNTIME,
+    }
+)
+_RUNTIME_NOT_INSTALLED_WAIVER = (
+    export_target_manifest_pb2.EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED
+)
 
 
 @overload
@@ -141,11 +163,7 @@ def _validate_manifest(manifest: export_target_manifest_pb2.ExportTargetManifest
     )
     if (
         not manifest.source_derived_model_manifest_path
-        and manifest.activation_mode
-        in {
-            export_target_manifest_pb2.EXPORT_ACTIVATION_MODE_FUSED_DERIVED_MODEL,
-            export_target_manifest_pb2.EXPORT_ACTIVATION_MODE_ADAPTER_BACKED_RUNTIME,
-        }
+        and manifest.activation_mode in _DERIVED_MODEL_ACTIVATION_MODES
     ):
         errors.append(
             "source_derived_model_manifest_path is required for derived model activation modes"
@@ -239,10 +257,10 @@ def _validate_runtime_requirements(
         errors.append("runtime_requirements.runtime_name is required")
     elif runtime.runtime_name != manifest.target_runtime:
         errors.append("runtime_requirements.runtime_name must match target_runtime")
-    if manifest.target_type in {
-        export_target_manifest_pb2.EXPORT_TARGET_TYPE_OLLAMA,
-        export_target_manifest_pb2.EXPORT_TARGET_TYPE_MLX_RUNTIME,
-    } and not runtime.runtime_binary_required:
+    if (
+        manifest.target_type in _RUNTIME_BINARY_REQUIRED_TARGET_TYPES
+        and not runtime.runtime_binary_required
+    ):
         errors.append("runtime_requirements.runtime_binary_required is required for this target type")
     if runtime.runtime_binary_required and not runtime.runtime_binary_name:
         errors.append("runtime_requirements.runtime_binary_name is required when runtime_binary_required is true")
@@ -261,18 +279,13 @@ def _validate_verification_policy(
         errors.append("verification_policy.policy_id is required")
     if not policy.metadata_check_required:
         errors.append("verification_policy.metadata_check_required must be true")
-    if manifest.target_type in {
-        export_target_manifest_pb2.EXPORT_TARGET_TYPE_MELIX_MANAGED,
-        export_target_manifest_pb2.EXPORT_TARGET_TYPE_OLLAMA,
-        export_target_manifest_pb2.EXPORT_TARGET_TYPE_MLX_RUNTIME,
-    } and not policy.load_check_required:
+    if (
+        manifest.target_type in _LOAD_CHECK_REQUIRED_TARGET_TYPES
+        and not policy.load_check_required
+    ):
         errors.append("verification_policy.load_check_required must be true for this target type")
     if manifest.target_type == export_target_manifest_pb2.EXPORT_TARGET_TYPE_GGUF:
-        allowed = set(policy.allowed_waiver_reasons)
-        if (
-            export_target_manifest_pb2.EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED
-            not in allowed
-        ):
+        if _RUNTIME_NOT_INSTALLED_WAIVER not in policy.allowed_waiver_reasons:
             errors.append("gguf verification_policy must allow runtime_not_installed waivers")
     if status.state == export_target_manifest_pb2.EXPORT_VERIFICATION_STATE_UNSPECIFIED:
         errors.append("verification_status.state must be specified")


### PR DESCRIPTION
## Summary
- Hoist repeated runtime export manifest enum membership gates into module-level constants.
- Avoid per-validation construction of short-lived activation/load-check/runtime-binary sets and GGUF waiver sets in the manifest validator hot path.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 45 passed in 0.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
# 45 passed in 0.68s; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_manifest_validation_probe.py
# {"elapsed_ms_mean": 2101.2249127961695, "fixture_count": 4.0, "iteration_count": 250.0, "manifest_byte_size": 21400.0, "peak_bytes_mean": 39352.8, "sample_count": 5.0, "schema_error_count": 0.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `export_target_manifest.py` plus registered probe/test files.
- Registered local probe: `runtime-export-manifest-validation` via `scripts/runtime_export_manifest_validation_probe.py`.
- Repeated local probe comparison with `MELIX_RUNTIME_EXPORT_MANIFEST_PROBE_ITERATIONS=150` and `MELIX_RUNTIME_EXPORT_MANIFEST_PROBE_SAMPLES=3`:
  - Baseline mean across 3 runs: `old_mean=1280.180096218828 ms`
  - Branch mean across 3 runs: `new_mean=1250.007673664691 ms`
  - Delta: `delta_ms=-30.17242255413703`, `speedup=1.024137789863065x` (~2.36% faster)
- Full registered branch probe sample: `elapsed_ms_mean=2101.2249127961695`, `peak_bytes_mean=39352.8`, `schema_error_count=0.0`.
- CI PR-scoped performance workflow is required for final registered probe validation before merge.

## Known Gaps
- Local evidence is Linux/Python-only; CI is the authoritative registered PR-scoped probe gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
