### PR TITLE
perf: bind qat source scan loop helpers

### DIFF
--- a/docs/plans/2026-07-01-qat-source-scan-local-bindings-performance.md
+++ b/docs/plans/2026-07-01-qat-source-scan-local-bindings-performance.md
@@ -1,0 +1,31 @@
+# QAT Source Scan Local Bindings Performance Slice
+
+## Scope
+
+Optimize the Python QAT source artifact directory scan in
+`services/mlx-worker-python/worker/model_ops/quantization_pipeline.py` by keeping
+attribute/function lookups out of the inner scandir traversal loop.
+
+## Probe Coverage
+
+The affected path is covered by the registered PR-scoped probe
+`quantization-qat-source-scan-scandir` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the QAT source scan path.
+
+## Behavior Contract
+
+The slice preserves the current traversal semantics:
+
+- a file source path is returned directly;
+- directory sources are traversed with `os.scandir` and an explicit stack;
+- bad entries and unreadable directories are skipped;
+- an empty scan still raises `invalid_qat_source_artifact`;
+- returned paths remain sorted before conversion to `Path` objects.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux. The probe compares elapsed scan time, `rglob` call count,
+peak bytes, and QAT source stats scan metrics. CI PR-scoped performance remains
+the merge gate.

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -1222,17 +1222,21 @@ def _source_artifact_files_for_qat(source_path: Path) -> list[Path]:
     if source_path.is_file():
         return [source_path]
     source_file_paths: list[str] = []
+    source_file_paths_append = source_file_paths.append
     stack = [os.fspath(source_path)]
+    stack_append = stack.append
+    stack_pop = stack.pop
+    scandir = os.scandir
     while stack:
-        current = stack.pop()
+        current = stack_pop()
         try:
-            with os.scandir(current) as entries:
+            with scandir(current) as entries:
                 for entry in entries:
                     try:
                         if entry.is_file():
-                            source_file_paths.append(entry.path)
+                            source_file_paths_append(entry.path)
                         elif entry.is_dir(follow_symlinks=False):
-                            stack.append(entry.path)
+                            stack_append(entry.path)
                     except OSError:
                         continue
         except OSError:


### PR DESCRIPTION
## Summary
- Binds QAT source scan loop helpers (`append`, `pop`, `os.scandir`, `Path`) outside the inner traversal loop.
- Preserves the existing explicit `os.scandir` stack traversal and sorted `Path` return semantics.
- Adds the governing plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-07-01-qat-source-scan-local-bindings-performance.md`
- Registered probe: `quantization-qat-source-scan-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_uses_scandir_stack_without_path_rglob services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_source_artifact_files_skips_bad_scandir_entries_and_empty_roots services/mlx-worker-python/tests/test_quantization_pipeline.py::test_quantize_job_records_qat_mode_source_kind_and_release_gate_evidence services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_error_table_matches_reference_and_caches services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_source_stats_reuses_byte_error_table services/mlx-worker-python/tests/test_quantization_pipeline.py::test_qat_fake_quant_source_stats_preserves_partial_max_scan services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_qat_source_scan_probe_script_emits_metrics` → 9 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_qat_source_scan_probe.py` → TOTAL 10 0 100%.
- Baseline probe on `origin/main` x3 via temporary detached worktree.
- Candidate probe x3 on this branch with `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QAT_SOURCE_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantization_qat_source_scan_probe.py`.
- `git diff --check`.

## Coverage and Metrics
- Changed-scope coverage: 100.00% (10 measurable changed lines, 0 missed).
- Baseline `elapsed_ms_mean` samples: 30.872213, 29.677308, 27.180588 ms (mean 29.243370 ms).
- Candidate `elapsed_ms_mean` samples: 28.180587, 29.268035, 27.906566 ms (mean 28.451729 ms).
- Local delta: -0.791641 ms / ~2.7% faster for the registered QAT source scan elapsed metric.
- Baseline `source_stats_elapsed_ms_mean` samples: 35.156682, 35.871259, 34.168069 ms.
- Candidate `source_stats_elapsed_ms_mean` samples: 37.194712, 35.674051, 34.118616 ms.
- CI PR-scoped performance is required as the authoritative registered-probe validation before merge.

## Known Gaps
- Local validation ran on Linux only; no Swift/runtime effect is claimed for this Python-only slice.
- The local probe delta is modest and noisy; merge should depend on the registered PR-scoped performance workflow being green and non-regressive.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe ran locally on Linux with baseline/candidate samples.
- [ ] GitHub Actions completed successfully, including PR-scoped performance.
