### PR TITLE
perf: short-circuit export private marker scans

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -171,6 +171,13 @@ fast path for rendered excerpt lines. ASCII runtime log lines now account for
 `len(rendered) + 1` directly and only encode the uncommon non-ASCII path, while
 clipped ASCII lines preserve the existing newline-inclusive byte boundary.
 
+A follow-up 2026-07-01 private-line marker scan slice keeps the redaction
+contract unchanged while short-circuiting prompt/response label checks before
+building lowercased prefix substrings. The marker helper now checks the second
+character for the `p*` and `r*` branches first, so common runtime lines such as
+`runtime load failed ...` and ordinary `plain ...` status lines can skip the
+anchored private-text regex without transient lowercased prefix strings.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -160,9 +160,13 @@ def test_export_target_diagnostics_identity_marker_fast_path_matches_markers(
     ("text", "expected"),
     [
         ("plain runtime status", False),
+        ("p", False),
+        ("R", False),
         ("  prompt: private customer prompt", True),
         ("Private prompt template: hidden", True),
+        ("\tPrIvAtE pRoMpT tEmPlAtE: hidden", True),
         ("Response=private completion", True),
+        ("runtime load failed at /tmp/melix/model", False),
         ("completion: private text", True),
         ("generated text: hidden", True),
         ("dataset row: hidden", True),

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -668,9 +668,19 @@ def _has_private_text_line_marker(text: str) -> bool:
         return False
     first = stripped[0]
     if first == "p" or first == "P":
+        if len(stripped) < 2:
+            return False
+        second = stripped[1]
+        if second != "r" and second != "R":
+            return False
         leading = stripped[:23].lower()
         return leading.startswith("prompt") or leading.startswith("private prompt template")
     if first == "r" or first == "R":
+        if len(stripped) < 2:
+            return False
+        second = stripped[1]
+        if second != "e" and second != "E":
+            return False
         return stripped[:8].lower() == "response"
     if first == "c" or first == "C":
         return stripped[:10].lower() == "completion"


### PR DESCRIPTION
## Summary
- Short-circuit runtime export diagnostic private-text marker checks for common `p*`/`r*` non-marker lines before lowercasing prefix substrings.
- Add boundary coverage for single-character marker candidates and mixed-case private prompt labels.
- Document the 2026-07-01 private-line marker scan slice in the diagnostic parser plan.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the private-line marker scan slice and validation boundary.
- Uses existing registered PR-scoped probe `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`; it already includes focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
- `PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_export_target_diagnostics.py -q` → 70 passed
- `PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py` → 76 passed; changed-line coverage 100%
- `PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py` → exit 0
- `python3 /tmp/runtime_export_private_marker_compare.py` → behavior parity with origin/main and marker microbenchmark
- `git diff --check` → exit 0

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local probe sample: `elapsed_ms_mean=2640.201480756514`, `path_redaction_elapsed_ms_mean=19.134729402139783`, `diagnosis_matching_elapsed_ms_mean=0.5989224184304476`, `peak_bytes_mean=202969.6`.
- Targeted marker microbenchmark vs `origin/main`: `old_mean=24.226356866872973ms`, `new_mean=21.324606004378033ms`, `delta_ms=-2.9017508624949393`, `speedup_pct=11.977660852766444`.

## Known Gaps
- Local validation is Linux-only. This slice touches Python diagnostic parsing, so Swift/macOS runtime effects are not applicable.
- The registered PR-scoped performance workflow must validate the probe in CI before merge.

## Evidence Checklist
- [x] Affected path is covered by registered PR-scoped probe `runtime-export-diagnostic-parser`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally.
- [x] Behavior parity checked against `origin/main` for representative marker inputs.
- [ ] GitHub Actions PR-scoped performance probe passed.
