### PR TITLE
perf: fast-path dataset registry split inference

### DIFF
--- a/docs/plans/2026-07-02-dataset-registry-single-directory-split-fastpath.md
+++ b/docs/plans/2026-07-02-dataset-registry-single-directory-split-fastpath.md
@@ -1,0 +1,30 @@
+# Dataset registry single-directory split inference fast path
+
+## Scope
+
+This Python performance slice is limited to `worker.dataset_registry.catalog._inferred_split_and_config()`.
+The registered PR-scoped probe is `dataset-registry-snapshot-inference-single-pass`, which covers:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+
+## Optimization
+
+Most Hugging Face snapshot sidecars discovered by the dataset registry follow a single-directory layout such as `config-00/train-00000.jsonl`. That common case does not need full path normalization, path-parts list materialization, or parent-part scanning. This slice adds a single-forward-slash fast path that:
+
+1. confirms the relative path has exactly one `/` and no Windows separator,
+2. derives the first directory and filename directly from string indexes,
+3. preserves default-config directories via `_DEFAULT_CONFIG_FIRST_PARTS`, and
+4. falls back to the existing normalized path-parts implementation for flat, multi-directory, empty, or Windows-style paths.
+
+## Verification Plan
+
+- Focused pytest for dataset registry behavior and PR-scoped performance selection.
+- Changed-scope coverage via the registered probe coverage command.
+- Local Linux registered probe run for `dataset-registry-snapshot-inference-single-pass`.
+- GitHub Actions PR-scoped performance report remains the merge gate.
+
+## Environment Boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -171,6 +171,7 @@ def test_dataset_catalog_inferred_split_and_config_preserves_legacy_helpers() ->
     assert catalog._inferred_config("custom/validation-00000.parquet") == "custom"
     assert catalog._inferred_split_and_config("data/train-00000-of-00001.jsonl") == ("train", "default")
     assert catalog._inferred_split_and_config("custom\\test.json") == ("test", "custom")
+    assert catalog._inferred_split_and_config("custom/train-00000-of-00001.jsonl") == ("train", "custom")
     assert catalog._inferred_split_and_config("validation/shard-00000.jsonl") == ("validation", "default")
     assert catalog._inferred_split_and_config("valid/shard-00000.jsonl") == ("validation", "default")
     assert catalog._inferred_split_and_config("dev/shard-00000.jsonl") == ("validation", "default")

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -1050,6 +1050,19 @@ def _inferred_config(relative_path: str) -> str:
 
 
 def _inferred_split_and_config(relative_path: str) -> tuple[str, str]:
+    slash_index = relative_path.find("/")
+    if slash_index > 0 and "\\" not in relative_path:
+        next_slash_index = relative_path.find("/", slash_index + 1)
+        if next_slash_index < 0 and slash_index < len(relative_path) - 1:
+            first = relative_path[:slash_index]
+            filename = relative_path[slash_index + 1 :]
+            stem = filename.rsplit(".", 1)[0]
+            split = _split_alias_from_candidate(stem)
+            if not split and first not in _DEFAULT_CONFIG_PARTS:
+                split = _split_alias_from_candidate(first)
+            if first in _DEFAULT_CONFIG_FIRST_PARTS:
+                return split, "default"
+            return split, first
     parts = [part for part in relative_path.replace("\\", "/").split("/") if part]
     if not parts:
         return "", "default"


### PR DESCRIPTION
## Summary
- Add a single-directory fast path for dataset registry split/config inference.
- Preserve the existing normalized fallback for flat, multi-directory, empty, and Windows-style paths.
- Document the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-07-02-dataset-registry-single-directory-split-fastpath.md`
- Registered probe: `dataset-registry-snapshot-inference-single-pass`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-registry-snapshot-inference-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-registry-flat-split-fastpath-20260702 --head-repo "$PWD" --output .runtime/perf/dataset-registry-single-directory-split.json`

## Coverage and Metrics
- Focused pytest: 62 passed.
- Changed-scope coverage: 100% (14/14 changed executable lines).
- Local registered probe (head-only): `elapsed_ms_mean=142.31853757519275`, `peak_bytes_mean=778439.8`, `legacy_inference_helper_calls_mean=0.0`.
- Local registered base-vs-head probe: `old_mean=156.74740218091756ms`, `new_mean=137.8020098200068ms`, `speedup=1.1375x`, `delta_ms=-18.945392360910773`; `peak_bytes_mean` changed from `778451.0` to `778439.8`.

## Known Gaps
- This is a Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance remains required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe shows a local improvement.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
