### PR TITLE
perf: fast path diagnostic excerpt ascii accounting

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -165,6 +165,12 @@ with an explicit loop helper. Lines still enter the per-pattern matcher only whe
 one registered diagnosis marker appears in the lowercased source text, but the
 hot scan path avoids creating a generator for every bounded excerpt line.
 
+A follow-up 2026-07-01 redacted excerpt byte accounting slice keeps the same
+bounded excerpt text, line map, and byte-limit semantics while using an ASCII
+fast path for rendered excerpt lines. ASCII runtime log lines now account for
+`len(rendered) + 1` directly and only encode the uncommon non-ASCII path, while
+clipped ASCII lines preserve the existing newline-inclusive byte boundary.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -384,6 +384,32 @@ def test_export_target_diagnostics_uses_lexical_target_path_fast_path(
     ) is None
 
 
+def test_export_target_diagnostics_ascii_excerpt_fast_path_preserves_byte_budget(
+    tmp_path: Path,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [
+            _SourceLine("logs/runtime.log", "runtime load failed while opening model"),
+            _SourceLine("logs/runtime.log", "plain ascii progress line"),
+        ],
+        bounded_bytes=77,
+        bounded_lines=20,
+    )
+
+    assert excerpt.summary.truncated is True
+    assert excerpt.summary.excerpt_byte_count == 77
+    assert excerpt.summary.excerpt_byte_count <= 77
+    assert "runtime load failed" in excerpt.text
+    assert excerpt.text.startswith("[logs/runtime.log] runtime load failed while opening model")
+
+
 def test_export_target_diagnostics_lowercases_source_line_once_per_match_scan() -> None:
     class TrackingText(str):
         lower_calls = 0

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -558,6 +558,21 @@ def _build_redacted_excerpt(
             break
         redacted = _redact_text(source_line.text, resolved_target_root, resolved_target_root_text, summary)
         rendered = f"[{source_line.source_path}] {redacted}"
+        if rendered.isascii():
+            rendered_byte_count = len(rendered) + 1
+            if used_bytes + rendered_byte_count > bounded_bytes:
+                remaining = max(0, bounded_bytes - used_bytes)
+                if remaining > 0:
+                    clipped = (rendered + "\n")[:remaining]
+                    output_lines.append(clipped)
+                    line_numbers[index] = len(output_lines)
+                    used_bytes += len(clipped)
+                summary.truncated = True
+                break
+            output_lines.append(rendered)
+            line_numbers[index] = len(output_lines)
+            used_bytes += rendered_byte_count
+            continue
         rendered_bytes = (rendered + "\n").encode("utf-8")
         if used_bytes + len(rendered_bytes) > bounded_bytes:
             remaining = max(0, bounded_bytes - used_bytes)


### PR DESCRIPTION
## Summary
- Fast-path ASCII rendered lines in the runtime export diagnostic redacted excerpt builder.
- Preserve the existing bounded byte budget, line map, and clipping semantics while avoiding UTF-8 encode work for the common ASCII runtime-log path.
- Add a regression test for ASCII clipped excerpt byte-budget behavior.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` updated with the 2026-07-01 ASCII byte-accounting slice.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 71 passed in 1.63s

bash /tmp/runtime_export_diag_coverage_cmd.sh
# 72 passed in 1.33s; changed-scope coverage TOTAL 24 0 100%

bash /tmp/runtime_export_diag_probe_cmd.sh (3 runs on this branch)
# elapsed_ms_mean: 2585.669831, 2605.949015, 2596.068869
```

## Coverage and Metrics
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` (already covers `services/mlx-worker-python/worker/productization/export_target_diagnostics.py` with focused test, coverage, and probe commands).
- Changed-scope coverage: 100.00% (`TOTAL 24 0 100%`).
- Local Linux probe comparison against `origin/main`:
  - old_mean=2657.632587 ms
  - new_mean=2595.895905 ms
  - delta_ms=-61.736682 ms
  - speedup=2.322995%
- Registered probe CI is required for final PR-scoped validation before merge.

## Known Gaps
- Full repository test matrix not run locally; this is a focused Python performance slice.
- Swift/macOS runtime effects are not applicable for this Python-only diagnostic parser slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
