### PR TITLE
perf: validate export retention decisions directly

### DIFF
--- a/docs/plans/2026-07-01-export-target-manifest-retention-direct-checks.md
+++ b/docs/plans/2026-07-01-export-target-manifest-retention-direct-checks.md
@@ -1,0 +1,43 @@
+# Export target manifest retention direct checks
+
+This Python-only performance slice is limited to retention-policy validation in
+`worker.productization.export_target_manifest`.
+
+## Registered probe
+
+The affected path is covered by the existing `runtime-export-manifest-validation`
+registered PR-scoped performance probe in `infra/perf/pr_scoped_probes.json`.
+The probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/export_target_manifest.py`
+- `services/mlx-worker-python/tests/test_export_target_manifest_contract.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/export_target_manifest_metrics_report.py`
+- `scripts/runtime_export_manifest_validation_probe.py`
+
+## Slice
+
+`_validate_retention_policy()` previously allocated an `expected_decisions`
+dictionary on every manifest validation, then iterated it only to compare six
+fixed fields. This slice replaces that per-call dictionary with module-level
+enum/name bindings and direct fixed field comparisons. Validation semantics and
+error strings remain unchanged.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and registered probe
+locally on Linux before opening the PR. GitHub Actions PR-scoped performance is
+the merge gate for the registered probe report.
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-manifest-validation --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/runtime_export_manifest_validation_probe.json
+```
+
+## Expected performance signal
+
+The expected directional improvement is lower validation latency and peak
+allocation during repeated manifest validation, with unchanged schema errors and
+fixture coverage.

--- a/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
+++ b/services/mlx-worker-python/tests/test_export_target_manifest_contract.py
@@ -155,6 +155,40 @@ def test_export_target_manifest_reports_required_field_errors(tmp_path: Path) ->
     assert "evidence.redaction_policy_id is required" in report.errors
 
 
