### PR TITLE
perf: bind trajectory scalar copy type lookup

### DIFF
--- a/docs/plans/2026-06-25-trajectory-copy-list-literal.md
+++ b/docs/plans/2026-06-25-trajectory-copy-list-literal.md
@@ -36,3 +36,12 @@ Run the focused registry test command, changed-scope coverage command, and the
 registered probe locally on Linux before opening the PR. The probe compares the
 deep-copy baseline with the optimized provenance copier and reports elapsed time,
 peak bytes, speedup, sample count, iteration count, and component count.
+
+## 2026-07-01 follow-up: scalar container type binding
+
+This follow-up keeps the same Python-only boundary and registered
+`trajectory-provenance-copy-elision` probe. The scalar-list and scalar-tuple copy
+guards now reuse a module-level `type` binding inside the per-item scan instead
+of resolving the builtin on every iteration. Container isolation and recursive
+copy behavior stay unchanged; the slice only targets the exact-scalar list/tuple
+hot loops measured by the registered probe.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -9,6 +9,7 @@ from typing import Any
 _JSON_LOADS = json.loads
 _PATH_READ_BYTES = Path.read_bytes
 _STR = str
+_TYPE = type
 
 
 def _strip_manifest_text(value: Any) -> str:
@@ -52,16 +53,18 @@ def _is_clean_manifest_text(value: Any) -> bool:
 
 def _copy_json_list(value: list[Any]) -> list[Any]:
     immutable_types = _JSON_IMMUTABLE_TYPE_SET
+    value_type = _TYPE
     for item in value:
-        if type(item) not in immutable_types:
+        if value_type(item) not in immutable_types:
             return [_copy_trajectory_provenance_value(item) for item in value]
     return [*value]
 
 
 def _copy_json_tuple(value: tuple[Any, ...]) -> tuple[Any, ...]:
     immutable_types = _JSON_IMMUTABLE_TYPE_SET
+    value_type = _TYPE
     for item in value:
-        if type(item) not in immutable_types:
+        if value_type(item) not in immutable_types:
             return tuple(_copy_trajectory_provenance_value(item) for item in value)
     return value
 


### PR DESCRIPTION
## Summary
- Reuses a module-level `type` binding in the trajectory provenance scalar list/tuple copy scans.
- Keeps container isolation and recursive-copy semantics unchanged for mutable nested values.
- Updates the trajectory copy performance plan with this 2026-07-01 follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-06-25-trajectory-copy-list-literal.md` with the scalar container type-binding follow-up.
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` already covers `services/mlx-worker-python/worker/trajectory_provenance.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q ... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py`
- Baseline registered probe from `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py`
- Candidate registered probe from this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 19 passed.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Baseline registered probe (`origin/main`, default 2000 iterations / 5 samples): `optimized_elapsed_ms_mean=361.18848198093474`, `scalar_list_elapsed_ms_mean=0.6445218110457063`, `scalar_list_speedup=1.443224064618739`, `peak_bytes_mean=12112.0`.
- Candidate registered probe (default 2000 iterations / 5 samples): `optimized_elapsed_ms_mean=357.339598168619`, `scalar_list_elapsed_ms_mean=0.6368753965944052`, `scalar_list_speedup=1.6157858255534283`, `peak_bytes_mean=12112.0`.
- Delta: `optimized_elapsed_ms_mean -3.849 ms (-1.07%)`, `scalar_list_elapsed_ms_mean -0.00765 ms (-1.19%)`, `scalar_list_speedup +0.173`, `peak_bytes_mean +0 bytes`.

## Known Gaps
- Linux local verification covers the Python trajectory provenance copy path only.
- The PR-scoped performance GitHub Actions report remains the merge gate for registered probe validation.
- The optimization is intentionally small; local timing deltas are modest and should be treated as directional until CI repeats the registered probe.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Existing behavior-preserving regression tests cover scalar list/tuple reuse and nested mutable copy isolation.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is >= 95% locally.
- [x] Registered probe ran locally on Linux with measured deltas.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
