### PR TITLE
perf: build selected tool receipts directly

### DIFF
--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -662,7 +662,7 @@ def _build_tool_selection_result(
         selected_registry = registry.select(tuple(selected_names))
         selected_tools = [
             {"tool_id": tool_name, "source": selected_sources[tool_name]}
-            for tool_name in selected_registry.names()
+            for tool_name in selected_names
         ]
     registry_metrics = registry.metrics()
     selected_metrics = selected_registry.metrics()


### PR DESCRIPTION
## Summary
- Build multi-tool selection receipt entries from the already-normalized `selected_names` list.
- Avoid the extra `selected_registry.names()` tuple method hop after `registry.select(...)` has already validated/cached the selected registry.

## Plan or Spec
- `AGENTS.md` performance-slice guidance and registered probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
- Behavior docs: N/A, no user-visible behavior or workflow changes.

## Commands Run
```text
# Baseline, origin/main (ac9e99c2)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; representative elapsed_ms_mean=23.715664772316813, selector_planning_elapsed_ms_mean=30.91284518595785

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 96 passed in 1.19s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; 96 passed in 0.51s; TOTAL 0 0 100%

# Registered probe, head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; representative elapsed_ms_mean=22.252886230126023, selector_planning_elapsed_ms_mean=31.94916839711368

# Alternating base/head probe spot-checks
# base elapsed_ms_mean: 23.715664772316813, 23.848529788665473, 22.7346213767305
# head elapsed_ms_mean: 22.252886230126023, 24.79908182285726, 21.94337439723313
# base selector_planning_elapsed_ms_mean: 30.91284518595785, 36.71898120082915, 31.99905282817781
# head selector_planning_elapsed_ms_mean: 31.94916839711368, 31.611817376688123, 30.84805915132165

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` from `scripts/changed_scope_coverage.py` for the touched tool-registry/probe/test scope.
- Registered local probe: `tool-registry-select-name-index-cache`.
- Local Linux probe mean over three alternating base/head runs:
  - `elapsed_ms_mean`: base `23.43293864590426` ms → head `22.99844748340547` ms (`-0.43449116249879083` ms, `1.8541898182912435%` faster).
  - `selector_planning_elapsed_ms_mean`: base `33.21029307165494` ms → head `31.46968164170782` ms (`-1.7406114299471191` ms, `5.2411805767313%` faster).
- CI PR-scoped performance workflow is required as the merge validation source.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this one-line Python hot-path slice; CI must validate broader gates.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated.
- [x] Dependency changes include updated lockfiles, or N/A is stated.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
