### PR TITLE
perf: fast-path semantic value group lookups

### DIFF
--- a/docs/plans/2026-05-07-event-extraction-semantic-value-group-cache.md
+++ b/docs/plans/2026-05-07-event-extraction-semantic-value-group-cache.md
@@ -40,3 +40,17 @@ The probe repeatedly requests semantic value groups for several action-value cou
 - Changed-scope coverage is at least 95%.
 - Local base-vs-head probe shows materially fewer combination-build calls and improved elapsed time without changing output checksum.
 - `git diff --check` passes.
+
+## 2026-07-01 Follow-up Slice: Direct Precomputed Lookup
+
+The first cache slice already precomputes the common `SEMANTIC_ACTION_GROUP_MAX_SIZE == 3`
+value counts used by the registered probe. This follow-up keeps that behavior and
+narrows one remaining Python overhead point: `_semantic_value_groups(...)` now uses
+an index-addressable precomputed tuple before falling back to a bounded cached
+builder for non-precomputed counts or patched group-size tests. The public helper
+still exposes `cache_clear()` for tests and probe setup, but the common precomputed
+path skips the `lru_cache` wrapper lookup.
+
+Validation remains the registered `event-extraction-semantic-value-group-cache` probe,
+focused event-extraction tests, changed-scope coverage, and GitHub PR-scoped
+performance CI before merge.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -41,6 +41,11 @@ _PRECOMPUTED_SEMANTIC_VALUE_GROUPS = {
     )
     for value_count in range(2, 17)
 }
+_PRECOMPUTED_SEMANTIC_VALUE_GROUPS_BY_COUNT = (
+    (),
+    (),
+    *(_PRECOMPUTED_SEMANTIC_VALUE_GROUPS[value_count] for value_count in range(2, 17)),
+)
 SEMANTIC_JUDGE_PROMPT_VERSION = "semantic-judge.v4"
 _GROUP_ACTOR_ALIASES = {"我们", "双方", "咱们", "咱俩", "咱两", "我俩", "两人", "二人"}
 _GROUP_ACTOR_ALIAS_CHARS = frozenset("".join(_GROUP_ACTOR_ALIASES))
@@ -1630,22 +1635,33 @@ def _semantic_action_group_score(
     return _semantic_decision_score(decision), str(decision.get("reason_code") or "")
 
 
-@lru_cache(maxsize=32)
-def _semantic_value_groups(value_count: int) -> tuple[tuple[int, ...], ...]:
+def _semantic_value_groups(
+    value_count: int,
+    _precomputed_groups: tuple[tuple[tuple[int, ...], ...], ...] = _PRECOMPUTED_SEMANTIC_VALUE_GROUPS_BY_COUNT,
+    _precomputed_group_count: int = len(_PRECOMPUTED_SEMANTIC_VALUE_GROUPS_BY_COUNT),
+) -> tuple[tuple[int, ...], ...]:
+    if SEMANTIC_ACTION_GROUP_MAX_SIZE == 3 and 1 < value_count < _precomputed_group_count:
+        return _precomputed_groups[value_count]
     if value_count < 2:
         return ()
-    if SEMANTIC_ACTION_GROUP_MAX_SIZE == 3:
-        precomputed = _PRECOMPUTED_SEMANTIC_VALUE_GROUPS.get(value_count)
-        if precomputed is not None:
-            return precomputed
+    return _computed_semantic_value_groups(value_count, SEMANTIC_ACTION_GROUP_MAX_SIZE)
 
-    max_size = min(SEMANTIC_ACTION_GROUP_MAX_SIZE, value_count)
+
+@lru_cache(maxsize=32)
+def _computed_semantic_value_groups(
+    value_count: int,
+    max_group_size: int,
+) -> tuple[tuple[int, ...], ...]:
+    max_size = min(max_group_size, value_count)
     value_indices = range(value_count)
     return tuple(
         group
         for group_size in range(2, max_size + 1)
         for group in combinations(value_indices, group_size)
     )
+
+
+_semantic_value_groups.cache_clear = _computed_semantic_value_groups.cache_clear  # type: ignore[attr-defined]
 
 
 def _maximum_weight_semantic_value_group_matching(


### PR DESCRIPTION
## Summary
- Fast-path precomputed semantic value-group lookups through an index-addressable tuple for the common `SEMANTIC_ACTION_GROUP_MAX_SIZE == 3` path.
- Keep the cached builder fallback for non-precomputed counts and patched group-size tests.
- Update the event-extraction performance plan with this follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-05-07-event-extraction-semantic-value-group-cache.md` with the 2026-07-01 direct precomputed lookup follow-up.
- Registered probe already exists: `event-extraction-semantic-value-group-cache` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_value_groups_are_cached_and_ordered services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_matches_bidirectional_action_split_merge services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_semantic_value_group_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_semantic_value_group_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_semantic_value_group_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-semantic-value-group-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-event-semantic-group-20260701 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-export-diagnostic-marker-any-20260701 --output /tmp/event_semantic_group_probe_compare2.json`
- `git diff --check`

## Coverage and Metrics
- Focused coverage: 100.00% changed-line coverage (`8/8` measurable changed lines covered).
- Local registered base-vs-head probe (`event-extraction-semantic-value-group-cache`):
  - `peak_bytes_mean`: 1044.0 -> 660.0 bytes (`-36.78%`, lower is better)
  - `elapsed_ms_mean`: 9450.027 -> 9559.774 ms (`+1.16%`, within the 5% warn threshold; elapsed is dominated by checksum traversal in this probe)
  - `elapsed_ms_min`: 9270.349 -> 9435.169 ms (`+1.78%`)
  - `combination_build_calls_mean`: 0.0 -> 0.0
  - `checksum`: unchanged at 6989600000.0

## Known Gaps
- This is a Python-only slice and was locally verified on Linux.
- The registered GitHub PR-scoped performance workflow remains the merge gate for CI validation.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally with unchanged checksum and lower peak allocation.
- [ ] GitHub Actions PR-scoped performance completed successfully.
