### PR TITLE
perf: bind changed-scope parser ascii markers

### DIFF
--- a/docs/plans/2026-06-30-changed-scope-parser-local-ascii-bindings-performance.md
+++ b/docs/plans/2026-06-30-changed-scope-parser-local-ascii-bindings-performance.md
@@ -1,0 +1,32 @@
+# Changed-Scope Parser Local ASCII Bindings Performance Slice
+
+## Scope
+
+Optimize exactly one Python hot path in the changed-scope coverage diff parser:
+`_parse_changed_lines` in `scripts/changed_scope_coverage.py`.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `changed-scope-coverage-diff-parser` in
+`infra/perf/pr_scoped_probes.json`. That probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and measures
+`elapsed_ms_mean` for a synthetic multi-file unified diff.
+
+## Slice
+
+Bind the parser's frequently used ASCII byte marker constants to local names
+before the inner diff-line loop. This keeps the parser behavior unchanged while
+removing repeated global lookups for the hot branch dispatch checks.
+
+## Verification Plan
+
+- Run the registered focused test command for
+  `changed-scope-coverage-diff-parser`.
+- Run the registered changed-scope coverage command and require at least 95%
+  coverage for the touched scope.
+- Run the registered probe command locally on Linux and compare against an
+  `origin/main` baseline from the same host.
+- Let GitHub Actions run the PR-scoped performance workflow before merge.
+
+## Boundary
+
+This is a Linux-verifiable Python slice. No Swift runtime effect is claimed.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -91,6 +91,11 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     header_prefix_len = len(header_prefix)
     header_separator_len = len(header_separator)
     parse_hunk_new_start_from_digit = _parse_hunk_new_start_from_digit_bytes
+    ascii_backslash = _ASCII_BACKSLASH
+    ascii_plus = _ASCII_PLUS
+    ascii_minus = _ASCII_MINUS
+    ascii_at = _ASCII_AT
+    ascii_lower_d = _ASCII_LOWER_D
     add_changed_line = None
     new_line: int | None = None
     for line in diff_text.encode().splitlines():
@@ -99,7 +104,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
                 new_line += 1
             continue
         first_char = line[0]
-        if first_char == _ASCII_LOWER_D and line.startswith(header_prefix):
+        if first_char == ascii_lower_d and line.startswith(header_prefix):
             separator_index = line.find(header_separator, header_prefix_len)
             add_changed_line = None
             if separator_index >= 0:
@@ -107,7 +112,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
                 add_changed_line = changed_by_path_setdefault(current_path, set()).add
             new_line = None
             continue
-        if first_char == _ASCII_AT and len(line) > 1 and line[1] == _ASCII_AT:
+        if first_char == ascii_at and len(line) > 1 and line[1] == ascii_at:
             new_range_index = line.find(b" +")
             if new_range_index < 0:
                 new_line = None
@@ -116,12 +121,12 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
             continue
         if add_changed_line is None or new_line is None:
             continue
-        if first_char == _ASCII_BACKSLASH:
+        if first_char == ascii_backslash:
             continue
-        if first_char == _ASCII_PLUS:
+        if first_char == ascii_plus:
             add_changed_line(new_line)
             new_line += 1
-        elif first_char == _ASCII_MINUS:
+        elif first_char == ascii_minus:
             continue
         else:
             new_line += 1


### PR DESCRIPTION
## Summary
- Bind frequently used changed-scope diff parser ASCII byte markers to local names before the hot parse loop.
- Keep parser behavior unchanged while reducing repeated global lookups in branch dispatch.

## Plan or Spec
- Added `docs/plans/2026-06-30-changed-scope-parser-local-ascii-bindings-performance.md`.
- Registered probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json` already provides focused test, coverage, and probe commands for this path.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- Baseline probe on `origin/main`: `python3 scripts/changed_scope_coverage_parse_probe.py`
- Candidate probe on this branch: `python3 scripts/changed_scope_coverage_parse_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 48 passed.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local Linux registered probe comparison:
  - baseline `elapsed_ms_mean=3.353522489002595`, `elapsed_ms_min=3.0479650013148785`
  - candidate `elapsed_ms_mean=2.9381259034077325`, `elapsed_ms_min=2.7077350532636046`
  - delta `-0.4153965855948627 ms`, speedup about `12.38%` by mean elapsed time.

## Known Gaps
- This is a Python-only Linux-verified slice. No Swift runtime effect is claimed.
- Final merge requires the GitHub Actions PR-scoped performance workflow and registered probe report to complete successfully.

## Evidence Checklist
- [x] Started from synced `origin/main`.
- [x] Confirmed registered probe includes focused test, coverage, and probe commands.
- [x] Ran focused local tests.
- [x] Ran changed-scope coverage for touched files.
- [x] Ran local baseline and candidate registered probes.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
