### PR TITLE
perf: bind vision prompt token media scans

### DIFF
--- a/docs/plans/2026-07-01-vision-family-prompt-token-count-local-bindings.md
+++ b/docs/plans/2026-07-01-vision-family-prompt-token-count-local-bindings.md
@@ -1,0 +1,39 @@
+# Vision Family Prompt Token Count Local Bindings
+
+## Scope
+
+This Python-only performance slice is limited to `ResolvedVisionFamilyConfig.prompt_token_count()` in `services/mlx-worker-python/worker/runtime/vision_family_adapters.py`.
+
+The slice keeps behavior unchanged while reducing repeated hot-path attribute lookups by binding the prepared request media collections once before the image and video token scans.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `vision-family-prompt-token-count-scan` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for focused vision-family token-count behavior and probe-registry tests.
+- `coverage_command` for changed-scope coverage of the adapter, shared token counting helper, tests, and probe script.
+- `probe_command` via `scripts/vision_family_prompt_token_count_probe.py`.
+
+## Verification
+
+Run before PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_same_media_request_cache services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_vision_runtime.py::test_resolved_vision_family_config_uses_slots_for_hot_path_instances services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_same_media_request_cache services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_vision_runtime.py::test_resolved_vision_family_config_uses_slots_for_hot_path_instances services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py
+```
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py
+```
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage is at least 95%.
+- Registered probe remains neutral or improves for `elapsed_ms_mean` without increasing split calls.

--- a/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/vision_family_adapters.py
@@ -88,7 +88,10 @@ class ResolvedVisionFamilyConfig:
     def prompt_token_count(self, prepared_request: PreparedVisionRequest) -> int:
         if prepared_request is self._last_media_prompt_request:
             return self._last_media_prompt_token_count
-        has_media = bool(prepared_request.images or prepared_request.video_frame_policies)
+
+        images = prepared_request.images
+        video_frame_policies = prepared_request.video_frame_policies
+        has_media = bool(images or video_frame_policies)
 
         prompt_tokens = _whitespace_token_count(prepared_request.prompt_text)
 
@@ -97,7 +100,7 @@ class ResolvedVisionFamilyConfig:
             image_token_divisor = 1
         image_tokens = 0
         image_multi_token_threshold = image_token_divisor * 2
-        for image in prepared_request.images:
+        for image in images:
             byte_count = len(image.bytes_data)
             if byte_count < image_multi_token_threshold:
                 image_tokens += 1
@@ -109,7 +112,7 @@ class ResolvedVisionFamilyConfig:
             video_frame_token_cost = 1
         video_frame_count = 0
         empty_video_frame_policies = 0
-        for policy in prepared_request.video_frame_policies:
+        for policy in video_frame_policies:
             effective_frame_count = policy.effective_frame_count
             if effective_frame_count > 0:
                 video_frame_count += effective_frame_count


### PR DESCRIPTION
## Summary
- Bind vision prompt-token media collections once before image/video scans.
- Add a scoped plan for the registered `vision-family-prompt-token-count-scan` slice.

## Plan or Spec
- `docs/plans/2026-07-01-vision-family-prompt-token-count-local-bindings.md`
- Registered probe: `vision-family-prompt-token-count-scan` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_matches_split_without_materializing_tokens services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_cached_prompt_scan services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_reuses_same_media_request_cache services/mlx-worker-python/tests/test_vision_runtime.py::test_vision_family_prompt_token_count_clamps_media_minimums services/mlx-worker-python/tests/test_vision_runtime.py::test_resolved_vision_family_config_uses_slots_for_hot_path_instances services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_vision_family_prompt_token_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_rejects_http_and_private_remote_image_inputs services/mlx-worker-python/tests/test_vision_runtime.py::test_bytes_from_local_image_uri_reuses_single_parsed_uri services/mlx-worker-python/tests/test_vision_runtime.py::test_prepare_vision_request_parses_each_image_uri_once` — pass, 10 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/vision_family_adapters.py services/mlx-worker-python/worker/runtime/token_counting.py services/mlx-worker-python/tests/test_vision_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/vision_family_prompt_token_count_probe.py` — pass
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/vision_family_prompt_token_count_probe.py` — run 3 times locally
- `git diff --check` — pass

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`
- Local registered probe baseline (3 runs before change): `elapsed_ms_mean` mean `0.143765 ms`; `split_calls_mean=0.0`; `peak_bytes_mean=157.714`; `config_object_footprint_bytes=312`; `token_count=1309`
- Local registered probe after change (3 runs): `elapsed_ms_mean` mean `0.139977 ms`; delta `-0.003788 ms` (`-2.63%`); `split_calls_mean=0.0`; `peak_bytes_mean=157.714`; `config_object_footprint_bytes=312`; `token_count=1309`
- CI PR-scoped performance report is required for merge validation.

## Known Gaps
- Linux local validation covers the Python runtime behavior and registered probe. No Swift runtime behavior is changed in this slice.

## Evidence Checklist
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe was run before and after the change.
- [x] PR body keeps required template headings.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
