### PR TITLE
perf: scan dense changed coverage lines with set membership

### DIFF
--- a/docs/plans/2026-06-30-changed-scope-coverage-dense-set-membership.md
+++ b/docs/plans/2026-06-30-changed-scope-coverage-dense-set-membership.md
@@ -1,0 +1,37 @@
+# Changed-scope coverage dense membership slice
+
+## Scope
+
+This Python performance slice is limited to `scripts/changed_scope_coverage.py`, specifically `_measurable_changed_lines()` when a changed hunk touches a dense set of measured lines.
+
+## Registered probe
+
+The affected path is covered by the existing registered PR-scoped probe `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.
+
+That probe already has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_measured_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+This slice extends the existing measured probe with a dense changed-line scenario so the registered probe directly exercises the new branch.
+
+## Optimization hypothesis
+
+For sorted coverage line lists, `_measurable_changed_lines()` currently checks each changed line against executed and missing lists with repeated binary searches, then repeats membership checks while partitioning covered and missed lines. That is efficient for sparse changed sets, but dense changed sets can be faster by scanning the already-sorted executed and missing coverage lists once and using the changed-line set for direct membership.
+
+The slice keeps sparse behavior unchanged and adds a dense threshold branch only when enough changed lines are present to amortize scanning coverage lists.
+
+## Verification plan
+
+1. Add a regression test that forces dense changed-line handling without calling `_sorted_line_list_contains()` and verifies covered/missed parity.
+2. Extend `scripts/changed_scope_coverage_measured_probe.py` with dense changed-line timing.
+3. Run the registered focused tests and coverage command locally on Linux.
+4. Run the registered probe locally and compare dense metrics against `origin/main` with an equivalent dense scenario.
+
+## Expected metrics
+
+Primary metric: `dense_elapsed_ms_mean` from `scripts/changed_scope_coverage_measured_probe.py`.
+
+Expected result: lower dense elapsed time while preserving existing sparse metrics and no source read regression for no-overlap cases.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -27,6 +27,7 @@ _ASCII_MINUS = ord("-")
 _ASCII_AT = ord("@")
 _ASCII_LOWER_D = ord("d")
 _EMPTY_CHANGED_LINES: frozenset[int] = frozenset()
+_DENSE_CHANGED_LINE_SCAN_THRESHOLD = 32
 
 
 def _is_diff_file_marker(line: str) -> bool:
@@ -268,12 +269,22 @@ def _measurable_changed_lines(
         else:
             missing_lookup = missing_lines
         if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
-            measured_changed = [
-                line_no
-                for line_no in changed
-                if _sorted_line_list_contains(executed_lookup, line_no)
-                or _sorted_line_list_contains(missing_lookup, line_no)
-            ]
+            measured_line_count = len(executed_lookup) + len(missing_lookup)
+            if (
+                measured_line_count
+                and len(changed) >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
+                and len(changed) * 4 >= measured_line_count
+            ):
+                executed_lookup = {line_no for line_no in executed_lines if line_no in changed}
+                missing_lookup = {line_no for line_no in missing_lines if line_no in changed}
+                measured_changed = list(executed_lookup | missing_lookup)
+            else:
+                measured_changed = [
+                    line_no
+                    for line_no in changed
+                    if _sorted_line_list_contains(executed_lookup, line_no)
+                    or _sorted_line_list_contains(missing_lookup, line_no)
+                ]
         else:
             measured_changed = [
                 line_no

--- a/scripts/changed_scope_coverage_measured_probe.py
+++ b/scripts/changed_scope_coverage_measured_probe.py
@@ -29,8 +29,10 @@ def run_probe(
 ) -> dict[str, float]:
     module = _load_changed_scope_coverage(repo_root)
     elapsed_samples: list[float] = []
+    dense_elapsed_samples: list[float] = []
     allowlist_elapsed_samples: list[float] = []
     read_samples: list[float] = []
+    dense_read_samples: list[float] = []
     allowlist_value = json.dumps("pkg/module_0.py")
 
     with tempfile.TemporaryDirectory(prefix="melix-changed-scope-measured-probe-") as tmp:
@@ -39,7 +41,10 @@ def run_probe(
         for rel_path in rel_paths:
             source_path = root / rel_path
             source_path.parent.mkdir(parents=True, exist_ok=True)
-            source_path.write_text("covered = 1\nmissed = 2\n", encoding="utf-8")
+            source_path.write_text(
+                "\n".join(f"line_{line_no}" for line_no in range(1, measured_lines_per_path + 1)),
+                encoding="utf-8",
+            )
 
         coverage_payload = {
             "files": {
@@ -51,6 +56,7 @@ def run_probe(
             }
         }
         changed_lines = {measured_lines_per_path + 1, measured_lines_per_path + 2}
+        dense_changed_lines = set(range(1, measured_lines_per_path + 1))
 
         original_read_text = module.Path.read_text
         try:
@@ -76,6 +82,24 @@ def run_probe(
                 elapsed_samples.append((time.perf_counter() - start) * 1000.0)
                 read_samples.append(float(read_calls))
 
+                read_calls = 0
+                start = time.perf_counter()
+                for rel_path in rel_paths:
+                    measurable, covered, missed = module._measurable_changed_lines(
+                        root,
+                        coverage_payload,
+                        rel_path,
+                        dense_changed_lines,
+                    )
+                    if not (measurable or covered or missed):
+                        continue
+                    if len(measurable) != measured_lines_per_path:
+                        raise RuntimeError("dense changed set should measure all fixture lines")
+                    if len(covered) + len(missed) != measured_lines_per_path:
+                        raise RuntimeError("dense changed set should partition all fixture lines")
+                dense_elapsed_samples.append((time.perf_counter() - start) * 1000.0)
+                dense_read_samples.append(float(read_calls))
+
                 start = time.perf_counter()
                 for _ in range(allowlist_parse_count):
                     allowlist = module._coverage_path_allowlist(
@@ -89,9 +113,11 @@ def run_probe(
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "dense_elapsed_ms_mean": statistics.fmean(dense_elapsed_samples),
         "allowlist_parse_elapsed_ms_mean": statistics.fmean(allowlist_elapsed_samples),
         "allowlist_parse_count": float(allowlist_parse_count),
         "source_read_calls_mean": statistics.fmean(read_samples),
+        "dense_source_read_calls_mean": statistics.fmean(dense_read_samples),
         "path_count": float(path_count),
         "measured_lines_per_path": float(measured_lines_per_path),
         "sample_count": float(samples),

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -607,6 +607,38 @@ def test_measurable_changed_lines_handles_large_measured_sets_without_union(tmp_
     assert missed == [2]
 
 
+def test_measurable_changed_lines_uses_dense_membership_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 81)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 80, 2)),
+                "missing_lines": list(range(2, 81, 2)),
+            }
+        }
+    }
+
+    def fail_sorted_contains(*args: object, **kwargs: object) -> bool:  # pragma: no cover
+        raise AssertionError("dense changed sets should scan measured lists with set membership")
+
+    monkeypatch.setattr(changed_scope_coverage, "_sorted_line_list_contains", fail_sorted_contains)
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        set(range(1, 81)),
+    )
+
+    assert measurable == list(range(1, 81))
+    assert covered == list(range(1, 80, 2))
+    assert missed == list(range(2, 81, 2))
+
+
 def test_measurable_changed_lines_keeps_reversed_coverage_fallback(tmp_path: Path) -> None:
     source_path = tmp_path / "foo.py"
     source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 6)), encoding="utf-8")
@@ -650,9 +682,11 @@ def test_changed_scope_coverage_measured_probe_emits_large_measured_metrics() ->
     assert metrics["measured_lines_per_path"] == 10.0
     assert metrics["sample_count"] == 2.0
     assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["dense_elapsed_ms_mean"] > 0
     assert metrics["allowlist_parse_elapsed_ms_mean"] > 0
     assert metrics["allowlist_parse_count"] == 10000.0
     assert metrics["source_read_calls_mean"] == 0.0
+    assert metrics["dense_source_read_calls_mean"] == 5.0
 
 
 def test_changed_scope_coverage_singleton_probe_emits_range_metrics() -> None:
@@ -693,6 +727,82 @@ def test_changed_scope_coverage_measured_probe_rejects_unexpected_allowlist_pars
     )
 
     with pytest.raises(RuntimeError, match="single-string allowlist parse"):
+        changed_scope_coverage_measured_probe.run_probe(
+            tmp_path,
+            path_count=1,
+            measured_lines_per_path=2,
+            allowlist_parse_count=1,
+            samples=1,
+        )
+
+
+def test_changed_scope_coverage_measured_probe_rejects_incomplete_dense_measurement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class IncompleteDenseCoverageModule:
+        Path = Path
+
+        @staticmethod
+        def _measurable_changed_lines(
+            repo_root: Path,
+            coverage_payload: dict[str, object],
+            rel_path: str,
+            changed: set[int],
+        ) -> tuple[list[int], list[int], list[int]]:
+            if 1 in changed:
+                return [1], [1], []
+            return [], [], []
+
+        @staticmethod
+        def _coverage_path_allowlist(env: dict[str, str]) -> frozenset[str]:
+            return frozenset({"pkg/module_0.py"})
+
+    monkeypatch.setattr(
+        changed_scope_coverage_measured_probe,
+        "_load_changed_scope_coverage",
+        lambda repo_root: IncompleteDenseCoverageModule,
+    )
+
+    with pytest.raises(RuntimeError, match="dense changed set should measure all fixture lines"):
+        changed_scope_coverage_measured_probe.run_probe(
+            tmp_path,
+            path_count=1,
+            measured_lines_per_path=2,
+            allowlist_parse_count=1,
+            samples=1,
+        )
+
+
+def test_changed_scope_coverage_measured_probe_rejects_incomplete_dense_partition(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class IncompletePartitionCoverageModule:
+        Path = Path
+
+        @staticmethod
+        def _measurable_changed_lines(
+            repo_root: Path,
+            coverage_payload: dict[str, object],
+            rel_path: str,
+            changed: set[int],
+        ) -> tuple[list[int], list[int], list[int]]:
+            if 1 in changed:
+                return [1, 2], [1], []
+            return [], [], []
+
+        @staticmethod
+        def _coverage_path_allowlist(env: dict[str, str]) -> frozenset[str]:
+            return frozenset({"pkg/module_0.py"})
+
+    monkeypatch.setattr(
+        changed_scope_coverage_measured_probe,
+        "_load_changed_scope_coverage",
+        lambda repo_root: IncompletePartitionCoverageModule,
+    )
+
+    with pytest.raises(RuntimeError, match="dense changed set should partition all fixture lines"):
         changed_scope_coverage_measured_probe.run_probe(
             tmp_path,
             path_count=1,


### PR DESCRIPTION
## Summary
- Optimize `scripts/changed_scope_coverage.py` for dense changed-line sets by scanning measured coverage lists with set membership after a density threshold.
- Keep the existing sparse changed-line binary-search path unchanged.
- Extend the registered measured-set probe with dense timing/read metrics and regression coverage.

## Plan or Spec
- `docs/plans/2026-06-30-changed-scope-coverage-dense-set-membership.md`
- Registered PR-scoped probe: `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
python3 -c "import sys; print(sys.path[0:3])"
# exit 0

