### PR TITLE
perf: avoid export smoke waiver set allocation

### DIFF
--- a/docs/plans/2026-07-01-runtime-export-smoke-waiver-direct-membership.md
+++ b/docs/plans/2026-07-01-runtime-export-smoke-waiver-direct-membership.md
@@ -1,0 +1,30 @@
+# Runtime Export Smoke Waiver Direct Membership
+
+## Status
+
+Accepted slice for 2026-07-01 performance iteration.
+
+## Scope
+
+This slice keeps the runtime export smoke policy behavior unchanged while
+removing one small allocation in the waiver path. `_waiver_for_load_failure()` no
+longer materializes `allowed_waiver_reasons` into a temporary `set` before
+checking for `EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED`.
+
+## Probe Coverage
+
+The affected code path is already covered by the registered PR-scoped probe
+`runtime-export-smoke-policy` in `infra/perf/pr_scoped_probes.json` with focused
+`test_command`, `coverage_command`, and `probe_command` entries. The probe emits
+`elapsed_ms_mean`, `peak_bytes_mean`, target count, latency buckets, and waiver
+counters.
+
+## Validation Plan
+
+- Add a regression test proving the waiver membership check does not materialize
+  a temporary set.
+- Run the focused runtime export smoke policy tests.
+- Run the registered changed-scope coverage command.
+- Run the registered runtime export smoke policy probe locally on Linux before
+  pushing.
+- Use the PR-scoped performance workflow as the merge gate.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6479,6 +6479,7 @@
       "scripts/runtime_export_smoke_policy_probe.py",
       "infra/perf/pr_scoped_probes.json",
       "docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md",
+      "docs/plans/2026-07-01-runtime-export-smoke-waiver-direct-membership.md",
       "docs/runbooks/runtime-export-smoke-policy.md"
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -154,6 +154,53 @@ def test_export_target_smoke_records_runtime_unavailable_waiver(
     assert updated_report["ok"] is True
 
 
+def test_export_target_smoke_waiver_reason_membership_avoids_set_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = FIXTURE_ROOT / "ollama/export-target-manifest.json"
+    export_report = materialize_export_target_layout(
+        manifest_path,
+        tmp_path,
+        create_placeholder_files=True,
+    )
+    target_root = tmp_path / str(export_report["target_root"])
+    manifest, validation_report = validate_export_target_manifest_file(
+        target_root / "export-target-manifest.json",
+        return_manifest=True,
+    )
+    assert validation_report.ok is True
+
+    load_check = export_target_smoke._CheckResult(
+        status=export_target_smoke.CHECK_STATUS_FAILED,
+        started_at="2026-07-01T00:00:00Z",
+        ended_at="2026-07-01T00:00:00Z",
+        duration_ms=0.0,
+        timeout_ms=1000,
+        failure_code="runtime_not_installed",
+        failure_message="runtime binary not installed: ollama",
+        evidence_path="smoke/smoke-receipt.json",
+        diagnostics_receipt_path="diagnostics/diagnostics-receipt.json",
+    )
+
+    def fail_set(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError(  # pragma: no cover - exercised only on regression
+            "waiver reason membership should not materialize a set"
+        )
+
+    monkeypatch.setattr(export_target_smoke, "set", fail_set, raising=False)
+
+    waiver = export_target_smoke._waiver_for_load_failure(
+        manifest,
+        load_check,
+        operator_id="ci-smoke",
+        now=0.0,
+    )
+
+    assert waiver is not None
+    assert waiver["reason"] == "EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED"
+
+
 def test_export_target_smoke_bounds_generation_preview_and_omits_host_paths(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -434,10 +434,11 @@ def _waiver_for_load_failure(
         return None
     if load_check.failure_code != "runtime_not_installed":
         return None
-    allowed = set(manifest.verification_policy.allowed_waiver_reasons)
+    if not manifest.verification_policy.waiver_allowed:
+        return None
     if (
-        not manifest.verification_policy.waiver_allowed
-        or export_target_manifest_pb2.EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED not in allowed
+        export_target_manifest_pb2.EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED
+        not in manifest.verification_policy.allowed_waiver_reasons
     ):
         return None
     reason = "EXPORT_WAIVER_REASON_RUNTIME_NOT_INSTALLED"


### PR DESCRIPTION
## Summary
- Avoid a temporary `set()` allocation in the runtime export smoke waiver membership check.
- Add a regression test that fails if `_waiver_for_load_failure()` materializes `allowed_waiver_reasons` into a set.
- Register the new slice plan path under the existing `runtime-export-smoke-policy` PR-scoped probe.

## Plan or Spec
- Added `docs/plans/2026-07-01-runtime-export-smoke-waiver-direct-membership.md`.
- Existing registered probe: `runtime-export-smoke-policy` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_waiver_reason_membership_avoids_set_materialization` (expected red before implementation)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_smoke_policy_probe.py`
- `MELIX_RUNTIME_EXPORT_SMOKE_PROBE_ITERATIONS=10 MELIX_RUNTIME_EXPORT_SMOKE_PROBE_SAMPLES=3 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 16 passed.
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Baseline local probe (10 iterations x 3 samples): `elapsed_ms_mean=1008.3369696512818`, `peak_bytes_mean=1170987.0`.
- New local probe (10 iterations x 3 samples): `elapsed_ms_mean=982.1842503345882`, `peak_bytes_mean=1177994.3333333333`.
- Local delta: `elapsed_ms_mean -26.1527193166936 ms` (~2.59% lower); `peak_bytes_mean +7007.3333333333 bytes` (~0.60% higher).
- Registered default local probe (30 iterations x 5 samples): `elapsed_ms_mean=3068.647229578346`, `peak_bytes_mean=1198856.0`, `target_count=4.0`, `timeout_count=0.0`.

## Known Gaps
- Linux local validation covers the Python runtime export smoke policy path only.
- The PR-scoped performance workflow is still required as the registered CI validation source before merge.

## Evidence Checklist
- [x] Focused test added and failed before implementation.
- [x] Focused tests pass after implementation.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe exists with focused test, coverage, and probe commands.
- [x] Local registered probe ran successfully.
- [ ] GitHub Actions and PR-scoped performance probe are green.
