### PR TITLE
perf: reuse export retention cleanup decision set

### DIFF
--- a/docs/plans/2026-06-30-export-retention-delete-decision-set.md
+++ b/docs/plans/2026-06-30-export-retention-delete-decision-set.md
@@ -1,0 +1,53 @@
+# Export Retention Delete Decision Membership Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to export target retention cleanup
+membership checks in `services/mlx-worker-python/worker/productization/export_target_layout.py`.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the export layout retention tests and probe, so no
+probe registry change is required for this slice.
+
+## Optimization
+
+`build_export_retention_report()` and `_decide_file()` previously allocated two-item
+set literals while classifying cleanup-eligible decisions. This slice hoists the
+cleanup-delete decision set into a module-level `frozenset` and reuses it for
+membership checks.
+
+Behavior remains unchanged: only cleanable and TTL-expired runtime-log decisions
+are unlinked when cleanup is enabled, retained files remain retained, missing
+files remain non-deleted, and report payload fields keep the same semantics.
+
+## Verification
+
+Run the registered focused local Linux commands from
+`runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json` before
+opening the PR:
+
+```bash
+python3 - <<'PY'
+import json, subprocess
+from pathlib import Path
+probe = next(
+    item for item in json.loads(Path("infra/perf/pr_scoped_probes.json").read_text())
+    if item["id"] == "runtime-export-layout-retention"
+)
+for key in ("test_command", "coverage_command", "probe_command"):
+    rc = subprocess.run(probe[key], shell=True).returncode
+    if rc:
+        raise SystemExit(rc)
+PY
+```
+
+CI PR-scoped performance remains the merge gate for the registered probe result.
+
+## Success Criteria
+
+- Focused export target layout retention tests pass.
+- Changed-scope coverage for `worker.productization.export_target_layout` stays at or above the repository threshold.
+- The registered probe reports a directionally improved layout-retention hot path.
+- PR-scoped performance CI selects and completes the registered probe before merge.

--- a/services/mlx-worker-python/worker/productization/export_target_layout.py
+++ b/services/mlx-worker-python/worker/productization/export_target_layout.py
@@ -58,6 +58,9 @@ _CLEANABLE_VERIFICATION_STATES = {
     export_target_manifest_pb2.EXPORT_VERIFICATION_STATE_PASSED,
     export_target_manifest_pb2.EXPORT_VERIFICATION_STATE_WAIVED,
 }
+_CLEANUP_DELETE_DECISIONS = frozenset(
+    (RETENTION_DECISION_CLEANABLE, RETENTION_DECISION_DELETE_AFTER_TTL)
+)
 _EVIDENCE_PATH_FIELDS = (
     "export_report_path",
     "retention_report_path",
@@ -220,10 +223,7 @@ def build_export_retention_report(
             if decision.decision == RETENTION_DECISION_RETAIN:
                 retained_byte_size += decision.byte_size
                 retained_file_count += 1
-            elif decision.decision in {
-                RETENTION_DECISION_CLEANABLE,
-                RETENTION_DECISION_DELETE_AFTER_TTL,
-            }:
+            elif decision.decision in _CLEANUP_DELETE_DECISIONS:
                 cleanable_byte_size += decision.byte_size
                 cleanable_file_count += 1
             if decision.deleted:
@@ -474,7 +474,7 @@ def _decide_file(
     if (
         apply_cleanup
         and exists
-        and decision in {RETENTION_DECISION_CLEANABLE, RETENTION_DECISION_DELETE_AFTER_TTL}
+        and decision in _CLEANUP_DELETE_DECISIONS
     ):
         path.unlink(missing_ok=True)
         deleted = True


### PR DESCRIPTION
## Summary
- Reuse a module-level cleanup decision `frozenset` in export target retention cleanup/reporting instead of allocating identical two-item set literals per file row.
- Add a focused plan for the Python performance slice and its registered PR-scoped probe gate.

## Plan or Spec
- `docs/plans/2026-06-30-export-retention-delete-decision-set.md`
- Registered probe: `runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py
# baseline before change: exit 0; elapsed_ms_mean=2587.200327613391, peak_bytes_mean=178265.4

python3 - <<'PY'
import json, subprocess
from pathlib import Path
probe = next(item for item in json.loads(Path('infra/perf/pr_scoped_probes.json').read_text()) if item['id']=='runtime-export-layout-retention')
for key in ('test_command','coverage_command','probe_command'):
    print(f'=== {key} ===', flush=True)
    rc = subprocess.run(probe[key], shell=True).returncode
    print(f'=== {key} exit {rc} ===', flush=True)
    if rc:
        raise SystemExit(rc)
PY
# final head after review follow-up:
# test_command: exit 0; 24 passed in 0.48s
# coverage_command: exit 0; 24 passed in 1.09s; changed_line_coverage=100.00%; TOTAL 1 0 100%
# probe_command: exit 0; elapsed_ms_mean=2509.0922149829566, peak_bytes_mean=182281.2

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/productization/export_target_layout.py` changed lines.
- Registered local probe (`runtime-export-layout-retention`, Linux): baseline `elapsed_ms_mean=2587.200327613391`; final head `elapsed_ms_mean=2509.0922149829566`; delta `-78.10811263043436 ms` (~`3.02%` faster). `peak_bytes_mean` changed from `178265.4` to `182281.2` bytes in the local sample.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make` gates were not run locally; this is a focused Python performance slice verified with the registered probe commands on Linux.
- No Swift runtime effect is claimed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.