### PR TITLE
perf: elide chunker segment count bookkeeping

### DIFF
--- a/docs/plans/2026-07-02-training-dataset-chunker-segment-count-elision.md
+++ b/docs/plans/2026-07-02-training-dataset-chunker-segment-count-elision.md
@@ -1,0 +1,35 @@
+# Training dataset chunker segment count elision
+
+## Scope
+
+This Python-only performance slice is limited to the single-turn long-context
+chunk search in `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`.
+
+## Registered Probe
+
+The affected path is covered by the existing PR-scoped registered probe
+`training-dataset-chunker-top-level-base-copy` in `infra/perf/pr_scoped_probes.json`.
+The registry entry has focused `test_command`, `coverage_command`, and
+`probe_command` entries and runs `scripts/training_dataset_chunker_top_level_copy_probe.py`.
+
+## Optimization Slice
+
+The previous streaming segment work guarantees that `_chunk_single_turn()` only
+searches candidate `k` values after rejecting `k_floor > word_count`, so each
+candidate `k` is `<= word_count`. For that domain `_iter_word_segments(words, k)`
+yields exactly `k` non-empty segments. This slice removes the per-segment
+`segment_count` bookkeeping and unreachable short-segment branch from the hot
+candidate loop, preserving the same accepted chunk boundaries and early break on
+over-budget segments.
+
+## Success Metrics
+
+- Focused chunker tests continue to pass.
+- Changed-scope coverage for the touched chunker scope remains at least 95%.
+- The registered local Linux probe reports lower or neutral `elapsed_ms_mean`
+  without increasing `peak_bytes_mean` beyond the registered threshold.
+
+## Linux Boundary
+
+This is a Python-only path and is locally verifiable on Linux. Hosted PR-scoped
+performance CI remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -272,38 +272,24 @@ def _chunk_single_turn(
         for k in range(k_floor, word_count + 1):
             chunks: list[list[dict[str, str]]] = []
             append_chunk = chunks.append
-            segment_count = 0
             for segment in iter_word_segments(words, k):
-                segment_count += 1
                 user_segment = {"role": "user", "content": segment}
                 chunk = system_prefix + [user_segment, assistant]
                 if render_len(chunk, tokenizer, tools=tools) > chunk_size:
                     break
                 append_chunk(chunk)
-            if segment_count < k:
-                # User content has fewer words than buckets — caller must try a
-                # smaller K. In practice this only fires when k > word_count,
-                # which the guard above already rejects.
-                continue
             if len(chunks) == k:
                 return chunks
     else:
         for k in range(k_floor, word_count + 1):
             chunks: list[list[dict[str, str]]] = []
             append_chunk = chunks.append
-            segment_count = 0
             for segment in iter_word_segments(words, k):
-                segment_count += 1
                 user_segment = {"role": "user", "content": segment}
                 chunk = [user_segment, assistant]
                 if render_len(chunk, tokenizer, tools=tools) > chunk_size:
                     break
                 append_chunk(chunk)
-            if segment_count < k:
-                # User content has fewer words than buckets — caller must try a
-                # smaller K. In practice this only fires when k > word_count,
-                # which the guard above already rejects.
-                continue
             if len(chunks) == k:
                 return chunks
 


### PR DESCRIPTION
## Summary
- Elides unreachable `segment_count` bookkeeping from the training dataset chunker single-turn candidate loop.
- Keeps the same chunk boundary search, accepted chunk messages, and early break on over-budget rendered segments.

## Plan or Spec
- `docs/plans/2026-07-02-training-dataset-chunker-segment-count-elision.md`
- Registered PR-scoped performance probe: `training-dataset-chunker-top-level-base-copy`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# baseline before change: exit 0; {"chunk_count": 174.0, "elapsed_ms_mean": 23.105017, "peak_bytes_mean": 774473.714, "sample_count": 7.0, "top_level_key_count": 123.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics
# exit 0; 11 passed in 1.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py
# exit 0; tests 11 passed in 0.27s; changed-scope coverage TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# after change: exit 0; {"chunk_count": 174.0, "elapsed_ms_mean": 22.463699, "peak_bytes_mean": 774473.714, "sample_count": 7.0, "top_level_key_count": 123.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` for the registered changed-scope coverage command.
- Local Linux registered probe (`training_dataset_chunker_top_level_copy_probe.py`): baseline `elapsed_ms_mean=23.105017`, candidate `elapsed_ms_mean=22.463699`, delta `-0.641318 ms` (`~2.78%` faster); `peak_bytes_mean` unchanged at `774473.714` bytes.
- CI PR-scoped performance report is required as the hosted merge gate.

## Known Gaps
- None for the Python Linux-verifiable slice.
- Swift/runtime effects are not applicable; this PR only touches Python chunker logic and its plan.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
