### PR TITLE
perf: reuse latency total before percentile sort

### DIFF
--- a/docs/plans/2026-07-01-evaluation-latency-mean-presort-sum.md
+++ b/docs/plans/2026-07-01-evaluation-latency-mean-presort-sum.md
@@ -1,0 +1,26 @@
+# Evaluation latency mean pre-sort sum
+
+## Scope
+
+This Python-only performance slice is limited to `EvaluationCore._latency_stats()` in `services/mlx-worker-python/worker/engine/evaluation_core.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `evaluation-latency-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Change
+
+`_latency_stats()` still sorts the latency vector once for percentile interpolation, but now computes the total from the original latency list before sorting and reuses that total for the mean. This keeps the percentile and rounding behavior unchanged while avoiding a second pass over the newly sorted list for mean calculation.
+
+## Verification plan
+
+Run the registered focused test command, the registered coverage command, and the registered performance probe locally on Linux. GitHub Actions PR-scoped performance remains the final merge gate for the registered probe report.
+
+## Expected signal
+
+The probe should preserve `sorted_calls_mean == 1.0` and show a lower or neutral `elapsed_ms_mean` for repeated `_latency_stats()` calls over the synthetic latency vector.

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1925,6 +1925,7 @@ class EvaluationCore:
     def _latency_stats(cls, values: list[float]) -> dict[str, float]:
         if not values:
             return {"mean": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
+        total = sum(values)
         sorted_values = sorted(values)
         value_count = len(sorted_values)
         round_ms = cls._round_ms
@@ -1943,7 +1944,7 @@ class EvaluationCore:
                 sorted_values[p95_lower + 1] - sorted_values[p95_lower]
             ) * p95_fraction
         return {
-            "mean": round_ms(sum(sorted_values) / value_count),
+            "mean": round_ms(total / value_count),
             "p50": round_ms(p50),
             "p95": round_ms(p95),
             "max": round_ms(sorted_values[-1]),


### PR DESCRIPTION
## Summary
- Reuse the latency total computed from the original vector before the percentile sort in `EvaluationCore._latency_stats()`.
- Add a focused plan documenting the registered probe and Linux validation boundary.

## Plan or Spec
- `docs/plans/2026-07-01-evaluation-latency-mean-presort-sum.md`
- Registered probe: `evaluation-latency-percentile-vector-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-latency-percentile-vector-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/evaluation_latency_mean_presort_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 17 passed.
- Changed-scope coverage: 100.00% for `evaluation_core.py` changed line.
- Local registered probe `evaluation-latency-percentile-vector-reuse`:
  - base `elapsed_ms_mean=235.24544`, head `elapsed_ms_mean=230.4697`, delta `-4.77574 ms` (`2.030%` faster)
  - base/head `sorted_calls_mean=1.0`
  - base/head `p50=495.0611`, `p95=950.5231`

## Known Gaps
- Linux local validation covers this Python slice. GitHub Actions PR-scoped performance is still required as the merge gate for the registered probe report.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally and showed an improvement.
- [ ] GitHub Actions PR-scoped performance completed successfully.
