### PR TITLE
perf: reuse tool selection append helper

### DIFF
--- a/docs/plans/2026-07-01-tool-registry-selection-append-helper.md
+++ b/docs/plans/2026-07-01-tool-registry-selection-append-helper.md
@@ -1,0 +1,60 @@
+# Tool Registry Selection Append Helper Performance Slice
+
+## Scope
+
+This slice keeps agentic tool selection behavior unchanged while moving the hot
+selection append checks out of the per-call nested closure in
+`select_agentic_tools_for_turn`.
+
+Affected paths:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+
+## Motivation
+
+`select_agentic_tools_for_turn` runs on every agentic planning turn. The prior
+implementation rebuilt a nested `add_tool` closure for every call and used that
+closure for always-available, vector, current-turn keyword, and context keyword
+candidate insertion. Reusing a module-level helper removes that per-call closure
+allocation while preserving the existing normalization, deduplication, capacity,
+and built-in-name validation rules.
+
+## Behavior Contract
+
+- Always-available tools remain inserted first.
+- Blank candidate names are ignored.
+- Duplicate candidate names are ignored after normalization.
+- Unknown candidate names are ignored.
+- `max_selected_tools` is still enforced before optional vector or keyword
+  candidates are appended.
+- Vector selection still returns immediately when at least one vector hit is
+  accepted.
+- Keyword fallback behavior remains unchanged when vector selection is absent or
+  produces no accepted hit.
+
+## Registered Probe
+
+The path is covered by the existing PR-scoped probe registry entry:
+
+- `tool-registry-select-name-index-cache`
+- `watch_globs` include `services/mlx-worker-python/worker/runtime/tool_registry.py`,
+  `services/mlx-worker-python/tests/test_tool_registry.py`, and
+  `scripts/tool_registry_select_probe.py`.
+- The registry entry provides focused `test_command`, `coverage_command`, and
+  `probe_command` values.
+
+## Verification Plan
+
+Run from the repository root with `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python"`:
+
+1. Focused pytest for tool registry selection and the registered PR-scoped probe tests.
+2. Changed-scope coverage for the touched Python/test/probe paths.
+3. Registered local probe: `uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`.
+4. Compare the probe output against a clean `origin/main` baseline worktree.
+
+## Decision Criteria
+
+Accept the slice only if focused tests and changed-scope coverage pass, and the
+registered local probe shows an improvement in the primary selection timing while
+any secondary metric regression remains within the registry warning threshold.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -681,6 +681,42 @@ def test_agentic_tool_selection_preserves_always_available_tools_with_vector_hit
     )
 
 
