### PR TITLE
perf: fast-path canonical tool append names

### DIFF
--- a/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
+++ b/docs/plans/2026-05-18-tool-registry-select-name-index-cache.md
@@ -105,6 +105,17 @@ semantics. The probe records `empty_selection_elapsed_ms_mean` and
 `empty_selection_tool_count_mean` so CI and local Linux runs validate the hot
 path directly.
 
+## Slice update: canonical selected-name append fast path
+
+This incremental slice keeps the same `tool-registry-select-name-index-cache`
+registered probe and narrows the optimization to `select_agentic_tools_for_turn()`
+append operations where selected tool ids are already canonical registry names.
+The append helper now avoids an unconditional `str.strip()` call for non-empty
+names with no leading or trailing whitespace, while preserving whitespace
+normalization, blank rejection, deduplication, max-selection limits, and unknown
+tool filtering. The probe's `selector_planning_elapsed_ms_mean` and
+`current_capacity_planning_elapsed_ms_mean` metrics exercise this path directly.
+
 ## Acceptance Criteria
 
 - Focused behavior tests pass locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -328,6 +328,52 @@ def test_tool_registry_select_trims_blanks_and_deduplicates_in_one_pass() -> Non
     assert selected.names() == ("visit", "image_crop")
 
 
+def test_append_selected_tool_skips_strip_for_canonical_names() -> None:
+    class StripCountingName(str):
+        strip_calls = 0
+
+        def strip(self, chars: str | None = None) -> str:
+            type(self).strip_calls += 1
+            return super().strip(chars)
+
+    selected_names: list[str] = []
+    selected_sources: dict[str, str] = {}
+    canonical_name = StripCountingName("text_search")
+
+    assert tool_registry_module._append_selected_tool(
+        selected_names,
+        selected_sources,
+        canonical_name,
+        "keyword",
+        4,
+    )
+
+    assert StripCountingName.strip_calls == 0
+    assert selected_names == ["text_search"]
+    assert selected_sources == {"text_search": "keyword"}
+
+    whitespace_name = StripCountingName("  visit  ")
+    assert tool_registry_module._append_selected_tool(
+        selected_names,
+        selected_sources,
+        whitespace_name,
+        "keyword",
+        4,
+    )
+    assert StripCountingName.strip_calls == 1
+    assert selected_names == ["text_search", "visit"]
+    assert selected_sources["visit"] == "keyword"
+
+    assert not tool_registry_module._append_selected_tool(
+        selected_names,
+        selected_sources,
+        StripCountingName("   "),
+        "keyword",
+        4,
+    )
+    assert StripCountingName.strip_calls == 2
+
+
 def test_tool_registry_select_reuses_cached_name_index() -> None:
     registry = ToolRegistry(built_in_tool_registry().tools)
     object.__setattr__(registry, "_tools", ())

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -513,10 +513,15 @@ def _append_selected_tool(
     source: str,
     max_selected_tools: int,
 ) -> bool:
-    if len(selected_names) >= max_selected_tools:
+    if len(selected_names) >= max_selected_tools or not tool_name:
         return False
-    normalized_name = tool_name.strip()
-    if not normalized_name or normalized_name in selected_sources:
+    if tool_name[0].isspace() or tool_name[-1].isspace():
+        normalized_name = tool_name.strip()
+        if not normalized_name:
+            return False
+    else:
+        normalized_name = tool_name
+    if normalized_name in selected_sources:
         return False
     if normalized_name not in _BUILTIN_AGENTIC_TOOL_NAME_SET:
         return False


### PR DESCRIPTION
## Summary
- Fast-path canonical agentic tool names in `_append_selected_tool()` by skipping an unconditional `str.strip()` when the name has no edge whitespace.
- Add regression coverage proving canonical names avoid `strip()` while whitespace normalization and blank rejection remain intact.
- Update the tool registry select-name-index performance plan for this incremental slice.

## Plan or Spec
- `docs/plans/2026-05-18-tool-registry-select-name-index-cache.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` (has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_append_selected_tool_skips_strip_for_canonical_names services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_select_trims_blanks_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics
# 3 passed in 1.26s

# Registered probe test_command for tool-registry-select-name-index-cache
bash /tmp/tool_test_cmd.sh
# 97 passed in 0.32s

# Registered probe coverage_command for tool-registry-select-name-index-cache
bash /tmp/tool_cov_cmd.sh
# 97 passed in 0.51s; changed-scope coverage TOTAL 27 0 100%

# Registered probe_command for tool-registry-select-name-index-cache
bash /tmp/tool_select_cmd.sh
# emitted command_json metrics successfully

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 27 0 100%`.
- Baseline local Linux probe from `origin/main` before change:
  - `elapsed_ms_mean=27.285009995102882`
  - `selector_planning_elapsed_ms_mean=34.301724447868764`
  - `current_capacity_planning_elapsed_ms_mean=30.6546674342826`
  - `raw_single_config_elapsed_ms_mean=16.450704401358962`
- Head local Linux probe after change:
  - `elapsed_ms_mean=22.27208218537271`
  - `selector_planning_elapsed_ms_mean=31.85947840102017`
  - `current_capacity_planning_elapsed_ms_mean=31.688112462870777`
  - `raw_single_config_elapsed_ms_mean=15.821768180467188`
- Direction: overall repeated-selection probe improved by about 18.37%; selector planning improved by about 7.12%. Current-capacity submetric was noise/slightly worse locally, so CI registered probe remains the merge gate.

## Known Gaps
- CI PR-scoped performance report is required before merge.
- Local validation is Linux/Python-only; no Swift runtime path is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
