### PR TITLE
perf: carry export excerpt line count

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -178,6 +178,13 @@ character for the `p*` and `r*` branches first, so common runtime lines such as
 `runtime load failed ...` and ordinary `plain ...` status lines can skip the
 anchored private-text regex without transient lowercased prefix strings.
 
+A follow-up 2026-07-01 excerpt line-number accounting slice keeps the redacted
+excerpt text, truncation behavior, and source-line map unchanged while carrying
+the emitted output-line count, bound output append method, and last source-path
+prefix in the loop. This avoids repeated `len()` calls on the growing output
+list, repeated append attribute lookups, and repeated prefix formatting for
+adjacent bounded log lines from the same source path.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -299,6 +299,28 @@ def test_export_target_diagnostics_excerpt_byte_count_reuses_incremental_account
     assert excerpt.summary.excerpt_line_count == 2
 
 
+def test_export_target_diagnostics_non_ascii_clipped_line_keeps_line_number(
+    tmp_path: Path,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [_SourceLine("logs/runtime.log", "runtime load failed at café")],
+        bounded_bytes=34,
+        bounded_lines=8,
+    )
+
+    assert excerpt.summary.truncated is True
+    assert excerpt.summary.excerpt_line_count == 1
+    assert excerpt.line_numbers == {0: 1}
+    assert excerpt.summary.excerpt_byte_count <= 34
+
+
 def test_export_target_diagnostics_resolves_target_root_once_for_many_path_redactions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -545,32 +545,44 @@ def _build_redacted_excerpt(
         return _Excerpt(path="", text="", line_numbers={}, summary=summary)
 
     output_lines: list[str] = []
+    output_append = output_lines.append
+    output_line_count = 0
     line_numbers: dict[int, int] = {}
     used_bytes = 0
+    last_source_path = ""
+    last_source_prefix = ""
     try:
         resolved_target_root = layout.target_root.resolve(strict=False)
     except OSError:
         resolved_target_root = layout.target_root
     resolved_target_root_text = str(resolved_target_root)
     for index, source_line in enumerate(source_lines):
-        if len(output_lines) >= bounded_lines:
+        if output_line_count >= bounded_lines:
             summary.truncated = True
             break
         redacted = _redact_text(source_line.text, resolved_target_root, resolved_target_root_text, summary)
-        rendered = f"[{source_line.source_path}] {redacted}"
+        if source_line.source_path == last_source_path:
+            source_prefix = last_source_prefix
+        else:
+            last_source_path = source_line.source_path
+            source_prefix = f"[{source_line.source_path}] "
+            last_source_prefix = source_prefix
+        rendered = source_prefix + redacted
         if rendered.isascii():
             rendered_byte_count = len(rendered) + 1
             if used_bytes + rendered_byte_count > bounded_bytes:
                 remaining = max(0, bounded_bytes - used_bytes)
                 if remaining > 0:
                     clipped = (rendered + "\n")[:remaining]
-                    output_lines.append(clipped)
-                    line_numbers[index] = len(output_lines)
+                    output_append(clipped)
+                    output_line_count += 1
+                    line_numbers[index] = output_line_count
                     used_bytes += len(clipped)
                 summary.truncated = True
                 break
-            output_lines.append(rendered)
-            line_numbers[index] = len(output_lines)
+            output_append(rendered)
+            output_line_count += 1
+            line_numbers[index] = output_line_count
             used_bytes += rendered_byte_count
             continue
         rendered_bytes = (rendered + "\n").encode("utf-8")
@@ -578,13 +590,15 @@ def _build_redacted_excerpt(
             remaining = max(0, bounded_bytes - used_bytes)
             if remaining > 0:
                 clipped = rendered_bytes[:remaining].decode("utf-8", errors="ignore")
-                output_lines.append(clipped)
-                line_numbers[index] = len(output_lines)
+                output_append(clipped)
+                output_line_count += 1
+                line_numbers[index] = output_line_count
                 used_bytes += len(clipped.encode("utf-8"))
             summary.truncated = True
             break
-        output_lines.append(rendered)
-        line_numbers[index] = len(output_lines)
+        output_append(rendered)
+        output_line_count += 1
+        line_numbers[index] = output_line_count
         used_bytes += len(rendered_bytes)
 
     text = "\n".join(output_lines)


### PR DESCRIPTION
## Summary
- Carries the emitted output-line count inside `_build_redacted_excerpt()` instead of repeatedly calling `len(output_lines)` while assigning source line numbers.
- Reuses a bound output append method on the bounded excerpt emission path.
- Adds a non-ASCII clipped-line regression test to preserve line-number accounting on the encoded clipping path.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the 2026-07-01 excerpt line-number accounting slice.
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` already covers `services/mlx-worker-python/worker/productization/export_target_diagnostics.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- Baseline registered probe from `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- Candidate registered probe from this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 77 passed.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Baseline registered probe (`origin/main`, default 30 iterations / 5 samples): `elapsed_ms_mean=2700.2769662300125`, `path_redaction_elapsed_ms_mean=19.105246383696795`, `diagnostic_latency_ms=8.611505152657628`, `peak_bytes_mean=198370.4`, `diagnosis_matching_elapsed_ms_mean=0.6263533839955926`.
- Candidate registered probe (default 30 iterations / 5 samples): `elapsed_ms_mean=2721.495937020518`, `path_redaction_elapsed_ms_mean=18.663687189109623`, `diagnostic_latency_ms=8.391743060201406`, `peak_bytes_mean=205016.2`, `diagnosis_matching_elapsed_ms_mean=0.5837792064994574`.
- Delta: `path_redaction_elapsed_ms_mean -0.442 ms (-2.31%)`, `diagnostic_latency_ms -0.220 ms (-2.55%)`, `diagnosis_matching_elapsed_ms_mean -0.043 ms (-6.80%)`, `elapsed_ms_mean +21.219 ms (+0.79%)`, `peak_bytes_mean +6646 bytes (+3.35%)`.

## Known Gaps
- Linux local verification covers the Python runtime-export diagnostics path only.
- The PR-scoped performance GitHub Actions report remains the merge gate for the registered probe validation.
- Overall elapsed and peak memory moved up locally but stayed below the registered 5% warning threshold; the targeted path-redaction/diagnostic metrics improved locally and CI should confirm no registered regression.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Behavior-preserving regression coverage added for the changed accounting path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is >= 95% locally.
- [x] Registered probe ran locally on Linux with measured deltas.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
