### PR TITLE
perf: normalize embedding digest vector in place

### DIFF
--- a/docs/plans/2026-06-30-embedding-project-digest-default-dimension-inplace.md
+++ b/docs/plans/2026-06-30-embedding-project-digest-default-dimension-inplace.md
@@ -1,0 +1,41 @@
+# Embedding Project Digest Default Dimension In-place Normalization
+
+This Python-only performance slice is limited to deterministic embedding digest
+projection in `services/mlx-worker-python/worker/runtime/embedding_backends.py`.
+It preserves the deterministic projection values while reducing temporary list
+allocation on the default eight-dimensional path.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe
+`deterministic-embedding-project-digest-allocation` in
+`infra/perf/pr_scoped_probes.json`. The registry already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/runtime/embedding_backends.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/deterministic_embedding_project_digest_probe.py`
+
+## Slice plan
+
+1. Keep the expanded-dimension digest projection behavior unchanged.
+2. For the default `dimensions == 8` path, normalize the base digest vector in
+   place and return it instead of allocating a second normalized list.
+3. Verify value parity with the existing embedding runtime tests.
+4. Run changed-scope coverage and the registered PR-scoped performance probe on
+   Linux before opening the PR. GitHub Actions remains the merge gate for the
+   registered probe report.
+
+## Metrics
+
+The local probe compares `origin/main` with this branch using
+`scripts/pr_scoped_performance_run.py` and reports:
+
+- `default_dimension_elapsed_ms_mean`
+- `default_dimension_peak_bytes_mean`
+- expanded-dimension `elapsed_ms_mean`
+- expanded-dimension `peak_bytes_mean`
+
+The expected directional gain is lower default-dimension peak allocation with no
+behavioral change.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -65,7 +65,9 @@ class DeterministicEmbeddingBackend:
             if l2_norm == 0.0:
                 return [0.0] * 8
             inverse_l2_norm = 1.0 / l2_norm
-            return [_round(value * inverse_l2_norm, 6) for value in base_values]
+            for index, value in enumerate(base_values):
+                base_values[index] = _round(value * inverse_l2_norm, 6)
+            return base_values
         return self._project_digest_expanded(base_values, dimensions)
 
     def _project_digest_expanded(


### PR DESCRIPTION
## Summary
- Normalize the deterministic embedding digest default-dimension vector in place instead of allocating a second normalized list.
- Keep expanded-dimension projection behavior and deterministic vector values unchanged.

## Plan or Spec
- `docs/plans/2026-06-30-embedding-project-digest-default-dimension-inplace.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 21 passed in 18.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# 21 passed in 52.54s; changed-line coverage TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-embedding-project-digest-tuple-fastpath-20260630 --head-repo "$PWD" --output /tmp/embedding_digest_probe.json
# head verification passed; registered probe ran base/head successfully

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/embedding_backends.py` changed lines `[68, 69, 70]`, covered `[68, 69, 70]`, `TOTAL 3 0 100%`.
- Registered probe: `deterministic-embedding-project-digest-allocation`.
- Local Linux probe metrics:
  - `default_dimension_elapsed_ms_mean`: base `119.960680`, head `116.050161`, delta `-3.910519 ms` (`~3.26%` faster).
  - `default_dimension_peak_bytes_mean`: base `1261.333333`, head `1093.333333`, delta `-168.0 bytes` (`~13.32%` lower).
  - Expanded-dimension `elapsed_ms_mean`: base `15.955589`, head `15.918808`, delta `-0.036781 ms`.
  - Expanded-dimension `peak_bytes_mean`: base `74840.888889`, head `74840.888889`, unchanged.
- GitHub Actions PR-scoped performance workflow is still required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux-only for this Python slice; no Swift/runtime effect is claimed.
- The registered CI probe report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: this slice only changes deterministic embedding projection allocation.
- [x] Deferred work and known gaps are stated explicitly.