+def test_export_target_manifest_reports_all_retention_decision_errors(
+    tmp_path: Path,
+) -> None:
+    def mutate_retention_policy(manifest: dict[str, object]) -> None:
+        retention_policy = manifest["retention_policy"]
+        assert isinstance(retention_policy, dict)
+        retention_policy.update(
+            {
+                "required_default_decision": "EXPORT_RETENTION_DECISION_CLEANABLE",
+                "evidence_default_decision": "EXPORT_RETENTION_DECISION_CLEANABLE",
+                "runtime_log_default_decision": "EXPORT_RETENTION_DECISION_RETAIN",
+                "intermediate_default_decision": "EXPORT_RETENTION_DECISION_RETAIN",
+                "cache_default_decision": "EXPORT_RETENTION_DECISION_RETAIN",
+                "temporary_default_decision": "EXPORT_RETENTION_DECISION_RETAIN",
+            }
+        )
+
+    manifest_path = _write_manifest(
+        tmp_path,
+        "melix_managed",
+        mutate_retention_policy,
+    )
+
+    report = validate_export_target_manifest_file(manifest_path)
+
+    assert report.ok is False
+    assert "retention_policy.required_default_decision must be EXPORT_RETENTION_DECISION_RETAIN" in report.errors
+    assert "retention_policy.evidence_default_decision must be EXPORT_RETENTION_DECISION_RETAIN" in report.errors
+    assert "retention_policy.runtime_log_default_decision must be EXPORT_RETENTION_DECISION_DELETE_AFTER_TTL" in report.errors
+    assert "retention_policy.intermediate_default_decision must be EXPORT_RETENTION_DECISION_CLEANABLE" in report.errors
+    assert "retention_policy.cache_default_decision must be EXPORT_RETENTION_DECISION_CLEANABLE" in report.errors
+    assert "retention_policy.temporary_default_decision must be EXPORT_RETENTION_DECISION_DELETE_AFTER_SUCCESS" in report.errors
+
+
 def test_export_target_manifest_rejects_unknown_numeric_target_type(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -52,6 +52,15 @@ _LOAD_CHECK_REQUIRED_TARGET_TYPES = frozenset(
 _RUNTIME_NOT_INSTALLED_WAIVER = (
     export_target_manifest_pb2.EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED
 )
+_RETENTION_DECISION_RETAIN = export_target_manifest_pb2.EXPORT_RETENTION_DECISION_RETAIN
+_RETENTION_DECISION_CLEANABLE = export_target_manifest_pb2.EXPORT_RETENTION_DECISION_CLEANABLE
+_RETENTION_DECISION_DELETE_AFTER_TTL = (
+    export_target_manifest_pb2.EXPORT_RETENTION_DECISION_DELETE_AFTER_TTL
+)
+_RETENTION_DECISION_DELETE_AFTER_SUCCESS = (
+    export_target_manifest_pb2.EXPORT_RETENTION_DECISION_DELETE_AFTER_SUCCESS
+)
+_RETENTION_DECISION_NAME = export_target_manifest_pb2.ExportRetentionDecision.Name
 
 
 @overload
@@ -304,38 +313,36 @@ def _validate_retention_policy(
     errors: list[str] = []
     if not policy.policy_id:
         errors.append("retention_policy.policy_id is required")
-    expected_decisions = {
-        "required_default_decision": (
-            policy.required_default_decision,
-            export_target_manifest_pb2.EXPORT_RETENTION_DECISION_RETAIN,
-        ),
-        "evidence_default_decision": (
-            policy.evidence_default_decision,
-            export_target_manifest_pb2.EXPORT_RETENTION_DECISION_RETAIN,
-        ),
-        "runtime_log_default_decision": (
-            policy.runtime_log_default_decision,
-            export_target_manifest_pb2.EXPORT_RETENTION_DECISION_DELETE_AFTER_TTL,
-        ),
-        "intermediate_default_decision": (
-            policy.intermediate_default_decision,
-            export_target_manifest_pb2.EXPORT_RETENTION_DECISION_CLEANABLE,
-        ),
-        "cache_default_decision": (
-            policy.cache_default_decision,
-            export_target_manifest_pb2.EXPORT_RETENTION_DECISION_CLEANABLE,
-        ),
-        "temporary_default_decision": (
-            policy.temporary_default_decision,
-            export_target_manifest_pb2.EXPORT_RETENTION_DECISION_DELETE_AFTER_SUCCESS,
-        ),
-    }
-    for field_name, (actual, expected) in expected_decisions.items():
-        if actual != expected:
-            errors.append(
-                f"retention_policy.{field_name} must be "
-                f"{export_target_manifest_pb2.ExportRetentionDecision.Name(expected)}"
-            )
+    if policy.required_default_decision != _RETENTION_DECISION_RETAIN:
+        errors.append(
+            "retention_policy.required_default_decision must be "
+            f"{_RETENTION_DECISION_NAME(_RETENTION_DECISION_RETAIN)}"
+        )
+    if policy.evidence_default_decision != _RETENTION_DECISION_RETAIN:
+        errors.append(
+            "retention_policy.evidence_default_decision must be "
+            f"{_RETENTION_DECISION_NAME(_RETENTION_DECISION_RETAIN)}"
+        )
+    if policy.runtime_log_default_decision != _RETENTION_DECISION_DELETE_AFTER_TTL:
+        errors.append(
+            "retention_policy.runtime_log_default_decision must be "
+            f"{_RETENTION_DECISION_NAME(_RETENTION_DECISION_DELETE_AFTER_TTL)}"
+        )
+    if policy.intermediate_default_decision != _RETENTION_DECISION_CLEANABLE:
+        errors.append(
+            "retention_policy.intermediate_default_decision must be "
+            f"{_RETENTION_DECISION_NAME(_RETENTION_DECISION_CLEANABLE)}"
+        )
+    if policy.cache_default_decision != _RETENTION_DECISION_CLEANABLE:
+        errors.append(
+            "retention_policy.cache_default_decision must be "
+            f"{_RETENTION_DECISION_NAME(_RETENTION_DECISION_CLEANABLE)}"
+        )
+    if policy.temporary_default_decision != _RETENTION_DECISION_DELETE_AFTER_SUCCESS:
+        errors.append(
+            "retention_policy.temporary_default_decision must be "
+            f"{_RETENTION_DECISION_NAME(_RETENTION_DECISION_DELETE_AFTER_SUCCESS)}"
+        )
     return errors
 
 


### PR DESCRIPTION
## Summary
- Replace per-validation retention decision dictionary allocation with direct fixed-field comparisons in export target manifest validation.
- Add regression coverage that all retention decision error strings remain stable.

## Plan or Spec
- docs/plans/2026-07-01-export-target-manifest-retention-direct-checks.md
- Registered probe: `runtime-export-manifest-validation` in `infra/perf/pr_scoped_probes.json` (existing focused test, coverage, and probe commands cover the changed path).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-manifest-validation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-export-manifest-retention-direct-checks-20260701 --head-repo "$PWD" --output /tmp/runtime_export_manifest_validation_probe.json`

## Coverage and Metrics
- Focused tests: 46 passed.
- Changed-scope coverage: 31/31 measurable changed lines covered (100.00%).
- Local registered probe (`runtime-export-manifest-validation`, Linux): base `elapsed_ms_mean=2105.368`, head `elapsed_ms_mean=2096.622`, delta `-8.746 ms`, speedup `0.415%`; base `peak_bytes_mean=42493.8`, head `peak_bytes_mean=37771.8`; `schema_error_count=0.0` for both.
- CI PR-scoped performance report is required as the final registered probe validation source.

## Known Gaps
- The local performance signal is small and may be noisy; this PR relies on the registered CI probe report before merge.
- This is a Python-only slice verified on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe ran with base/head comparison.
- [ ] GitHub Actions and PR-scoped performance CI completed successfully.