+def test_agentic_tool_selection_caps_vector_hits_without_optional_routing() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Search local evidence, then visit fixture://docs/provider-contract.",
+            vector_selected_tool_ids=("text_search", "visit"),
+            vector_available=True,
+            max_selected_tools=2,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selection_mode"] == "vector"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "text_search", "source": "vector"},
+    ]
+
+
+def test_agentic_tool_selection_ignores_blank_and_duplicate_vector_hits() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Search local evidence.",
+            vector_selected_tool_ids=("", " text_search ", "text_search"),
+            vector_available=True,
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selection_mode"] == "vector"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "text_search", "source": "vector"},
+    ]
+
+
 def test_agentic_tool_selection_uses_builtin_name_set_for_membership() -> None:
     result = select_agentic_tools_for_turn(
         ToolSelectionInput(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -506,6 +506,25 @@ def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> co
     return copy_tool_config(config)
 
 
+def _append_selected_tool(
+    selected_names: list[str],
+    selected_sources: dict[str, str],
+    tool_name: str,
+    source: str,
+    max_selected_tools: int,
+) -> bool:
+    if len(selected_names) >= max_selected_tools:
+        return False
+    normalized_name = tool_name.strip()
+    if not normalized_name or normalized_name in selected_sources:
+        return False
+    if normalized_name not in _BUILTIN_AGENTIC_TOOL_NAME_SET:
+        return False
+    selected_sources[normalized_name] = source
+    selected_names.append(normalized_name)
+    return True
+
+
 def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSelectionResult:
     registry = agentic_tool_catalog_registry()
     max_selected_tools = max(1, selection_input.max_selected_tools)
@@ -520,27 +539,12 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         return _build_always_only_tool_selection_result(registry, selection_input)
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
+    append_selected_tool = _append_selected_tool
     has_vector_selection = False
     has_keyword_selection = False
 
-    def add_tool(tool_name: str, source: str) -> None:
-        nonlocal has_keyword_selection, has_vector_selection
-        if len(selected_names) >= max_selected_tools:
-            return
-        normalized_name = tool_name.strip()
-        if not normalized_name or normalized_name in selected_sources:
-            return
-        if normalized_name not in _BUILTIN_AGENTIC_TOOL_NAME_SET:
-            return
-        selected_sources[normalized_name] = source
-        selected_names.append(normalized_name)
-        if source == "vector":
-            has_vector_selection = True
-        elif source == "keyword" or source == "keyword_context":
-            has_keyword_selection = True
-
     for tool_name in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES:
-        add_tool(tool_name, "always")
+        append_selected_tool(selected_names, selected_sources, tool_name, "always", max_selected_tools)
 
     selection_mode = "fallback"
     fallback_reason = "no_keyword_match"
@@ -556,7 +560,14 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
 
     if selection_input.vector_available and selection_input.vector_selected_tool_ids:
         for tool_name in selection_input.vector_selected_tool_ids:
-            add_tool(tool_name, "vector")
+            if append_selected_tool(
+                selected_names,
+                selected_sources,
+                tool_name,
+                "vector",
+                max_selected_tools,
+            ):
+                has_vector_selection = True
         if has_vector_selection:
             return _build_tool_selection_result(
                 registry,
@@ -570,13 +581,27 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     if selection_mode != "vector":
         current_matches = _keyword_tool_matches(selection_input.current_user_turn)
         for tool_name in current_matches:
-            add_tool(tool_name, "keyword")
+            if append_selected_tool(
+                selected_names,
+                selected_sources,
+                tool_name,
+                "keyword",
+                max_selected_tools,
+            ):
+                has_keyword_selection = True
         if selection_input.recent_user_turns and len(selected_names) < max_selected_tools:
             context_matches = _keyword_tool_matches(
                 _recent_user_turns_keyword_context(selection_input.recent_user_turns)
             )
             for tool_name in context_matches:
-                add_tool(tool_name, "keyword_context")
+                if append_selected_tool(
+                    selected_names,
+                    selected_sources,
+                    tool_name,
+                    "keyword_context",
+                    max_selected_tools,
+                ):
+                    has_keyword_selection = True
         if has_keyword_selection:
             selection_mode = "keyword"
             fallback_reason = "vector_unavailable" if not selection_input.vector_available else "vector_no_match"


### PR DESCRIPTION
## Summary
- Move agentic tool selection candidate insertion to a reusable module-level helper to avoid rebuilding the per-call nested append closure.
- Add regression coverage for capacity-limited vector hits and blank/duplicate vector candidates.
- Document the focused performance slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-07-01-tool-registry-selection-append-helper.md`

## Commands Run
```text
# Focused local tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
  services/mlx-worker-python/tests/test_tool_registry.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# Result: 96 passed in 0.23s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
  services/mlx-worker-python/worker/runtime/tool_registry.py \
  services/mlx-worker-python/tests/test_tool_registry.py \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py \
  scripts/tool_registry_select_probe.py
# Result: TOTAL 29 0 100%

# Registered local probe, default registry settings
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# Result: elapsed_ms_mean=22.52204781398177, selector_planning_elapsed_ms_mean=31.712993630208075

# Registered local probe comparison with larger sample count
MELIX_TOOL_REGISTRY_SELECT_SAMPLES=20 MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=200000 \
  PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# origin/main baseline: elapsed_ms_mean=55.033284559613094, selector_planning_elapsed_ms_mean=86.18932309909724
# PR head: elapsed_ms_mean=55.02690991270356, selector_planning_elapsed_ms_mean=80.09329902124591

git diff --check
# Result: passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 29 0 100%`.
- Registered probe: `tool-registry-select-name-index-cache` (`command_json`, Ubuntu runner) covers `tool_registry.py`, `test_tool_registry.py`, and `scripts/tool_registry_select_probe.py` with focused test, coverage, and probe commands.
- Local Linux probe comparison (`MELIX_TOOL_REGISTRY_SELECT_SAMPLES=20`, `MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=200000`):
  - `elapsed_ms_mean`: `55.033285 -> 55.026910` (`-0.006375 ms`, `-0.01%`)
  - `selector_planning_elapsed_ms_mean`: `86.189323 -> 80.093299` (`-6.096024 ms`, `-7.07%`)
  - `current_capacity_planning_elapsed_ms_mean`: `83.927125 -> 76.510939` (`-7.416186 ms`, `-8.84%`)
  - `always_only_planning_elapsed_ms_mean`: `52.810169 -> 50.807297` (`-2.002872 ms`, `-3.79%`)
  - `whitespace_turn_planning_elapsed_ms_mean`: `52.836074 -> 51.165479` (`-1.670596 ms`, `-3.16%`)
  - `missing_selection_elapsed_ms_mean`: `35.978933 -> 35.318077` (`-0.660856 ms`, `-1.84%`)
  - `empty_selection_elapsed_ms_mean`: `6.065511 -> 6.310847` (`+0.245335 ms`, `+4.04%`, within the registered 5% warning threshold)
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local verification is Linux-only; Swift/macOS runtime behavior is not touched by this PR.
- The registered CI PR-scoped performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
