### PR TITLE
perf: shallow copy local job projection receipts

### DIFF
--- a/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
+++ b/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
@@ -21,6 +21,12 @@ The affected path is covered by the registered PR-scoped performance probe `loca
 
 This Python-only follow-up keeps the same registered `local-job-followup-scan-scandir` probe and narrows the top-level scandir filter. `scan_followup_candidates(...)` now rejects non-`.json` directory entries before calling `DirEntry.is_file(follow_symlinks=False)`, and uses direct suffix slicing rather than `str.endswith(...)` on the hot path. JSON-named directories still receive the no-follow file check and are skipped; non-record files such as `*.json.tmp` and `*.txt` avoid an unnecessary metadata query.
 
+## 2026-07-01 follow-up: projection receipt shallow copy
+
+This Python-only follow-up keeps the same registered `local-job-followup-scan-scandir` probe and narrows the batch projection copy path. `project_local_job_session_followups(...)` now copies the claim-batch receipt envelope with a receipt-aware shallow copier instead of calling generic `deepcopy(...)` over the full receipt tuple. The helper still isolates top-level receipt mutations and the nested `prompt_context_receipts` list used by claimed follow-ups, while avoiding recursive traversal of immutable scalar fields for every projected local-job receipt.
+
+The focused regression guard mutates both a copied top-level receipt field and a nested prompt-context receipt field to prove downstream projection mutations do not leak back into the claim batch. No record schema, reconciliation, claim, prompt-context admission, scan ordering, or receipt payload semantics change.
+
 ## Linux validation boundary
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime behavior changes are included.

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -1138,6 +1138,15 @@ def test_store_scan_followup_candidates_reconciles_and_filters_ready_records(
         projection_batch.claim_batch.receipts[claimed_receipt_index]["reason"]
         == "followup_claimed"
     )
+    projection_batch.receipts[claimed_receipt_index]["prompt_context_receipts"][0][
+        "segment_id"
+    ] = "downstream-mutation"
+    assert (
+        projection_batch.claim_batch.receipts[claimed_receipt_index][
+            "prompt_context_receipts"
+        ][0]["segment_id"]
+        != "downstream-mutation"
+    )
     assert projection_batch.refusal_receipts == ()
     assert projection_store.load_record("projection-live") == replace(
         projection_live,

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -925,9 +925,23 @@ def project_local_job_session_followups(
         claim_batch=claim_batch,
         projections=tuple(projections),
         followup_messages=tuple(followup_messages),
-        receipts=deepcopy(claim_batch.receipts),
-        refusal_receipts=deepcopy(claim_batch.refusal_receipts),
+        receipts=_copy_receipt_sequence(claim_batch.receipts),
+        refusal_receipts=_copy_receipt_sequence(claim_batch.refusal_receipts),
     )
+
+
+def _copy_receipt_sequence(
+    receipts: Sequence[dict[str, Any]],
+) -> tuple[dict[str, Any], ...]:
+    return tuple(_copy_receipt(receipt) for receipt in receipts)
+
+
+def _copy_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    copied = dict(receipt)
+    prompt_context_receipts = copied.get("prompt_context_receipts")
+    if prompt_context_receipts:
+        copied["prompt_context_receipts"] = [dict(item) for item in prompt_context_receipts]
+    return copied
 
 
 def _project_local_job_session_followup_claim(


### PR DESCRIPTION
## Summary
- Replace generic `deepcopy(...)` for local-job projection batch receipt envelopes with a receipt-aware copier.
- Preserve downstream mutation isolation for top-level receipts and nested `prompt_context_receipts`.
- Update the local-job follow-up performance plan with the 2026-07-01 slice.

## Plan or Spec
- `docs/plans/2026-06-15-local-job-followup-loop-bindings.md`
- Registered PR-scoped probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`

## Commands Run
```text
# Baseline (origin/main f4956937) vs branch, record_count=500, projection_records=1000, samples=9
origin/main: projection_elapsed_ms_mean=536.179253, projection_elapsed_ms_min=502.724871, elapsed_ms_mean=17.53114
branch:      projection_elapsed_ms_mean=512.508763, projection_elapsed_ms_min=486.095403, elapsed_ms_mean=18.640785

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics
# 3 passed in 0.15s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q [registered local-job probe test command]
# 15 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py
# 99 passed in 0.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py
# 103 passed in 0.59s; TOTAL 10 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
# {"projection_elapsed_ms_mean": 126.89, "projection_elapsed_ms_min": 118.57982, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local registered probe command completed successfully on Linux.
- Baseline vs branch projection metric: `projection_elapsed_ms_mean` 536.179253 ms -> 512.508763 ms (`-23.67049 ms`, ~4.41% faster) for 1000 projected local-job follow-ups over 9 samples.
- Scan syscall shape remained stable in the probe (`scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux-only local validation for this Python slice; no Swift runtime behavior changed.
- The registered command's shell wrapper was not run locally in this environment because shell `bash -c` required approval; the equivalent direct probe script was run and the CI registered probe remains the authoritative gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
