### PR TITLE
perf: bind native mtp extra shard string helpers

### DIFF
--- a/docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md
+++ b/docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md
@@ -1,0 +1,37 @@
+# Native MTP Loader Extra-Path Local Bindings
+
+## Scope
+
+This Python-only performance slice is limited to
+`services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` and the
+native-MTP sidecar shard discovery hot path. It preserves the existing behavior:
+only top-level native-MTP `*.safetensors` sidecar shards referenced by the model
+index are loaded, duplicate index entries are skipped, missing listed shards are
+warned and ignored, and base `model*.safetensors` files remain excluded from the
+sidecar list.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+That probe already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the native-MTP loader, regression tests, and the
+JSON-emitting performance probe script.
+
+## Slice plan
+
+1. Keep the existing scandir and index-filtering behavior unchanged.
+2. Narrow the implementation to local bindings for repeated string helper calls
+   in `_extra_mtp_safetensor_file_paths(...)` so the hot loop avoids repeated
+   attribute lookup while scanning large native-MTP index maps.
+3. Reuse the existing native-MTP regression tests and changed-scope coverage
+   command from the registered probe.
+4. Run the registered probe locally on Linux before opening the PR. GitHub
+   Actions PR-scoped performance remains the merge gate for the registered probe
+   report.
+
+## Validation boundary
+
+This slice changes Python worker code only. Linux local validation covers the
+Python regression tests, changed-scope coverage, and registered probe command.
+No Swift/macOS runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -80,23 +80,28 @@ def _extra_mtp_safetensor_file_paths(model_path: Path) -> list[str]:
     path_sep = os.sep
     key_prefixes = _MTP_WEIGHT_KEY_PREFIXES
     to_text = str
+    str_startswith = str.startswith
+    str_endswith = str.endswith
+    str_rfind = str.rfind
+    safetensors_suffix = ".safetensors"
+    model_prefix = "model"
     for key, file_name in weight_map.items():
         if type(key) is str:
-            if not key.startswith(key_prefixes):
+            if not str_startswith(key, key_prefixes):
                 continue
-        elif not to_text(key).startswith(key_prefixes):
+        elif not str_startswith(to_text(key), key_prefixes):
             continue
         if type(file_name) is str:
             file_name_text = file_name
         else:
             file_name_text = to_text(file_name)
-        if not file_name_text.endswith(".safetensors"):
+        if not str_endswith(file_name_text, safetensors_suffix):
             continue
         if file_name_text in seen:
             continue
-        separator_index = file_name_text.rfind(path_sep)
+        separator_index = str_rfind(file_name_text, path_sep)
         file_basename = file_name_text if separator_index < 0 else file_name_text[separator_index + 1 :]
-        if file_basename.startswith("model"):
+        if str_startswith(file_basename, model_prefix):
             continue
         seen_add(file_name_text)
         path_text = path_join(model_path_text, file_name_text)


### PR DESCRIPTION
## Summary
- Binds repeated string helper calls in the native-MTP extra shard discovery loop.
- Keeps native-MTP sidecar filtering semantics unchanged while reducing hot-loop attribute lookups.
- Adds the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md`
- Registered PR-scoped probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics` → 11 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q ... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` → 9 passed; changed-line coverage 100.00%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 10/10 measurable changed lines covered, 100.00%.
- Local registered probe JSON: `old_mean_ms=9.0534`, `new_mean_ms=8.5652`, `delta_ms=-0.4882`, `speedup=1.0570`.
- Native-MTP extra shard submetric: `extra_old_mean_ms=198.0260`, `extra_new_mean_ms=35.5603`, `extra_delta_ms=-162.4657`, `extra_speedup=5.5687`.
- PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Linux local validation covers Python behavior and probe metrics only; no Swift/macOS runtime effect is claimed.
- The optimization is intentionally narrow and does not change native-MTP loader behavior or generated artifacts.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused Python tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally and emitted JSON metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