PYTHONPATH=. uv run pytest tests/test_changed_scope_coverage.py -q
# 45 passed, exit 0

PYTHONPATH=services/mlx-worker-python:. uv run pytest tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py -q
# 61 passed, exit 0

PYTHONPATH=. uv run coverage run --source=scripts.changed_scope_coverage,scripts.changed_scope_coverage_measured_probe -m pytest tests/test_changed_scope_coverage.py -q && uv run coverage json -o /tmp/changed_scope_coverage_dense_membership_coverage.json
# 45 passed, exit 0
# Coverage JSON written to /tmp/changed_scope_coverage_dense_membership_coverage.json

PYTHONPATH=. python3 scripts/changed_scope_coverage_measured_probe.py --path-count 2000 --measured-lines-per-path 120 --allowlist-parse-count 20000 --samples 5
# exit 0; dense_elapsed_ms_mean=110.737, elapsed_ms_mean=1.553

python3 - <<'PY'
# Compare current branch against origin/main using the extended dense probe scenario.
# exit 0
PY
# old dense_elapsed_ms_mean=269.331 ms; new dense_elapsed_ms_mean=111.233 ms
# delta=-158.098 ms; speedup=2.421x; improvement=58.70%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage artifact: `/tmp/changed_scope_coverage_dense_membership_coverage.json`
- Local probe comparison (Linux, 5 samples, 2,000 paths, 120 measured lines/path):
  - `origin/main` dense mean: `269.331 ms`
  - branch dense mean: `111.233 ms`
  - delta: `-158.098 ms`
  - speedup: `2.421x` (`58.70%` faster)
- Existing sparse/no-overlap metric stayed low: branch `elapsed_ms_mean=1.477 ms`, `source_read_calls_mean=0.0`.
- CI must run the registered PR-scoped performance probe before merge.

## Known Gaps
- Swift runtime effects are not involved in this Python-only slice.
- CI is the authoritative registered PR-scoped probe gate for merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: no observability mode changes; probe source reads are recorded.
- [x] Deferred work and known gaps are stated explicitly.
