### PR TITLE
perf: cache quantized metadata tensor names

### DIFF
--- a/docs/plans/2026-06-30-quantized-metadata-tensor-names-cache.md
+++ b/docs/plans/2026-06-30-quantized-metadata-tensor-names-cache.md
@@ -1,0 +1,47 @@
+# Quantized metadata tensor-name snapshot cache
+
+## Scope
+
+This Python-only performance slice is limited to `QuantizedTensorMetadata.tensor_names`
+in `services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py`.
+
+`tensor_names` is a convenience snapshot used by model-dir/header fallback paths
+and probe/report code. Before this slice each property access rebuilt a
+`frozenset` from the immutable mapping. The metadata object is already immutable,
+so the tensor-name snapshot can be built once during normalization and reused.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json`.
+
+This slice extends the existing registered probe with focused `tensor_names`
+access metrics while keeping the same focused `test_command`, `coverage_command`,
+and `probe_command` structure:
+
+- `tensor_names_access_elapsed_ms_mean`
+- `tensor_names_access_peak_bytes_mean`
+- `tensor_names_access_count`
+
+## Plan
+
+1. Add regression coverage proving `tensor_names` returns the normalized immutable
+   snapshot and reuses the same frozenset object on repeated access.
+2. Cache the frozenset during `QuantizedTensorMetadata` construction and in the
+   normalized-mapping fast path used by index/header parsing.
+3. Extend the registered probe script and registry metrics to measure repeated
+   tensor-name snapshot access.
+4. Run focused pytest, changed-scope coverage, and the registered probe locally
+   on Linux before opening the PR.
+5. Use GitHub Actions and the registered PR-scoped performance report as the
+   merge gate.
+
+## Verification
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_backed_loader_uses_tokenizer_for_text_only_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantized_tensor_metadata_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,*/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py,*/scripts/quantized_tensor_metadata_prepass_probe.py' -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantized_tensor_metadata_prepass_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantized_tensor_metadata_prepass_probe.py
+```

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5820,7 +5820,8 @@
       "scripts/quantized_tensor_metadata_prepass_probe.py",
       "infra/perf/pr_scoped_probes.json",
       "docs/plans/2026-06-26-quantized-high-precision-segment-scan.md",
-      "docs/plans/2026-06-27-quantized-metadata-string-normalization.md"
+      "docs/plans/2026-06-27-quantized-metadata-string-normalization.md",
+      "docs/plans/2026-06-30-quantized-metadata-tensor-names-cache.md"
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_backed_loader_uses_tokenizer_for_text_only_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantized_tensor_metadata_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,*/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py,*/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py,*/scripts/quantized_tensor_metadata_prepass_probe.py' -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_backed_loader_uses_tokenizer_for_text_only_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantized_tensor_metadata_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantized_tensor_metadata_prepass_probe.py",
@@ -5899,6 +5900,24 @@
         "unit": "count",
         "direction": "higher_is_better",
         "warn_pct": 0.0
+      },
+      {
+        "key": "tensor_names_access_count",
+        "unit": "count",
+        "direction": "higher_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "tensor_names_access_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "tensor_names_access_peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
       },
       {
         "key": "header_tensor_count",

--- a/scripts/quantized_tensor_metadata_prepass_probe.py
+++ b/scripts/quantized_tensor_metadata_prepass_probe.py
@@ -215,6 +215,15 @@ def run_probe() -> dict[str, float]:
         sum(1 for prefix in prefixes if _is_cross_shard_quantized_pair(metadata, prefix))
     )
 
