### PR TITLE
perf: partition changed-scope coverage lines once

### DIFF
--- a/docs/plans/2026-07-01-changed-scope-covered-missed-single-loop.md
+++ b/docs/plans/2026-07-01-changed-scope-covered-missed-single-loop.md
@@ -1,0 +1,34 @@
+# Changed-scope covered/missed single-loop slice
+
+This Python-only performance slice is limited to `scripts/changed_scope_coverage.py`.
+
+The changed-scope coverage helper already switches dense measured-line lookups to sets when the changed-line set is large enough. After source-line filtering, the set-backed branch still performed two passes over `measurable` to partition covered and missed changed lines. This slice keeps the existing semantics and replaces that with a single partition loop using local append bindings.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries, and selects this probe when `scripts/changed_scope_coverage.py` changes.
+
+## Verification plan
+
+1. Record the baseline `python3 scripts/changed_scope_coverage_measured_probe.py` metrics on Linux before editing.
+2. Apply the single-loop covered/missed partition only in the set-backed dense branch.
+3. Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux.
+4. Open a PR and rely on PR-scoped performance CI to validate the registered probe report before merge.
+
+## Local probe evidence
+
+Baseline probe before change on Linux:
+
+```text
+python3 scripts/changed_scope_coverage_measured_probe.py
+{"allowlist_parse_count": 10000.0, "allowlist_parse_elapsed_ms_mean": 2.8098820143246224, "dense_elapsed_ms_mean": 48.931839543261695, "dense_source_read_calls_mean": 300.0, "elapsed_ms_mean": 0.286503678320774, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}
+```
+
+Post-change probe on Linux:
+
+```text
+python3 scripts/changed_scope_coverage_measured_probe.py
+{"allowlist_parse_count": 10000.0, "allowlist_parse_elapsed_ms_mean": 2.9733424307778478, "dense_elapsed_ms_mean": 47.3435391572171, "dense_source_read_calls_mean": 300.0, "elapsed_ms_mean": 0.2688430083383407, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0}
+```
+
+Dense changed-line partition mean improved from `48.931839543261695 ms` to `47.3435391572171 ms` (about 3.25% faster). The sparse no-read case improved from `0.286503678320774 ms` to `0.2688430083383407 ms`; the allowlist parse metric is unrelated noise for this slice.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -317,8 +317,15 @@ def _measurable_changed_lines(
             if _sorted_line_list_contains(missing_lookup, line_no)
         ]
     else:
-        covered = [line_no for line_no in measurable if line_no in executed_lookup]
-        missed = [line_no for line_no in measurable if line_no in missing_lookup]
+        covered = []
+        missed = []
+        covered_append = covered.append
+        missed_append = missed.append
+        for line_no in measurable:
+            if line_no in executed_lookup:
+                covered_append(line_no)
+            elif line_no in missing_lookup:
+                missed_append(line_no)
     return measurable, covered, missed
 
 


### PR DESCRIPTION
## Summary
- Partition set-backed changed-scope coverage covered/missed lines in one pass instead of scanning `measurable` twice.
- Add a short plan note for the changed-scope covered/missed single-loop performance slice.

## Plan or Spec
- `docs/plans/2026-07-01-changed-scope-covered-missed-single-loop.md`
- Registered PR-scoped probe: `changed-scope-coverage-measured-set-filter`

## Commands Run
- `python3 scripts/changed_scope_coverage_measured_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_measured_probe.py` (post-change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 48 passed.
- Changed-scope coverage: `TOTAL 9 0 100%`.
- Baseline probe: `dense_elapsed_ms_mean=48.931839543261695`, `elapsed_ms_mean=0.286503678320774`.
- Post-change probe: `dense_elapsed_ms_mean=47.3435391572171`, `elapsed_ms_mean=0.2688430083383407`.
- Local delta: dense partition path improved by about 3.25%; sparse no-read path improved by about 6.16%.
- Registered PR-scoped performance CI is required for final probe validation before merge.

## Known Gaps
- Local validation was Linux-only.
- The allowlist parse timing in the measured probe moved slightly slower, but this slice does not touch allowlist parsing and treats that as unrelated sample noise.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95%+ gate for changed files.
- [x] Registered probe ran locally with an improved dense-path metric.
- [ ] PR-scoped performance workflow completed successfully in CI.
