### PR TITLE
perf: cache empty tool registry selections

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -94,6 +94,17 @@ fallback before allocating the selected-name/source containers or invoking the
 keyword matcher. The receipt shape, `vector_available` flag, fallback reason,
 and selected tool list remain unchanged.
 
+## Slice update: empty selection cache fast path
+
+This incremental slice keeps the same `tool-registry-select-name-index-cache`
+registered probe and narrows the optimization to explicit empty selection
+requests such as `select([])` and `select(())`. The empty selected registry is
+now served from the selection cache before allocating normalization containers,
+while preserving the empty registry metrics snapshot and immutable selection
+semantics. The probe records `empty_selection_elapsed_ms_mean` and
+`empty_selection_tool_count_mean` so CI and local Linux runs validate the hot
+path directly.
+
 ## Acceptance Criteria
 
 - Focused behavior tests pass locally on Linux.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4896,6 +4896,17 @@
         "warn_pct": 5.0
       },
       {
+        "key": "empty_selection_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "empty_selection_tool_count_mean",
+        "unit": "tools",
+        "direction": "informational"
+      },
+      {
         "key": "missing_selection_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -37,6 +37,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     full_config_template_elapsed_samples: list[float] = []
     full_config_template_samples: list[float] = []
     raw_single_config_elapsed_samples: list[float] = []
+    empty_selection_elapsed_samples: list[float] = []
+    empty_selection_tool_count_samples: list[float] = []
     missing_selection_elapsed_samples: list[float] = []
     missing_selection_error_samples: list[float] = []
     selector_planning_elapsed_samples: list[float] = []
@@ -82,6 +84,16 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         raw_single_config_elapsed_samples.append(
             (time.perf_counter() - raw_single_config_started) * 1000.0
         )
+
+        empty_selection_tool_count = 0
+        empty_selection_started = time.perf_counter()
+        for _index in range(full_config_iterations):
+            selected = registry.select([])
+            empty_selection_tool_count += len(selected.tools)
+        empty_selection_elapsed_samples.append(
+            (time.perf_counter() - empty_selection_started) * 1000.0
+        )
+        empty_selection_tool_count_samples.append(float(empty_selection_tool_count))
 
         missing_selection_started = time.perf_counter()
         missing_selection_count = 0
@@ -207,6 +219,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         "full_config_template_hits_mean": statistics.fmean(full_config_template_samples),
         "raw_single_config_elapsed_ms_mean": statistics.fmean(
             raw_single_config_elapsed_samples
+        ),
+        "empty_selection_elapsed_ms_mean": statistics.fmean(
+            empty_selection_elapsed_samples
+        ),
+        "empty_selection_tool_count_mean": statistics.fmean(
+            empty_selection_tool_count_samples
         ),
         "missing_selection_elapsed_ms_mean": statistics.fmean(
             missing_selection_elapsed_samples

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -207,6 +207,19 @@ def test_tool_registry_metrics_snapshot_updates_for_selected_registry() -> None:
     )
 
 
+def test_tool_registry_empty_selection_reuses_cached_registry() -> None:
+    registry = built_in_tool_registry()
+
+    selected = registry.select([])
+
+    assert selected.names() == ()
+    assert selected.metrics().tool_count == 0
+    assert selected.metrics().schema_bytes == 0
+    assert selected.metrics().required_argument_count == 0
+    assert registry.select(()) is selected
+    assert registry.select([]) is selected
+
+
 def test_tool_registry_names_reuses_registry_snapshot() -> None:
     registry = ToolRegistry(built_in_tool_registry().tools)
     expected_names = registry.names()

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -289,6 +289,19 @@ class ToolRegistry:
         return self._metrics
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        if not names:
+            cached_selection = self._selection_cache.get(())
+            if cached_selection is not None:
+                return cached_selection
+            selection = ToolRegistry(
+                (),
+                schema_version=self._schema_version,
+                toolset_version=self._toolset_version,
+                parser=self._parser,
+                parser_contract_version=self._parser_contract_version,
+            )
+            self._selection_cache[()] = selection
+            return selection
         if isinstance(names, tuple):
             if names == self._tool_names:
                 return self


### PR DESCRIPTION
## Summary
- Cache explicit empty tool registry selections before normalization allocates temporary containers.
- Add a focused regression test proving `select([])` / `select(())` reuse the cached empty registry and preserve empty metrics.
- Extend the registered `tool-registry-select-name-index-cache` probe with empty-selection metrics.

## Plan or Spec
- Updated `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md` with the empty selection cache fast path slice.
- Registered probe remains `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- Baseline/head microbench: `uv run --project services/mlx-worker-python python3 /tmp/empty_selection_bench.py` against `origin/main` and this branch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 94 passed.
- Changed-scope coverage: 100% (25/25 measurable changed lines covered).
- Registered probe local head output includes `empty_selection_elapsed_ms_mean=2.4547543842345476`, `empty_selection_tool_count_mean=0.0`.
- Baseline/head empty-selection microbench (16k calls x 5 samples): old_mean=8.736670622602105 ms, new_mean=4.0571009973064065 ms, delta_ms=-4.679570 ms, speedup=2.15x, improvement=53.56%.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- This is a Python-only slice validated locally on Linux; GitHub Actions must confirm the registered PR-scoped performance report in CI.
- No Swift runtime effects are claimed.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance CI completed successfully.
- [ ] Required PR checks are green before merge.