+    tensor_names_access_ms, tensor_names_access_peaks, tensor_names_access_count = _measure(
+        lambda: sum(
+            len(metadata.tensor_names)
+            for _ in range(decision_iterations)
+            for _prefix in prefixes
+        ),
+        samples=samples,
+    )
+
     metadata_decision_ms, metadata_decision_peaks, metadata_decision_count = _measure(
         lambda: sum(
             int(quantized_scales_present(prefix, metadata=metadata, weights={}))  # type: ignore[arg-type]
@@ -266,6 +275,9 @@ def run_probe() -> dict[str, float]:
         "high_precision_decision_count": float(cast(int, high_precision_decision_count)),
         "matched_decision_count": float(metadata_decision_count),
         "metadata_tensor_count": metadata_tensor_count,
+        "tensor_names_access_count": float(cast(int, tensor_names_access_count)),
+        "tensor_names_access_elapsed_ms_mean": statistics.fmean(tensor_names_access_ms),
+        "tensor_names_access_peak_bytes_mean": statistics.fmean(tensor_names_access_peaks),
         "header_tensor_count": float(len(header_metadata.tensor_names)),
         "cross_shard_pair_count": cross_shard_pair_count,
         "pair_count": float(pair_count),

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -2493,6 +2493,8 @@ def test_quantized_tensor_metadata_normalizes_index_keys_once() -> None:
     assert metadata.tensor_to_shard == {
         "language_model.layers.0.q_proj.scales": "model-00001.safetensors"
     }
+    assert metadata.tensor_names == frozenset(("language_model.layers.0.q_proj.scales",))
+    assert metadata.tensor_names is metadata.tensor_names
     assert tensor_name.calls == 1
     assert empty_tensor_name.calls == 1
     assert shard_name.calls == 1

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -670,6 +670,9 @@ def test_quantized_tensor_metadata_prepass_probe_script_emits_metrics(
     assert metrics["high_precision_decision_elapsed_ms_mean"] >= 0.0
     assert metrics["high_precision_decision_count"] == 6.0
     assert metrics["metadata_tensor_count"] == 18.0
+    assert metrics["tensor_names_access_count"] == 216.0
+    assert metrics["tensor_names_access_elapsed_ms_mean"] >= 0.0
+    assert metrics["tensor_names_access_peak_bytes_mean"] >= 0.0
     assert metrics["header_tensor_count"] == 18.0
     assert metrics["cross_shard_pair_count"] == 6.0
     assert metrics["matched_decision_count"] == 12.0

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import os
 from pathlib import Path
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Sequence
 @dataclass(frozen=True, slots=True)
 class QuantizedTensorMetadata:
     tensor_to_shard: Mapping[str, str]
+    _tensor_names: frozenset[str] = field(default_factory=frozenset, init=False, repr=False)
 
     def __post_init__(self) -> None:
         normalized: dict[str, str] = {}
@@ -23,10 +24,11 @@ class QuantizedTensorMetadata:
             "tensor_to_shard",
             MappingProxyType(normalized),
         )
+        object.__setattr__(self, "_tensor_names", frozenset(normalized))
 
     @property
     def tensor_names(self) -> frozenset[str]:
-        return frozenset(self.tensor_to_shard)
+        return self._tensor_names
 
     def has_tensor(self, tensor_name: str) -> bool:
         return tensor_name in self.tensor_to_shard
@@ -57,6 +59,7 @@ def _metadata_from_normalized_mapping(tensor_to_shard: dict[str, str]) -> Quanti
         return EMPTY_QUANTIZED_TENSOR_METADATA
     metadata = object.__new__(QuantizedTensorMetadata)
     object.__setattr__(metadata, "tensor_to_shard", MappingProxyType(tensor_to_shard))
+    object.__setattr__(metadata, "_tensor_names", frozenset(tensor_to_shard))
     return metadata
 
 


### PR DESCRIPTION
## Summary
- Cache `QuantizedTensorMetadata.tensor_names` once during metadata normalization instead of rebuilding a `frozenset` on every property access.
- Extend the registered `quantized-tensor-metadata-prepass` PR-scoped probe with tensor-name access metrics.
- Add regression coverage and a governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-06-30-quantized-metadata-tensor-names-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_only_language_model_quantizes_from_presanitize_metadata services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_gemma4_text_backed_loader_uses_tokenizer_for_text_only_exports services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_mlx_vlm_runtime_uses_generate_step_for_mtp_when_available services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantized_tensor_metadata_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_vlm_runtime_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 16 passed in 1.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,*/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py,*/scripts/quantized_tensor_metadata_prepass_probe.py' -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 8 passed in 0.53s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantized_tensor_metadata_prepass_probe.py
# TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" MELIX_QUANTIZED_METADATA_SAMPLES=5 MELIX_QUANTIZED_METADATA_PAIR_COUNT=2000 MELIX_QUANTIZED_METADATA_DECISION_ITERATIONS=20 uv run --project services/mlx-worker-python python3 scripts/quantized_tensor_metadata_prepass_probe.py
# {"tensor_names_access_elapsed_ms_mean": 16.496599407400936, "tensor_names_access_peak_bytes_mean": 516.0, ...}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered local probe (head): `tensor_names_access_elapsed_ms_mean=16.496599407400936`, `tensor_names_access_peak_bytes_mean=516.0`, `tensor_names_access_count=240000000.0`.
- Local same-workload base/head tensor-name microbenchmark: `old_mean=9230.429902405012ms`, `new_mean=27.10557618411258ms`, `delta_ms=-9203.324`, `speedup=340.54x`, `peak_bytes` from `656144.0` to `576.0`.
- CI is required for the registered PR-scoped performance validation before merge.

## Known Gaps
- Linux local validation only. This slice touches Python worker code; no Swift runtime effect is claimed.
- The full repository `make` gates were not run locally; focused tests, changed-scope coverage, and the registered probe were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
