### PR TITLE
perf: slice local job json suffix check

### DIFF
--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -366,15 +366,19 @@ class LocalJobContinuationStore:
             record_job_ids: list[str] = []
             record_job_ids_append = record_job_ids.append
             json_suffix = ".json"
+            json_suffix_length = len(json_suffix)
             for entry in os.scandir(root_fspath):
                 name = entry.name
-                if not name.endswith(json_suffix):
+                if (
+                    len(name) < json_suffix_length
+                    or name[-json_suffix_length:] != json_suffix
+                ):
                     continue
                 if entry.is_file(follow_symlinks=False):
                     # The scan has already filtered this to a .json file name.
                     # Slice directly rather than calling Path.stem or a helper for
                     # every record in large follow-up stores.
-                    record_job_ids_append(json_suffix if name == json_suffix else name[:-5])
+                    record_job_ids_append(json_suffix if name == json_suffix else name[:-json_suffix_length])
             record_job_ids.sort()
         except FileNotFoundError:
             return LocalJobContinuationFollowupScan(candidates=(), receipts=())


### PR DESCRIPTION
## Summary
- Optimize `LocalJobContinuationStore.scan_followup_candidates(...)` by replacing the hot `str.endswith(".json")` branch with a direct suffix slice using one bound suffix length.
- Preserve the existing no-follow file check for JSON-named entries and keep non-JSON entries filtered before metadata queries.

## Plan or Spec
- Follows `docs/plans/2026-06-15-local-job-followup-loop-bindings.md`, especially the 2026-06-30 follow-up for suffix checking before file stat.
- Affected path is already covered by registered PR-scoped probe `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered `local-job-followup-scan-scandir` focused selection) → 15 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && ... coverage json ... && python3 scripts/changed_scope_coverage.py ...` → 100% changed-line coverage.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id local-job-followup-scan-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-local-job-json-suffix-slice-20260630 --head-repo "$PWD" --output /tmp/local_job_json_suffix_probe_final.json`.
- `git diff --check`.

## Coverage and Metrics
- Focused tests: 15 passed locally on Linux.
- Changed-scope coverage: 100% (`3/3` measurable changed lines covered).
- Registered local probe (`local-job-followup-scan-scandir`, 500 records, 5 samples):
  - `elapsed_ms_mean`: base `20.438115`, head `18.187636`, delta `-2.250479 ms`, speedup `1.1237x` / `11.011%` improvement.
  - `projection_elapsed_ms_mean`: base `136.376064`, head `134.942692`, delta `-1.433372 ms`.
  - Invariants: `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`, `candidate_count_mean=500.0`, `receipt_count_mean=500.0` on both base and head.
- CI PR-scoped performance workflow is required as the final registered probe validation source before merge.

## Known Gaps
- Python-only slice; no Swift runtime behavior changed.
- Local metrics are Linux probe results; merge remains gated on GitHub Actions and PR-scoped performance CI.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95% for touched scope.
- [x] Local registered probe was run against `origin/main` baseline and this branch.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
