### PR TITLE
perf: fast path runtime kwarg function checks

### DIFF
--- a/docs/plans/2026-07-01-runtime-kwarg-function-fastpath-performance.md
+++ b/docs/plans/2026-07-01-runtime-kwarg-function-fastpath-performance.md
@@ -1,0 +1,20 @@
+# Runtime kwarg function fast-path performance
+
+## Context
+
+`worker.runtime.runtime_utils.callable_accepts_kwarg()` is on text runtime hot paths that repeatedly test whether a backend helper accepts optional keyword arguments. The affected path is already covered by the registered PR-scoped probe `runtime-utils-kwarg-signature-cache` in `infra/perf/pr_scoped_probes.json`, including focused test, coverage, and probe commands.
+
+## Slice
+
+Add a narrow fast path for plain Python functions in `callable_accepts_kwarg()` so repeated hot-path calls can consult the cached signature directly without re-running the generic callable cache-target normalization.
+
+## Validation
+
+- Focused unit tests from the registered probe entry.
+- Changed-scope coverage from the registered probe entry.
+- Registered local probe `scripts/runtime_utils_kwarg_cache_probe.py` on Linux.
+- PR-scoped CI performance validation after push.
+
+## Boundaries
+
+This slice only changes Python runtime utility dispatch for plain functions. Bound methods and other callable objects continue to use the generic `callable_kwarg_signature()` path.

--- a/services/mlx-worker-python/worker/runtime/runtime_utils.py
+++ b/services/mlx-worker-python/worker/runtime/runtime_utils.py
@@ -100,7 +100,13 @@ def callable_declares_kwarg(callable_obj: Any, keyword: str) -> bool:
 
 
 def callable_accepts_kwarg(callable_obj: Any, keyword: str) -> bool:
-    signature = callable_kwarg_signature(callable_obj)
+    if type(callable_obj) is FunctionType:
+        signature = _callable_kwarg_signature_cached(
+            callable_obj,
+            skip_first_parameter=False,
+        )
+    else:
+        signature = callable_kwarg_signature(callable_obj)
     return keyword in signature.keyword_accessible_params or signature.accepts_var_keyword
 
 


### PR DESCRIPTION
## Summary
- Add a plain-function fast path in `callable_accepts_kwarg()` so repeated kwarg capability checks use the cached signature directly.
- Keep bound methods and non-function callables on the existing generic cache-target path.

## Plan or Spec
- `docs/plans/2026-07-01-runtime-kwarg-function-fastpath-performance.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_utils_kwarg_cache_probe.py
# before: {"elapsed_ms_mean": 15.955550409853458, "inspect_signature_calls_mean": 1.0, "iterations_per_sample": 40000.0, "sample_count": 5.0}
# after:  {"elapsed_ms_mean": 12.361592403613031, "inspect_signature_calls_mean": 1.0, "iterations_per_sample": 40000.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
# 23 passed in 0.21s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_utils_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_utils_kwarg_cache_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/runtime_utils.py services/mlx-worker-python/tests/test_runtime_utils.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_utils_kwarg_cache_probe.py
# TOTAL 3 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 3 0 100%`).
- Registered probe: `runtime-utils-kwarg-signature-cache`.
- Local Linux probe delta: `elapsed_ms_mean` 15.955550409853458 ms -> 12.361592403613031 ms (`-3.593958006240427 ms`, ~22.52% faster); `inspect_signature_calls_mean` remains 1.0.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Linux local validation covers the Python runtime utility path only; GitHub Actions must provide the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
