### PR TITLE
perf: avoid local job scan suffix slices

### DIFF
--- a/docs/plans/2026-06-30-local-job-followup-extension-suffix.md
+++ b/docs/plans/2026-06-30-local-job-followup-extension-suffix.md
@@ -1,0 +1,37 @@
+# Local Job Follow-up JSON Suffix Fast Path
+
+## Context
+
+`LocalJobContinuationStore.scan_followup_candidates()` scans flat local-job record stores and filters record files by the `.json` suffix before loading and reconciling each candidate. The PR-scoped probe `local-job-followup-scan-scandir` covers this path with focused tests, coverage, and a command-json performance probe.
+
+## Slice
+
+Use `str.endswith(".json")` with a local suffix binding during the scandir loop instead of creating a five-character slice for every directory entry. This keeps semantics unchanged:
+
+- only non-symlink regular files with `.json` names are considered;
+- `.json.tmp`, lock files, directories, and non-record notes stay ignored;
+- sorted job-id ordering remains unchanged;
+- the existing special handling for an exact `.json` filename is preserved.
+
+## Verification Plan
+
+- Focused local tests from the registered probe entry.
+- Changed-scope coverage command from `infra/perf/pr_scoped_probes.json`.
+- Registered local probe command `scripts/local_job_followup_scan_probe.py` on Linux.
+- GitHub PR-scoped performance workflow after PR creation.
+
+## Metrics
+
+Baseline Linux probe before the slice, compared against the fresh `origin/main` checkout with `MELIX_LOCAL_JOB_SCAN_RECORDS=500` and `MELIX_LOCAL_JOB_SCAN_SAMPLES=9` across three runs:
+
+- `elapsed_ms_mean` samples: `21.762993`, `20.699737`, `21.088847`
+- aggregate baseline mean: `21.183859 ms`
+- `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`
+
+After the slice under the same local settings:
+
+- `elapsed_ms_mean` samples: `17.618416`, `17.841842`, `18.506472`
+- aggregate head mean: `17.988910 ms`
+- `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`
+
+Local delta: `-3.194949 ms` mean, about `15.08%` faster on the scan probe. CI remains the registered validation source for PR-scoped comparison.

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -365,15 +365,16 @@ class LocalJobContinuationStore:
         try:
             record_job_ids: list[str] = []
             record_job_ids_append = record_job_ids.append
+            json_suffix = ".json"
             for entry in os.scandir(root_fspath):
                 name = entry.name
-                if name[-5:] != ".json":
+                if not name.endswith(json_suffix):
                     continue
                 if entry.is_file(follow_symlinks=False):
                     # The scan has already filtered this to a .json file name.
                     # Slice directly rather than calling Path.stem or a helper for
                     # every record in large follow-up stores.
-                    record_job_ids_append(".json" if name == ".json" else name[:-5])
+                    record_job_ids_append(json_suffix if name == json_suffix else name[:-5])
             record_job_ids.sort()
         except FileNotFoundError:
             return LocalJobContinuationFollowupScan(candidates=(), receipts=())


### PR DESCRIPTION
## Summary
- Avoid per-entry suffix slicing in `LocalJobContinuationStore.scan_followup_candidates()` by using a local `.json` suffix binding and `str.endswith()` in the scandir loop.
- Preserve existing scan semantics: one scandir pass, no glob/path-exists checks, no symlink following, sorted job-id processing, and exact `.json` filename handling.

## Plan or Spec
- `docs/plans/2026-06-30-local-job-followup-extension-suffix.md`
- Registered PR-scoped probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json` already covers the touched path with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline probe from fresh origin/main checkout, three runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" MELIX_LOCAL_JOB_SCAN_RECORDS=500 MELIX_LOCAL_JOB_SCAN_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0; elapsed_ms_mean samples: 21.762993, 20.699737, 21.088847

# Head probe under the same settings, three runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" MELIX_LOCAL_JOB_SCAN_RECORDS=500 MELIX_LOCAL_JOB_SCAN_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0; elapsed_ms_mean samples: 17.618416, 17.841842, 18.506472

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <local-job-followup-scan-scandir focused test list>
exit 0; 15 passed in 1.24s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py
exit 0; TOTAL 3 0 100%

# Registered probe script (direct equivalent of probe_command local path)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0; candidate_count_mean=500.0; scandir_calls_mean=1.0; path_glob_calls_mean=0.0; path_exists_calls_mean=0.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local Linux probe comparison (`record_count=500`, `samples=9`, three probe runs): baseline aggregate `elapsed_ms_mean=21.183859 ms`; head aggregate `elapsed_ms_mean=17.988910 ms`; delta `-3.194949 ms` / `15.08%` faster.
- Invariant counters remained stable: `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`, `candidate_count_mean=500.0`.
- CI PR-scoped performance workflow is required for registered base-vs-head validation before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a narrowly scoped Python runtime scan slice covered by the registered focused test, coverage, and probe commands.
- No Swift runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
