### PR TITLE
Add storage cleanup inventory receipts

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -68,6 +68,16 @@ public struct WorkspacePreflightOptions: Equatable, Sendable {
     }
 }
 
+public struct StorageMaintenanceOptions: Equatable, Sendable {
+    public let workspaceManifestPath: String
+    public let json: Bool
+
+    public init(workspaceManifestPath: String = "", json: Bool = false) {
+        self.workspaceManifestPath = workspaceManifestPath
+        self.json = json
+    }
+}
+
 public struct DatasetPrepareIngestOptions: Equatable, Sendable {
     public let workspaceProjectID: String
     public let workspaceManifestPath: String
@@ -2342,6 +2352,9 @@ public enum MelixCLICommand: Equatable, Sendable {
     case schema(DiscoveryJSONOptions)
     case configMetadata(DiscoveryJSONOptions)
     case workspacePreflight(WorkspacePreflightOptions)
+    case storageInventory(StorageMaintenanceOptions)
+    case storageCleanupPlan(StorageMaintenanceOptions)
+    case storageCleanupApply(StorageMaintenanceOptions)
     case doctor(DoctorOptions)
     case system(SystemOptions)
     case monitor(MonitorOptions)
@@ -2525,6 +2538,8 @@ public enum MelixCLIParser {
             return try parseConfig(tail)
         case "workspace":
             return try parseWorkspace(tail)
+        case "storage":
+            return try parseStorage(tail)
         case "doctor":
             return try parseDoctor(tail)
         case "system":
@@ -2592,6 +2607,9 @@ public enum MelixCLIParser {
       melix schema --json
       melix config metadata --json
       melix workspace preflight --manifest PATH [--output PATH] [--json]
+      melix storage inventory [--workspace-manifest PATH] [--json]
+      melix storage cleanup plan [--workspace-manifest PATH] [--json]
+      melix storage cleanup apply [--workspace-manifest PATH] [--json]
       melix doctor [--json]
       melix system --json
       melix monitor [--from PATH] [--json]
@@ -2891,6 +2909,42 @@ public enum MelixCLIParser {
                 json: values.flags.contains("--json")
             )
         )
+    }
+
+    private static func parseStorage(_ arguments: [String]) throws -> MelixCLICommand {
+        guard let action = arguments.first else {
+            throw MelixCLIError.usage(Self.usageText)
+        }
+        let tail = Array(arguments.dropFirst())
+        switch action {
+        case "inventory":
+            let values = try ArgumentCursor(arguments: tail).parse()
+            return .storageInventory(
+                .init(
+                    workspaceManifestPath: values.single["--workspace-manifest"] ?? "",
+                    json: values.flags.contains("--json")
+                )
+            )
+        case "cleanup":
+            guard let mode = tail.first else {
+                throw MelixCLIError.usage(Self.usageText)
+            }
+            let values = try ArgumentCursor(arguments: Array(tail.dropFirst())).parse()
+            let options = StorageMaintenanceOptions(
+                workspaceManifestPath: values.single["--workspace-manifest"] ?? "",
+                json: values.flags.contains("--json")
+            )
+            switch mode {
+            case "plan":
+                return .storageCleanupPlan(options)
+            case "apply":
+                return .storageCleanupApply(options)
+            default:
+                throw MelixCLIError.usage(Self.usageText)
+            }
+        default:
+            throw MelixCLIError.usage(Self.usageText)
+        }
     }
 
     private static func parseDoctor(_ arguments: [String]) throws -> MelixCLICommand {
@@ -7820,6 +7874,18 @@ public actor MelixCLIRunner {
             return try prettyJSON(payload)
         case .workspacePreflight(let options):
             return try await runWorkspacePreflight(options)
+        case .storageInventory(let options):
+            let store = storageMaintenanceStore()
+            let receipt = try store.inventory(workspaceManifestPath: options.workspaceManifestPath)
+            return options.json ? try prettyJSON(receipt) : renderStorageInventory(receipt)
+        case .storageCleanupPlan(let options):
+            let store = storageMaintenanceStore()
+            let plan = try store.cleanupPlan(workspaceManifestPath: options.workspaceManifestPath)
+            return options.json ? try prettyJSON(plan) : renderStorageCleanupPlan(plan)
+        case .storageCleanupApply(let options):
+            let store = storageMaintenanceStore()
+            let receipt = try store.applyCleanup(workspaceManifestPath: options.workspaceManifestPath)
+            return options.json ? try prettyJSON(receipt) : renderStorageCleanupReceipt(receipt)
         case .uriInspect(let options):
             return try runURIInspect(options)
         case .uriImport(let options):
@@ -9632,6 +9698,13 @@ public actor MelixCLIRunner {
         )
     }
 
+    private func storageMaintenanceStore() -> MelixStorageMaintenanceStore {
+        MelixStorageMaintenanceStore(
+            melixHome: MelixHome(environment: environment),
+            environment: environment
+        )
+    }
+
     private func jobStatusStore() -> MelixJobStatusStore {
         let melixHome = MelixHome(environment: environment)
         return MelixJobStatusStore(
@@ -10449,6 +10522,47 @@ public actor MelixCLIRunner {
             return "\(bytes) B"
         }
         return String(format: "%.2f %@", locale: Locale(identifier: "en_US_POSIX"), value, units[unitIndex])
+    }
+
+    private func renderStorageInventory(_ receipt: [String: Any]) -> String {
+        let summary = receipt["summary"] as? [String: Any] ?? [:]
+        let artifactCount = intValue(summary["artifact_count"])
+        let cleanableBytes = uint64Value(summary["cleanable_byte_size"])
+        let protectedBytes = uint64Value(summary["protected_byte_size"])
+        return "Storage inventory: \(artifactCount) artifacts, \(formatBinaryBytes(cleanableBytes)) cleanable, \(formatBinaryBytes(protectedBytes)) protected.\n"
+    }
+
+    private func renderStorageCleanupPlan(_ plan: [String: Any]) -> String {
+        let summary = plan["summary"] as? [String: Any] ?? [:]
+        let cleanableCount = intValue(summary["cleanable_entry_count"])
+        let retainedCount = intValue(summary["retained_entry_count"])
+        let protectedCount = intValue(summary["protected_entry_count"])
+        let blockedCount = intValue(summary["blocked_entry_count"])
+        let cleanableBytes = uint64Value(summary["cleanable_byte_size"])
+        return "Storage cleanup dry-run: \(cleanableCount) cleanable, \(retainedCount) retained, \(protectedCount) protected, \(blockedCount) blocked, \(formatBinaryBytes(cleanableBytes)) reclaimable.\n"
+    }
+
+    private func renderStorageCleanupReceipt(_ receipt: [String: Any]) -> String {
+        let summary = receipt["summary"] as? [String: Any] ?? [:]
+        let deleteCount = intValue(summary["safe_delete_count"])
+        let deletedBytes = uint64Value(summary["deleted_byte_size"])
+        let protectedCount = intValue(summary["protected_entry_count"])
+        let failedCount = intValue(summary["failed_entry_count"])
+        return "Storage cleanup applied: \(deleteCount) deleted, \(formatBinaryBytes(deletedBytes)) reclaimed, \(protectedCount) protected, \(failedCount) failed.\n"
+    }
+
+    private func intValue(_ value: Any?) -> Int {
+        if let number = value as? NSNumber {
+            return number.intValue
+        }
+        return value as? Int ?? 0
+    }
+
+    private func uint64Value(_ value: Any?) -> UInt64 {
+        if let number = value as? NSNumber {
+            return number.uint64Value
+        }
+        return value as? UInt64 ?? 0
     }
 
     private func renderRegistryRoots(_ roots: [String]) -> String {

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -24,6 +24,12 @@ public enum MelixCLICommandCodec {
             return "config.metadata"
         case .workspacePreflight:
             return "workspace.preflight"
+        case .storageInventory:
+            return "storage.inventory"
+        case .storageCleanupPlan:
+            return "storage.cleanup.plan"
+        case .storageCleanupApply:
+            return "storage.cleanup.apply"
         case .doctor:
             return "doctor"
         case .system:
@@ -293,6 +299,18 @@ public enum MelixCLICommandCodec {
             arguments = ["workspace", "preflight"]
             appendOption("--manifest", value: options.manifestPath, into: &arguments)
             appendOption("--output", value: options.outputPath, into: &arguments)
+            json = options.json
+        case .storageInventory(let options):
+            arguments = ["storage", "inventory"]
+            appendOption("--workspace-manifest", value: options.workspaceManifestPath, into: &arguments)
+            json = options.json
+        case .storageCleanupPlan(let options):
+            arguments = ["storage", "cleanup", "plan"]
+            appendOption("--workspace-manifest", value: options.workspaceManifestPath, into: &arguments)
+            json = options.json
+        case .storageCleanupApply(let options):
+            arguments = ["storage", "cleanup", "apply"]
+            appendOption("--workspace-manifest", value: options.workspaceManifestPath, into: &arguments)
             json = options.json
         case .doctor(let options):
             arguments = ["doctor"]

--- a/Sources/MelixCLICore/MelixDiagnostics.swift
+++ b/Sources/MelixCLICore/MelixDiagnostics.swift
@@ -1134,12 +1134,62 @@ public struct MelixDiagnosticsStore {
             to: root.appendingPathComponent("error.json")
         )
 
-        let manifestPayload: [String: Any] = [
+        let storageStore = MelixStorageMaintenanceStore(
+            melixHome: melixHome,
+            environment: environment,
+            fileManager: fileManager
+        )
+        let storageReceipts = try storageStore.inventoryAndCleanupPlan()
+        let redactedStorageInventory = MelixDiagnosticsRedaction.redactMapping(storageReceipts.inventory)
+        let redactedStorageCleanupPlan = MelixDiagnosticsRedaction.redactMapping(storageReceipts.cleanupPlan)
+        totalRedacted += redactedStorageInventory.redactedFieldCount
+            + redactedStorageCleanupPlan.redactedFieldCount
+        try writeJSON(
+            redactedStorageInventory.payload,
+            to: root.appendingPathComponent("storage-inventory.json")
+        )
+        try writeJSON(
+            redactedStorageCleanupPlan.payload,
+            to: root.appendingPathComponent("storage-cleanup-plan.json")
+        )
+        let redactedStorageCleanupReceipt: (payload: [String: Any], redactedFieldCount: Int)?
+        if let latestCleanupReceipt = try storageStore.latestCleanupReceipt() {
+            let redacted = MelixDiagnosticsRedaction.redactMapping(latestCleanupReceipt)
+            totalRedacted += redacted.redactedFieldCount
+            redactedStorageCleanupReceipt = redacted
+            try writeJSON(
+                redacted.payload,
+                to: root.appendingPathComponent("storage-cleanup-receipt.json")
+            )
+        } else {
+            redactedStorageCleanupReceipt = nil
+        }
+        var debugBundleArtifacts: [String: String] = [
+            "command": "command.txt",
+            "redacted_env": "redacted-env.json",
+            "environment_diagnostic": "environment-diagnostic.json",
+            "effective_config": "effective-config.json",
+            "system": "system.json",
+            "capability_receipts": "capability-receipts.json",
+            "memory_estimate": "memory-estimate.json",
+            "logs": "logs.txt",
+            "metrics": "metrics.json",
+            "error": "error.json",
+            "storage_inventory": "storage-inventory.json",
+            "storage_cleanup_plan": "storage-cleanup-plan.json",
+        ]
+        if redactedStorageCleanupReceipt != nil {
+            debugBundleArtifacts["storage_cleanup_receipt"] = "storage-cleanup-receipt.json"
+        }
+
+        var manifestPayload: [String: Any] = [
             "schema_version": "melix.diagnostics.bundle.v1",
             "bundle_id": record.runID,
             "created_at_unix_ms": currentUnixMilliseconds(),
             "diagnostics_consent_state": MelixSystemDiagnostics.diagnosticsConsentState,
             "media_route_receipt": Self.mediaRouteReceipt(for: record),
+            "storage_inventory": redactedStorageInventory.payload,
+            "storage_cleanup_plan": redactedStorageCleanupPlan.payload,
             "probe_policy": Self.probePolicyPayload(environment: environment),
             "debug_artifact_policy": "explicit_cli_command",
             "debug_jsonl_enabled": MelixProbeMode.fromEnvironment(environment).debugArtifactsEnabled,
@@ -1147,19 +1197,11 @@ public struct MelixDiagnosticsStore {
             "redaction_schema_version": MelixDiagnosticsRedaction.schemaVersion,
             "redacted_field_count": totalRedacted,
             "source_run_record_path": record.path,
-            "artifacts": [
-                "command": "command.txt",
-                "redacted_env": "redacted-env.json",
-                "environment_diagnostic": "environment-diagnostic.json",
-                "effective_config": "effective-config.json",
-                "system": "system.json",
-                "capability_receipts": "capability-receipts.json",
-                "memory_estimate": "memory-estimate.json",
-                "logs": "logs.txt",
-                "metrics": "metrics.json",
-                "error": "error.json",
-            ],
+            "artifacts": debugBundleArtifacts,
         ]
+        if let redactedStorageCleanupReceipt {
+            manifestPayload["storage_cleanup_receipt"] = redactedStorageCleanupReceipt.payload
+        }
         let redactedManifest = MelixDiagnosticsRedaction.redactMapping(manifestPayload)
         totalRedacted += redactedManifest.redactedFieldCount
         var manifest = redactedManifest.payload

--- a/Sources/MelixCLICore/MelixDiagnostics.swift
+++ b/Sources/MelixCLICore/MelixDiagnostics.swift
@@ -1153,7 +1153,7 @@ public struct MelixDiagnosticsStore {
             to: root.appendingPathComponent("storage-cleanup-plan.json")
         )
         let redactedStorageCleanupReceipt: (payload: [String: Any], redactedFieldCount: Int)?
-        if let latestCleanupReceipt = try storageStore.latestCleanupReceipt() {
+        if let latestCleanupReceipt = try? storageStore.latestCleanupReceipt() {
             let redacted = MelixDiagnosticsRedaction.redactMapping(latestCleanupReceipt)
             totalRedacted += redacted.redactedFieldCount
             redactedStorageCleanupReceipt = redacted

--- a/Sources/MelixCLICore/MelixStorageMaintenance.swift
+++ b/Sources/MelixCLICore/MelixStorageMaintenance.swift
@@ -1,0 +1,912 @@
+import CryptoKit
+import Foundation
+import MelixControlPlaneCore
+
+public final class MelixStorageMaintenanceStore {
+    private let melixHome: MelixHome
+    private let environment: [String: String]
+    private let fileManager: FileManager
+
+    public init(
+        melixHome: MelixHome,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) {
+        self.melixHome = melixHome
+        self.environment = environment
+        self.fileManager = fileManager
+    }
+
+    public func inventory(workspaceManifestPath: String = "") throws -> [String: Any] {
+        try buildInventory(workspaceManifestPath: workspaceManifestPath).payload
+    }
+
+    private func buildInventory(workspaceManifestPath: String = "") throws -> StorageInventoryBuild {
+        let startedAt = storageUnixMilliseconds()
+        let start = DispatchTime.now()
+        let activeRoots = try loadActiveArtifactRoots()
+        let manifest = try loadWorkspaceManifest(workspaceManifestPath)
+        var entries: [StorageArtifactEntry] = []
+
+        if let manifest {
+            entries.append(contentsOf: artifactEntries(from: manifest, activeRoots: activeRoots))
+        }
+        entries.append(contentsOf: try melixOwnedEntries(activeRoots: activeRoots))
+        entries = deduplicated(entries)
+
+        let completedAt = storageUnixMilliseconds()
+        let latency = elapsedMilliseconds(since: start)
+        let summary = storageSummary(entries: entries)
+        let inventorySeed = [
+            "\(startedAt)",
+            "\(entries.count)",
+            entries.map(\.pathDigest).joined(separator: ","),
+        ].joined(separator: "|")
+        let payload: [String: Any] = [
+            "schema_version": "melix.storage_inventory_receipt.v1",
+            "inventory_id": stableID(prefix: "storage-inventory", seed: inventorySeed),
+            "started_at_unix_ms": startedAt,
+            "completed_at_unix_ms": max(completedAt, startedAt),
+            "workspace_roots": manifest.map(workspaceRootPayloads) ?? [],
+            "artifact_roots": manifest.map(artifactRootPayloads) ?? [],
+            "artifact_entries": entries.map(\.payload),
+            "summary": summary,
+            "redaction_summary": [
+                "schema_version": MelixDiagnosticsRedaction.schemaVersion,
+                "redacted_field_count": entries.count,
+            ],
+            "active_artifact_summary": [
+                "protected_active_artifact_count": entries.filter { $0.cleanupEligibility == "protected_active" }.count,
+                "active_root_count": activeRoots.count,
+            ],
+            "metrics": [
+                "storage_inventory_latency_ms": latency,
+                "inventory_artifact_count": entries.count,
+                "inventory_byte_size": summary["inventory_byte_size"] ?? 0,
+                "retained_byte_size": summary["retained_byte_size"] ?? 0,
+                "cleanable_byte_size": summary["cleanable_byte_size"] ?? 0,
+                "protected_active_artifact_count": entries.filter { $0.cleanupEligibility == "protected_active" }.count,
+            ],
+        ]
+        return StorageInventoryBuild(payload: payload, entries: entries)
+    }
+
+    public func cleanupPlan(workspaceManifestPath: String = "") throws -> [String: Any] {
+        try inventoryAndCleanupPlan(workspaceManifestPath: workspaceManifestPath).cleanupPlan
+    }
+
+    public func inventoryAndCleanupPlan(workspaceManifestPath: String = "") throws -> (
+        inventory: [String: Any],
+        cleanupPlan: [String: Any]
+    ) {
+        let start = DispatchTime.now()
+        let inventoryBuild = try buildInventory(workspaceManifestPath: workspaceManifestPath)
+        let plan = cleanupPlanPayload(
+            inventoryPayload: inventoryBuild.payload,
+            entries: inventoryBuild.entries,
+            mode: "dry_run",
+            latencyMetricName: "cleanup_dry_run_latency_ms",
+            latency: elapsedMilliseconds(since: start)
+        )
+        return (inventoryBuild.payload, plan)
+    }
+
+    public func applyCleanup(workspaceManifestPath: String = "") throws -> [String: Any] {
+        let startedAt = storageUnixMilliseconds()
+        let start = DispatchTime.now()
+        let inventoryBuild = try buildInventory(workspaceManifestPath: workspaceManifestPath)
+        let plannedEntries = inventoryBuild.entries
+        let plan = cleanupPlanPayload(
+            inventoryPayload: inventoryBuild.payload,
+            entries: plannedEntries,
+            mode: "apply",
+            latencyMetricName: "cleanup_dry_run_latency_ms",
+            latency: 0
+        )
+        let activeRoots = try loadActiveArtifactRoots()
+        var deleted: [StorageArtifactEntry] = []
+        let retained: [StorageArtifactEntry] = plannedEntries.filter { $0.cleanupEligibility == "retain" }
+        var protected: [StorageArtifactEntry] = plannedEntries.filter {
+            $0.cleanupEligibility == "protected_active" || isBlockedCleanupEligibility($0.cleanupEligibility)
+        }
+        var failed: [[String: Any]] = []
+
+        for entry in plannedEntries where entry.cleanupEligibility == "cleanable" {
+            do {
+                guard let refreshed = try refresh(entry: entry, activeRoots: activeRoots) else {
+                    var missing = entry
+                    missing.cleanupEligibility = "missing"
+                    missing.cleanupReason = "artifact_missing_before_apply"
+                    protected.append(missing)
+                    continue
+                }
+                guard refreshed.mtimeUnixMS == entry.mtimeUnixMS,
+                      refreshed.byteSize == entry.byteSize,
+                      refreshed.pathDigest == entry.pathDigest else {
+                    var changed = refreshed
+                    changed.cleanupEligibility = "protected_active"
+                    changed.cleanupReason = "changed_since_plan"
+                    protected.append(changed)
+                    continue
+                }
+                guard refreshed.cleanupEligibility == "cleanable" else {
+                    protected.append(refreshed)
+                    continue
+                }
+                try fileManager.removeItem(at: refreshed.url)
+                deleted.append(refreshed)
+            } catch {
+                failed.append([
+                    "artifact_id": entry.artifactID,
+                    "artifact_kind": entry.artifactKind,
+                    "path_redaction": entry.pathRedaction,
+                    "path_digest": entry.pathDigest,
+                    "cleanup_reason": "delete_failed",
+                    "error": MelixDiagnosticsRedaction.redactString(String(describing: error)),
+                ])
+            }
+        }
+
+        let completedAt = storageUnixMilliseconds()
+        let deletedBytes = deleted.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let protectedBytes = protected.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let retainedBytes = retained.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let planID = plan["cleanup_plan_id"] as? String ?? ""
+        let receiptSeed = [
+            "\(startedAt)",
+            planID,
+            deleted.map(\.pathDigest).joined(separator: ","),
+            protected.map(\.pathDigest).joined(separator: ","),
+            "\(failed.count)",
+        ].joined(separator: "|")
+        let receiptID = stableID(prefix: "storage-cleanup-receipt", seed: receiptSeed)
+        let receiptURL = cleanupReceiptURL(receiptID: receiptID)
+        let receipt: [String: Any] = [
+            "schema_version": "melix.storage_cleanup_receipt.v1",
+            "cleanup_receipt_id": receiptID,
+            "cleanup_plan_id": planID,
+            "started_at_unix_ms": startedAt,
+            "completed_at_unix_ms": max(completedAt, startedAt),
+            "receipt_path_redaction": redactedPath(receiptURL),
+            "receipt_path_digest": sha256Hex(receiptURL.standardizedFileURL.path),
+            "deleted_entries": deleted.map(\.payload),
+            "retained_entries": retained.map(\.payload),
+            "protected_entries": protected.map(\.payload),
+            "failed_entries": failed,
+            "summary": [
+                "safe_delete_count": deleted.count,
+                "deleted_entry_count": deleted.count,
+                "retained_entry_count": retained.count,
+                "protected_entry_count": protected.count,
+                "failed_entry_count": failed.count,
+                "deleted_byte_size": deletedBytes,
+                "retained_byte_size": retainedBytes,
+                "protected_byte_size": protectedBytes,
+            ],
+            "metrics": [
+                "cleanup_apply_latency_ms": elapsedMilliseconds(since: start),
+                "safe_delete_count": deleted.count,
+                "deleted_byte_size": deletedBytes,
+                "cleanup_failure_count": failed.count,
+            ],
+        ]
+        try writeJSON(receipt, to: receiptURL)
+        return receipt
+    }
+
+    public func latestCleanupReceipt() throws -> [String: Any]? {
+        let directory = cleanupReceiptsDirectory()
+        guard isDirectory(directory) else {
+            return nil
+        }
+        let receipts = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ).compactMap { url -> (url: URL, modifiedAt: Date)? in
+            guard url.pathExtension == "json" else {
+                return nil
+            }
+            let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey])
+            guard values.isRegularFile != false else {
+                return nil
+            }
+            return (url, values.contentModificationDate ?? .distantPast)
+        }.sorted {
+            if $0.modifiedAt == $1.modifiedAt {
+                return $0.url.lastPathComponent > $1.url.lastPathComponent
+            }
+            return $0.modifiedAt > $1.modifiedAt
+        }
+        guard let latest = receipts.first else {
+            return nil
+        }
+        let data = try Data(contentsOf: latest.url)
+        guard let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw MelixCLIError.runtime("Latest storage cleanup receipt is not a JSON object.")
+        }
+        return payload
+    }
+
+    private func cleanupPlanPayload(
+        inventoryPayload: [String: Any],
+        entries: [StorageArtifactEntry],
+        mode: String,
+        latencyMetricName: String,
+        latency: Double
+    ) -> [String: Any] {
+        let retained = entries.filter { $0.cleanupEligibility == "retain" }
+        let cleanable = entries.filter { $0.cleanupEligibility == "cleanable" }
+        let protected = entries.filter { $0.cleanupEligibility == "protected_active" }
+        let blocked = entries.filter { isBlockedCleanupEligibility($0.cleanupEligibility) }
+        let retainedBytes = retained.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let cleanableBytes = cleanable.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let protectedBytes = protected.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let blockedBytes = blocked.reduce(UInt64(0)) { $0 + $1.byteSize }
+        let inventoryID = inventoryPayload["inventory_id"] as? String ?? ""
+        return [
+            "schema_version": "melix.storage_cleanup_plan.v1",
+            "cleanup_plan_id": stableID(prefix: "storage-cleanup-plan", seed: "\(inventoryID)-\(mode)"),
+            "inventory_id": inventoryID,
+            "mode": mode,
+            "generated_at_unix_ms": storageUnixMilliseconds(),
+            "retained_entries": retained.map(\.payload),
+            "cleanable_entries": cleanable.map(\.payload),
+            "protected_entries": protected.map(\.payload),
+            "blocked_entries": blocked.map(\.payload),
+            "summary": [
+                "retained_entry_count": retained.count,
+                "cleanable_entry_count": cleanable.count,
+                "protected_entry_count": protected.count,
+                "blocked_entry_count": blocked.count,
+                "retained_byte_size": retainedBytes,
+                "cleanable_byte_size": cleanableBytes,
+                "protected_byte_size": protectedBytes,
+                "blocked_byte_size": blockedBytes,
+            ],
+            "metrics": [
+                latencyMetricName: latency,
+                "retained_byte_size": retainedBytes,
+                "cleanable_byte_size": cleanableBytes,
+                "protected_active_artifact_count": protected.count,
+                "safe_delete_count": cleanable.count,
+            ],
+        ]
+    }
+
+    private func loadWorkspaceManifest(_ path: String) throws -> StorageWorkspaceManifest? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            return nil
+        }
+        let url = URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)
+        let data = try Data(contentsOf: url)
+        let object = try JSONSerialization.jsonObject(with: data)
+        guard let payload = object as? [String: Any] else {
+            throw MelixCLIError.runtime("Workspace manifest is not a JSON object.")
+        }
+        return StorageWorkspaceManifest(manifestURL: url, payload: payload)
+    }
+
+    private func artifactEntries(
+        from manifest: StorageWorkspaceManifest,
+        activeRoots: [URL]
+    ) -> [StorageArtifactEntry] {
+        manifest.artifacts.map { artifact in
+            let root = manifest.roots[artifact.rootID]
+            let baseURL = root.map { manifest.resolveRoot($0.path) } ?? manifest.manifestURL.deletingLastPathComponent()
+            let resolvedArtifact = resolveManifestArtifactURL(
+                baseURL: baseURL,
+                relativePath: artifact.relativePath
+            )
+            let ownership = ownership(for: root)
+            let artifactKind = artifactKind(for: artifact.artifactType)
+            return makeEntry(
+                artifactID: artifact.artifactID,
+                artifactKind: artifactKind,
+                rootKind: root?.kind ?? "unknown",
+                url: resolvedArtifact.url,
+                ownership: ownership,
+                activeRoots: activeRoots,
+                forcedCleanupEligibility: resolvedArtifact.isSafe ? nil : "blocked_unsafe_path",
+                forcedCleanupReason: resolvedArtifact.isSafe ? nil : "artifact_path_outside_root",
+                includeFileStats: resolvedArtifact.isSafe
+            )
+        }
+    }
+
+    private func melixOwnedEntries(activeRoots: [URL]) throws -> [StorageArtifactEntry] {
+        var entries: [StorageArtifactEntry] = []
+        entries.append(contentsOf: try filesUnder(melixHome.logsDirectoryURL, kind: "runtime_log", rootKind: "melix_logs", activeRoots: activeRoots))
+        entries.append(contentsOf: try staleTempFilesUnder(melixHome.runtimeDirectoryURL, activeRoots: activeRoots))
+        entries.append(contentsOf: try jobArtifactEntriesUnder(melixHome.modelOpsJobsRootURL, activeRoots: activeRoots))
+        entries.append(contentsOf: try jobArtifactEntriesUnder(melixHome.evaluationJobsRootURL, activeRoots: activeRoots))
+        return entries
+    }
+
+    private func filesUnder(
+        _ root: URL,
+        kind: String,
+        rootKind: String,
+        activeRoots: [URL]
+    ) throws -> [StorageArtifactEntry] {
+        guard isDirectory(root) else {
+            return []
+        }
+        return try shallowFiles(root).map { url in
+            makeEntry(
+                artifactID: stableID(prefix: kind, seed: url.path),
+                artifactKind: kind,
+                rootKind: rootKind,
+                url: url,
+                ownership: "melix_owned",
+                activeRoots: activeRoots
+            )
+        }
+    }
+
+    private func staleTempFilesUnder(_ root: URL, activeRoots: [URL]) throws -> [StorageArtifactEntry] {
+        guard isDirectory(root) else {
+            return []
+        }
+        let files = try shallowFiles(root).filter { url in
+            let name = url.lastPathComponent.lowercased()
+            let path = url.path.lowercased()
+            return name.contains("tmp") || name.contains("temp") || path.contains("/tmp/") || path.contains("/temp/")
+        }
+        return files.map { url in
+            makeEntry(
+                artifactID: stableID(prefix: "stale-temp-file", seed: url.path),
+                artifactKind: "stale_temp_file",
+                rootKind: "melix_runtime",
+                url: url,
+                ownership: "melix_owned",
+                activeRoots: activeRoots
+            )
+        }
+    }
+
+    private func jobArtifactEntriesUnder(_ root: URL, activeRoots: [URL]) throws -> [StorageArtifactEntry] {
+        guard isDirectory(root) else {
+            return []
+        }
+        var entries: [StorageArtifactEntry] = []
+        for url in try shallowFiles(root) {
+            let path = url.path.lowercased()
+            let kind: String?
+            if path.contains("/checkpoint") {
+                kind = "checkpoint"
+            } else if path.hasSuffix(".log") || path.contains("/logs") {
+                kind = "runtime_log"
+            } else if path.contains("/export") || path.contains("/tmp") || path.contains("/temp") {
+                kind = "export_intermediate"
+            } else {
+                kind = nil
+            }
+            guard let kind else {
+                continue
+            }
+            entries.append(
+                makeEntry(
+                    artifactID: stableID(prefix: kind, seed: url.path),
+                    artifactKind: kind,
+                    rootKind: "melix_jobs",
+                    url: url,
+                    ownership: "melix_owned",
+                    activeRoots: activeRoots
+                )
+            )
+        }
+        return entries
+    }
+
+    private func makeEntry(
+        artifactID: String,
+        artifactKind: String,
+        rootKind: String,
+        url: URL,
+        ownership: String,
+        activeRoots: [URL],
+        forcedCleanupEligibility: String? = nil,
+        forcedCleanupReason: String? = nil,
+        includeFileStats: Bool = true
+    ) -> StorageArtifactEntry {
+        let standardizedURL = url.standardizedFileURL
+        let stats = includeFileStats ? fileStats(standardizedURL) : (exists: false, byteSize: UInt64(0), mtimeUnixMS: 0)
+        let active = activeRoots.first { root in path(standardizedURL, isInside: root) } != nil
+        let eligibility = forcedCleanupEligibility ?? cleanupEligibility(
+            artifactKind: artifactKind,
+            ownership: ownership,
+            exists: stats.exists,
+            active: active
+        )
+        let reason = forcedCleanupReason ?? cleanupReason(eligibility: eligibility, artifactKind: artifactKind)
+        return StorageArtifactEntry(
+            artifactID: artifactID.isEmpty ? stableID(prefix: artifactKind, seed: standardizedURL.path) : artifactID,
+            artifactKind: artifactKind,
+            rootKind: rootKind,
+            url: standardizedURL,
+            pathRedaction: redactedPath(standardizedURL),
+            pathDigest: sha256Hex(standardizedURL.path),
+            byteSize: stats.byteSize,
+            mtimeUnixMS: stats.mtimeUnixMS,
+            retentionClass: retentionClass(for: artifactKind),
+            ownership: ownership,
+            cleanupEligibility: eligibility,
+            cleanupReason: reason,
+            activeProtection: [
+                "protected": active,
+                "reason": active ? "active_job_artifact_root" : "none",
+            ]
+        )
+    }
+
+    private func refresh(entry: StorageArtifactEntry, activeRoots: [URL]) throws -> StorageArtifactEntry? {
+        guard fileManager.fileExists(atPath: entry.url.path) else {
+            return nil
+        }
+        return makeEntry(
+            artifactID: entry.artifactID,
+            artifactKind: entry.artifactKind,
+            rootKind: entry.rootKind,
+            url: entry.url,
+            ownership: entry.ownership,
+            activeRoots: activeRoots
+        )
+    }
+
+    private func loadActiveArtifactRoots() throws -> [URL] {
+        let runRecords = try MelixRunRecordStore(melixHome: melixHome, fileManager: fileManager).loadRecords()
+        let recordRoots = runRecords
+            .filter { isActiveStatus($0.status) }
+            .compactMap { nonEmptyURL($0.artifactRoot) }
+        let queueRoots = (try? LocalTrainingQueueStore(melixHome: melixHome, fileManager: fileManager).list())?
+            .filter { $0.status.isActive }
+            .compactMap { nonEmptyURL($0.runDirectory) } ?? []
+        return storageUniqueURLs(recordRoots + queueRoots)
+    }
+
+    private func storageSummary(entries: [StorageArtifactEntry]) -> [String: Any] {
+        let retained = entries.filter { $0.cleanupEligibility == "retain" }
+        let cleanable = entries.filter { $0.cleanupEligibility == "cleanable" }
+        let protected = entries.filter { $0.cleanupEligibility == "protected_active" }
+        let blocked = entries.filter { isBlockedCleanupEligibility($0.cleanupEligibility) }
+        return [
+            "artifact_count": entries.count,
+            "inventory_byte_size": entries.reduce(UInt64(0)) { $0 + $1.byteSize },
+            "retained_entry_count": retained.count,
+            "cleanable_entry_count": cleanable.count,
+            "protected_entry_count": protected.count,
+            "blocked_entry_count": blocked.count,
+            "retained_byte_size": retained.reduce(UInt64(0)) { $0 + $1.byteSize },
+            "cleanable_byte_size": cleanable.reduce(UInt64(0)) { $0 + $1.byteSize },
+            "protected_byte_size": protected.reduce(UInt64(0)) { $0 + $1.byteSize },
+            "blocked_byte_size": blocked.reduce(UInt64(0)) { $0 + $1.byteSize },
+        ]
+    }
+
+    private func workspaceRootPayloads(_ manifest: StorageWorkspaceManifest) -> [[String: Any]] {
+        manifest.roots.values
+            .filter { $0.kind.lowercased().contains("workspace") }
+            .sorted { $0.rootID < $1.rootID }
+            .map { root in
+                [
+                    "root_id": root.rootID,
+                    "root_kind": root.kind,
+                    "path_redaction": redactedPath(manifest.resolveRoot(root.path)),
+                    "path_digest": sha256Hex(manifest.resolveRoot(root.path).path),
+                ]
+            }
+    }
+
+    private func artifactRootPayloads(_ manifest: StorageWorkspaceManifest) -> [[String: Any]] {
+        manifest.roots.values.sorted { $0.rootID < $1.rootID }.map { root in
+            [
+                "root_id": root.rootID,
+                "root_kind": root.kind,
+                "ownership": ownership(for: root),
+                "path_redaction": redactedPath(manifest.resolveRoot(root.path)),
+                "path_digest": sha256Hex(manifest.resolveRoot(root.path).path),
+            ]
+        }
+    }
+
+    private func deduplicated(_ entries: [StorageArtifactEntry]) -> [StorageArtifactEntry] {
+        var seen: Set<String> = []
+        var result: [StorageArtifactEntry] = []
+        for entry in entries {
+            let key = "\(entry.pathDigest)::\(entry.artifactKind)"
+            if seen.insert(key).inserted {
+                result.append(entry)
+            }
+        }
+        return result.sorted {
+            if $0.artifactKind == $1.artifactKind {
+                return $0.pathRedaction < $1.pathRedaction
+            }
+            return $0.artifactKind < $1.artifactKind
+        }
+    }
+
+    private func shallowFiles(_ root: URL, maxDepth: Int = 4) throws -> [URL] {
+        var results: [URL] = []
+        func walk(_ directory: URL, depth: Int) throws {
+            guard depth <= maxDepth else {
+                return
+            }
+            let children = try fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            for child in children {
+                if isDirectory(child) {
+                    try walk(child, depth: depth + 1)
+                } else {
+                    results.append(child)
+                }
+            }
+        }
+        try walk(root, depth: 0)
+        return results
+    }
+
+    private func fileStats(_ url: URL) -> (exists: Bool, byteSize: UInt64, mtimeUnixMS: Int) {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return (false, 0, 0)
+        }
+        if isDirectory(url) {
+            let files = (try? shallowFiles(url, maxDepth: 8)) ?? []
+            let size = files.reduce(UInt64(0)) { partial, file in
+                partial + fileStats(file).byteSize
+            }
+            let mtime = files.map { fileStats($0).mtimeUnixMS }.max() ?? 0
+            return (true, size, mtime)
+        }
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path) else {
+            return (true, 0, 0)
+        }
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let mtime = ((attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0) * 1000
+        return (true, size, Int(mtime))
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    private func path(_ url: URL, isInside root: URL) -> Bool {
+        let path = url.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    private func nonEmptyURL(_ path: String) -> URL? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else {
+            return nil
+        }
+        return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)
+    }
+
+    private func artifactKind(for artifactType: String) -> String {
+        switch artifactType {
+        case "WORKSPACE_ARTIFACT_TYPE_RAW_INPUTS":
+            return "raw_file"
+        case "WORKSPACE_ARTIFACT_TYPE_CLEANED_DATA":
+            return "cleaned_segment"
+        case "WORKSPACE_ARTIFACT_TYPE_DATASET_VERSION":
+            return "dataset_version"
+        case "WORKSPACE_ARTIFACT_TYPE_ADAPTER":
+            return "adapter_output"
+        case "WORKSPACE_ARTIFACT_TYPE_LOG":
+            return "runtime_log"
+        case "WORKSPACE_ARTIFACT_TYPE_EXPORT":
+            return "export_intermediate"
+        case "WORKSPACE_ARTIFACT_TYPE_REPORT", "WORKSPACE_ARTIFACT_TYPE_EVIDENCE_BUNDLE":
+            return "evidence_bundle"
+        default:
+            return "unknown"
+        }
+    }
+
+    private func ownership(for root: StorageArtifactRoot?) -> String {
+        guard let root else {
+            return "external_read_only"
+        }
+        if root.melixOwned == false {
+            return "external_read_only"
+        }
+        return root.kind.lowercased().contains("workspace") ? "workspace_owned" : "melix_owned"
+    }
+
+    private func retentionClass(for artifactKind: String) -> String {
+        switch artifactKind {
+        case "raw_file", "dataset_version", "adapter_output", "evidence_bundle":
+            return "retained_evidence"
+        case "cleaned_segment", "checkpoint", "export_intermediate", "runtime_log", "stale_temp_file":
+            return "derived_cache"
+        default:
+            return "unknown"
+        }
+    }
+
+    private func cleanupEligibility(
+        artifactKind: String,
+        ownership: String,
+        exists: Bool,
+        active: Bool
+    ) -> String {
+        guard exists else {
+            return "missing"
+        }
+        guard ownership != "external_read_only" else {
+            return "blocked_external"
+        }
+        guard artifactKind != "unknown" else {
+            return "blocked_unknown"
+        }
+        guard active == false else {
+            return "protected_active"
+        }
+        switch artifactKind {
+        case "cleaned_segment", "checkpoint", "export_intermediate", "runtime_log", "stale_temp_file":
+            return "cleanable"
+        default:
+            return "retain"
+        }
+    }
+
+    private func cleanupReason(eligibility: String, artifactKind: String) -> String {
+        switch eligibility {
+        case "retain":
+            return "\(artifactKind)_retained_by_policy"
+        case "cleanable":
+            return "\(artifactKind)_derived_inactive"
+        case "protected_active":
+            return "active_job_artifact_root"
+        case "blocked_external":
+            return "external_read_only_root"
+        case "missing":
+            return "artifact_missing"
+        case "blocked_unsafe_path":
+            return "artifact_path_outside_root"
+        default:
+            return "unknown_artifact_or_ownership"
+        }
+    }
+
+    private func resolveManifestArtifactURL(baseURL: URL, relativePath: String) -> (url: URL, isSafe: Bool) {
+        let rootURL = baseURL.standardizedFileURL
+        let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let candidate = rootURL.appendingPathComponent(trimmed).standardizedFileURL
+        guard isSafeManifestRelativePath(trimmed), path(candidate, isInside: rootURL) else {
+            return (candidate, false)
+        }
+        return (candidate, true)
+    }
+
+    private func isSafeManifestRelativePath(_ path: String) -> Bool {
+        guard path.isEmpty == false,
+              path.hasPrefix("/") == false,
+              path.hasPrefix("//") == false,
+              path.contains("\\") == false,
+              path.contains("\0") == false else {
+            return false
+        }
+        if path.count >= 2 {
+            let driveSeparatorIndex = path.index(after: path.startIndex)
+            if path[driveSeparatorIndex] == ":" {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func redactedPath(_ url: URL) -> String {
+        let path = url.standardizedFileURL.path
+        let roots = [
+            (melixHome.rootURL.standardizedFileURL.path, "$MELIX_HOME"),
+            (environment["MELIX_PROJECT_ROOT"] ?? "", "$MELIX_PROJECT_ROOT"),
+        ]
+        for (root, label) in roots where root.isEmpty == false {
+            if path == root {
+                return label
+            }
+            if path.hasPrefix(root + "/") {
+                return label + String(path.dropFirst(root.count))
+            }
+        }
+        return "<redacted-path>/\(url.lastPathComponent)"
+    }
+
+    private func cleanupReceiptURL(receiptID: String) -> URL {
+        cleanupReceiptsDirectory()
+            .appendingPathComponent("\(receiptID).json")
+    }
+
+    private func cleanupReceiptsDirectory() -> URL {
+        melixHome.rootURL
+            .appendingPathComponent("storage-cleanup", isDirectory: true)
+            .appendingPathComponent("cleanup-receipts", isDirectory: true)
+    }
+
+    private func writeJSON(_ payload: [String: Any], to url: URL) throws {
+        var data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        data.append(0x0a)
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: MelixHome.directoryPermissions]
+        )
+        try data.write(to: url, options: [.atomic])
+        try? fileManager.setAttributes([.posixPermissions: MelixHome.filePermissions], ofItemAtPath: url.path)
+    }
+}
+
+private struct StorageArtifactEntry {
+    var artifactID: String
+    var artifactKind: String
+    var rootKind: String
+    var url: URL
+    var pathRedaction: String
+    var pathDigest: String
+    var byteSize: UInt64
+    var mtimeUnixMS: Int
+    var retentionClass: String
+    var ownership: String
+    var cleanupEligibility: String
+    var cleanupReason: String
+    var activeProtection: [String: Any]
+
+    var payload: [String: Any] {
+        [
+            "artifact_id": artifactID,
+            "artifact_kind": artifactKind,
+            "root_kind": rootKind,
+            "path_redaction": pathRedaction,
+            "path_digest": pathDigest,
+            "byte_size": byteSize,
+            "mtime_unix_ms": mtimeUnixMS,
+            "retention_class": retentionClass,
+            "ownership": ownership,
+            "active_protection": activeProtection,
+            "cleanup_eligibility": cleanupEligibility,
+            "cleanup_reason": cleanupReason,
+        ]
+    }
+
+    init(
+        artifactID: String,
+        artifactKind: String,
+        rootKind: String,
+        url: URL,
+        pathRedaction: String,
+        pathDigest: String,
+        byteSize: UInt64,
+        mtimeUnixMS: Int,
+        retentionClass: String,
+        ownership: String,
+        cleanupEligibility: String,
+        cleanupReason: String,
+        activeProtection: [String: Any]
+    ) {
+        self.artifactID = artifactID
+        self.artifactKind = artifactKind
+        self.rootKind = rootKind
+        self.url = url
+        self.pathRedaction = pathRedaction
+        self.pathDigest = pathDigest
+        self.byteSize = byteSize
+        self.mtimeUnixMS = mtimeUnixMS
+        self.retentionClass = retentionClass
+        self.ownership = ownership
+        self.cleanupEligibility = cleanupEligibility
+        self.cleanupReason = cleanupReason
+        self.activeProtection = activeProtection
+    }
+}
+
+private struct StorageInventoryBuild {
+    let payload: [String: Any]
+    let entries: [StorageArtifactEntry]
+}
+
+private struct StorageWorkspaceManifest {
+    let manifestURL: URL
+    let payload: [String: Any]
+    let roots: [String: StorageArtifactRoot]
+    let artifacts: [StorageManifestArtifact]
+
+    init(manifestURL: URL, payload: [String: Any]) {
+        self.manifestURL = manifestURL
+        self.payload = payload
+        let roots = (payload["artifact_roots"] as? [[String: Any]] ?? [])
+            .map(StorageArtifactRoot.init(payload:))
+        self.roots = Dictionary(uniqueKeysWithValues: roots.map { ($0.rootID, $0) })
+        artifacts = (payload["artifacts"] as? [[String: Any]] ?? [])
+            .map(StorageManifestArtifact.init(payload:))
+    }
+
+    func resolveRoot(_ rawPath: String) -> URL {
+        let path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard path.isEmpty == false else {
+            return manifestURL.deletingLastPathComponent()
+        }
+        if path.hasPrefix("/") {
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        return manifestURL.deletingLastPathComponent().appendingPathComponent(path, isDirectory: true)
+    }
+}
+
+private struct StorageArtifactRoot {
+    let rootID: String
+    let kind: String
+    let path: String
+    let melixOwned: Bool
+
+    init(payload: [String: Any]) {
+        rootID = payload["root_id"] as? String ?? ""
+        kind = payload["kind"] as? String ?? ""
+        path = payload["path"] as? String ?? ""
+        melixOwned = payload["melix_owned"] as? Bool ?? false
+    }
+}
+
+private struct StorageManifestArtifact {
+    let artifactID: String
+    let artifactType: String
+    let rootID: String
+    let relativePath: String
+
+    init(payload: [String: Any]) {
+        artifactID = payload["artifact_id"] as? String ?? ""
+        artifactType = payload["artifact_type"] as? String ?? ""
+        rootID = payload["root_id"] as? String ?? ""
+        relativePath = payload["relative_path"] as? String ?? ""
+    }
+}
+
+private func isActiveStatus(_ status: String) -> Bool {
+    switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "active", "in_progress", "in-progress", "pending", "processing", "queued", "running", "started":
+        return true
+    default:
+        return false
+    }
+}
+
+private func isBlockedCleanupEligibility(_ eligibility: String) -> Bool {
+    switch eligibility {
+    case "blocked_external", "blocked_unknown", "blocked_unsafe_path", "missing":
+        return true
+    default:
+        return false
+    }
+}
+
+private func storageUnixMilliseconds() -> Int {
+    Int(Date().timeIntervalSince1970 * 1000)
+}
+
+private func stableID(prefix: String, seed: String) -> String {
+    "\(prefix)-\(sha256Hex(seed).prefix(12))"
+}
+
+private func sha256Hex(_ value: String) -> String {
+    SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+}
+
+private func storageUniqueURLs(_ urls: [URL]) -> [URL] {
+    var seen: Set<String> = []
+    var result: [URL] = []
+    for url in urls {
+        let path = url.standardizedFileURL.path
+        if seen.insert(path).inserted {
+            result.append(url.standardizedFileURL)
+        }
+    }
+    return result
+}

--- a/Sources/MelixCLICore/MelixStorageMaintenance.swift
+++ b/Sources/MelixCLICore/MelixStorageMaintenance.swift
@@ -113,7 +113,7 @@ public final class MelixStorageMaintenanceStore {
 
         for entry in plannedEntries where entry.cleanupEligibility == "cleanable" {
             do {
-                guard let refreshed = try refresh(entry: entry, activeRoots: activeRoots) else {
+                guard let refreshed = refresh(entry: entry, activeRoots: activeRoots) else {
                     var missing = entry
                     missing.cleanupEligibility = "missing"
                     missing.cleanupReason = "artifact_missing_before_apply"
@@ -207,8 +207,8 @@ public final class MelixStorageMaintenanceStore {
             guard url.pathExtension == "json" else {
                 return nil
             }
-            let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey])
-            guard values.isRegularFile != false else {
+            guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey]),
+                  values.isRegularFile == true else {
                 return nil
             }
             return (url, values.contentModificationDate ?? .distantPast)
@@ -333,7 +333,7 @@ public final class MelixStorageMaintenanceStore {
         guard isDirectory(root) else {
             return []
         }
-        return try shallowFiles(root).map { url in
+        return shallowFiles(root).map { url in
             makeEntry(
                 artifactID: stableID(prefix: kind, seed: url.path),
                 artifactKind: kind,
@@ -349,7 +349,7 @@ public final class MelixStorageMaintenanceStore {
         guard isDirectory(root) else {
             return []
         }
-        let files = try shallowFiles(root).filter { url in
+        let files = shallowFiles(root).filter { url in
             let name = url.lastPathComponent.lowercased()
             let path = url.path.lowercased()
             return name.contains("tmp") || name.contains("temp") || path.contains("/tmp/") || path.contains("/temp/")
@@ -371,7 +371,7 @@ public final class MelixStorageMaintenanceStore {
             return []
         }
         var entries: [StorageArtifactEntry] = []
-        for url in try shallowFiles(root) {
+        for url in shallowFiles(root) {
             let path = url.path.lowercased()
             let kind: String?
             if path.contains("/checkpoint") {
@@ -441,7 +441,7 @@ public final class MelixStorageMaintenanceStore {
         )
     }
 
-    private func refresh(entry: StorageArtifactEntry, activeRoots: [URL]) throws -> StorageArtifactEntry? {
+    private func refresh(entry: StorageArtifactEntry, activeRoots: [URL]) -> StorageArtifactEntry? {
         guard fileManager.fileExists(atPath: entry.url.path) else {
             return nil
         }
@@ -456,7 +456,7 @@ public final class MelixStorageMaintenanceStore {
     }
 
     private func loadActiveArtifactRoots() throws -> [URL] {
-        let runRecords = try MelixRunRecordStore(melixHome: melixHome, fileManager: fileManager).loadRecords()
+        let runRecords = (try? MelixRunRecordStore(melixHome: melixHome, fileManager: fileManager).loadRecords()) ?? []
         let recordRoots = runRecords
             .filter { isActiveStatus($0.status) }
             .compactMap { nonEmptyURL($0.artifactRoot) }
@@ -528,47 +528,59 @@ public final class MelixStorageMaintenanceStore {
         }
     }
 
-    private func shallowFiles(_ root: URL, maxDepth: Int = 4) throws -> [URL] {
+    private func shallowFiles(_ root: URL, maxDepth: Int = 4) -> [URL] {
         var results: [URL] = []
-        func walk(_ directory: URL, depth: Int) throws {
+        func walk(_ directory: URL, depth: Int) {
             guard depth <= maxDepth else {
                 return
             }
-            let children = try fileManager.contentsOfDirectory(
+            guard let children = try? fileManager.contentsOfDirectory(
                 at: directory,
                 includingPropertiesForKeys: [.isDirectoryKey],
                 options: [.skipsHiddenFiles]
-            )
+            ) else {
+                return
+            }
             for child in children {
-                if isDirectory(child) {
-                    try walk(child, depth: depth + 1)
+                let isDirectory = (try? child.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+                if isDirectory {
+                    walk(child, depth: depth + 1)
                 } else {
                     results.append(child)
                 }
             }
         }
-        try walk(root, depth: 0)
+        walk(root, depth: 0)
         return results
     }
 
     private func fileStats(_ url: URL) -> (exists: Bool, byteSize: UInt64, mtimeUnixMS: Int) {
-        guard fileManager.fileExists(atPath: url.path) else {
+        var isDirectory = ObjCBool(false)
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
             return (false, 0, 0)
         }
-        if isDirectory(url) {
-            let files = (try? shallowFiles(url, maxDepth: 8)) ?? []
-            let size = files.reduce(UInt64(0)) { partial, file in
-                partial + fileStats(file).byteSize
+        if isDirectory.boolValue {
+            let files = shallowFiles(url, maxDepth: 8)
+            var totalSize: UInt64 = 0
+            var maxMtimeUnixMS = 0
+            for file in files {
+                let stats = regularFileStats(file)
+                totalSize += stats.byteSize
+                maxMtimeUnixMS = max(maxMtimeUnixMS, stats.mtimeUnixMS)
             }
-            let mtime = files.map { fileStats($0).mtimeUnixMS }.max() ?? 0
-            return (true, size, mtime)
+            return (true, totalSize, maxMtimeUnixMS)
         }
+        let stats = regularFileStats(url)
+        return (true, stats.byteSize, stats.mtimeUnixMS)
+    }
+
+    private func regularFileStats(_ url: URL) -> (byteSize: UInt64, mtimeUnixMS: Int) {
         guard let attributes = try? fileManager.attributesOfItem(atPath: url.path) else {
-            return (true, 0, 0)
+            return (0, 0)
         }
         let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
         let mtime = ((attributes[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0) * 1000
-        return (true, size, Int(mtime))
+        return (size, Int(mtime))
     }
 
     private func isDirectory(_ url: URL) -> Bool {
@@ -681,7 +693,9 @@ public final class MelixStorageMaintenanceStore {
         let rootURL = baseURL.standardizedFileURL
         let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
         let candidate = rootURL.appendingPathComponent(trimmed).standardizedFileURL
-        guard isSafeManifestRelativePath(trimmed), path(candidate, isInside: rootURL) else {
+        guard isSafeManifestRelativePath(trimmed),
+              path(candidate, isInside: rootURL),
+              candidate.path != rootURL.path else {
             return (candidate, false)
         }
         return (candidate, true)

--- a/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
+++ b/apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift
@@ -8574,6 +8574,24 @@ struct DesktopDiagnosticsToolSectionView: View {
                     value: result.servingDiagnosticsDropSummaryText
                 )
             }
+            if let storageInventory = result.storageInventory {
+                debugBundleResultRow(
+                    title: "Storage Inventory",
+                    value: storageInventory.summaryText
+                )
+            }
+            if let storageCleanupPlan = result.storageCleanupPlan {
+                debugBundleResultRow(
+                    title: "Storage Cleanup Plan",
+                    value: storageCleanupPlan.summaryText
+                )
+            }
+            if let storageCleanupReceipt = result.storageCleanupReceipt {
+                debugBundleResultRow(
+                    title: "Storage Cleanup Result",
+                    value: storageCleanupReceipt.summaryText
+                )
+            }
             ForEach(Array(result.artifactRows.prefix(6))) { row in
                 debugBundleResultRow(title: row.kindText, value: row.path, allowsArtifactActions: true)
             }

--- a/apps/macos-menubar/Sources/AppMain/Models/RuntimeDiagnosticsDebugBundleState.swift
+++ b/apps/macos-menubar/Sources/AppMain/Models/RuntimeDiagnosticsDebugBundleState.swift
@@ -117,6 +117,120 @@ public struct RuntimeEnvironmentDiagnosticSummaryState: Equatable, Sendable, Dec
     }
 }
 
+public struct RuntimeStorageInventorySummaryState: Equatable, Sendable, Decodable {
+    public let artifactCount: Int
+    public let cleanableByteSize: Int
+    public let protectedByteSize: Int
+
+    public var summaryText: String {
+        "\(artifactCount) artifacts • \(cleanableByteSize) B cleanable • \(protectedByteSize) B protected"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let summary = try container.decodeIfPresent(SummaryPayload.self, forKey: .summary)
+        artifactCount = max(0, summary?.artifactCount ?? 0)
+        cleanableByteSize = max(0, summary?.cleanableByteSize ?? 0)
+        protectedByteSize = max(0, summary?.protectedByteSize ?? 0)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case summary
+    }
+
+    private struct SummaryPayload: Decodable {
+        let artifactCount: Int?
+        let cleanableByteSize: Int?
+        let protectedByteSize: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case artifactCount = "artifact_count"
+            case cleanableByteSize = "cleanable_byte_size"
+            case protectedByteSize = "protected_byte_size"
+        }
+    }
+}
+
+public struct RuntimeStorageCleanupPlanSummaryState: Equatable, Sendable, Decodable {
+    public let mode: String
+    public let cleanableEntryCount: Int
+    public let retainedEntryCount: Int
+    public let protectedEntryCount: Int
+    public let blockedEntryCount: Int
+
+    public var summaryText: String {
+        let normalizedMode = mode.isEmpty ? "dry_run" : mode
+        return "\(normalizedMode) • \(cleanableEntryCount) cleanable • \(retainedEntryCount) retained • \(protectedEntryCount) protected • \(blockedEntryCount) blocked"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        mode = RichOutputSanitizer.sanitized(try container.decodeIfPresent(String.self, forKey: .mode) ?? "")
+        let summary = try container.decodeIfPresent(SummaryPayload.self, forKey: .summary)
+        cleanableEntryCount = max(0, summary?.cleanableEntryCount ?? 0)
+        retainedEntryCount = max(0, summary?.retainedEntryCount ?? 0)
+        protectedEntryCount = max(0, summary?.protectedEntryCount ?? 0)
+        blockedEntryCount = max(0, summary?.blockedEntryCount ?? 0)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case summary
+    }
+
+    private struct SummaryPayload: Decodable {
+        let cleanableEntryCount: Int?
+        let retainedEntryCount: Int?
+        let protectedEntryCount: Int?
+        let blockedEntryCount: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case cleanableEntryCount = "cleanable_entry_count"
+            case retainedEntryCount = "retained_entry_count"
+            case protectedEntryCount = "protected_entry_count"
+            case blockedEntryCount = "blocked_entry_count"
+        }
+    }
+}
+
+public struct RuntimeStorageCleanupReceiptSummaryState: Equatable, Sendable, Decodable {
+    public let safeDeleteCount: Int
+    public let deletedByteSize: Int
+    public let protectedEntryCount: Int
+    public let failedEntryCount: Int
+
+    public var summaryText: String {
+        "\(safeDeleteCount) deleted • \(deletedByteSize) B reclaimed • \(protectedEntryCount) protected • \(failedEntryCount) failed"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let summary = try container.decodeIfPresent(SummaryPayload.self, forKey: .summary)
+        safeDeleteCount = max(0, summary?.safeDeleteCount ?? 0)
+        deletedByteSize = max(0, summary?.deletedByteSize ?? 0)
+        protectedEntryCount = max(0, summary?.protectedEntryCount ?? 0)
+        failedEntryCount = max(0, summary?.failedEntryCount ?? 0)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case summary
+    }
+
+    private struct SummaryPayload: Decodable {
+        let safeDeleteCount: Int?
+        let deletedByteSize: Int?
+        let protectedEntryCount: Int?
+        let failedEntryCount: Int?
+
+        private enum CodingKeys: String, CodingKey {
+            case safeDeleteCount = "safe_delete_count"
+            case deletedByteSize = "deleted_byte_size"
+            case protectedEntryCount = "protected_entry_count"
+            case failedEntryCount = "failed_entry_count"
+        }
+    }
+}
+
 public struct RuntimeDiagnosticsDebugBundleState: Equatable, Sendable, Decodable {
     public let schemaVersion: String
     public let bundleID: String
@@ -132,6 +246,9 @@ public struct RuntimeDiagnosticsDebugBundleState: Equatable, Sendable, Decodable
     public let mediaRouteReceipt: RuntimeDiscoveryMediaRouteReceiptState?
     public let servingDiagnostics: RuntimeDiagnosticsServingDiagnosticsSummary?
     public let environmentDiagnostic: RuntimeEnvironmentDiagnosticSummaryState?
+    public let storageInventory: RuntimeStorageInventorySummaryState?
+    public let storageCleanupPlan: RuntimeStorageCleanupPlanSummaryState?
+    public let storageCleanupReceipt: RuntimeStorageCleanupReceiptSummaryState?
 
     public var manifestPath: String {
         guard bundlePath.isEmpty == false else {
@@ -236,6 +353,18 @@ public struct RuntimeDiagnosticsDebugBundleState: Equatable, Sendable, Decodable
             RuntimeEnvironmentDiagnosticSummaryState.self,
             forKey: .environmentDiagnostic
         )
+        storageInventory = try container.decodeIfPresent(
+            RuntimeStorageInventorySummaryState.self,
+            forKey: .storageInventory
+        )
+        storageCleanupPlan = try container.decodeIfPresent(
+            RuntimeStorageCleanupPlanSummaryState.self,
+            forKey: .storageCleanupPlan
+        )
+        storageCleanupReceipt = try container.decodeIfPresent(
+            RuntimeStorageCleanupReceiptSummaryState.self,
+            forKey: .storageCleanupReceipt
+        )
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -253,6 +382,9 @@ public struct RuntimeDiagnosticsDebugBundleState: Equatable, Sendable, Decodable
         case mediaRouteReceipt = "media_route_receipt"
         case servingDiagnostics = "serving_diagnostics"
         case environmentDiagnostic = "environment_diagnostic"
+        case storageInventory = "storage_inventory"
+        case storageCleanupPlan = "storage_cleanup_plan"
+        case storageCleanupReceipt = "storage_cleanup_receipt"
     }
 
     private func artifactPath(_ relativePath: String) -> String {

--- a/apps/macos-menubar/Tests/MenuBarTests/RuntimeEvidenceReportStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/RuntimeEvidenceReportStateTests.swift
@@ -266,6 +266,86 @@ struct RuntimeEvidenceReportStateTests {
         #expect(renderedTexts.contains("24 debug events were dropped; diagnosis may be partial."))
     }
 
+    @Test("diagnostics renders storage cleanup receipts from debug bundle state")
+    @MainActor
+    func diagnosticsRendersStorageCleanupReceiptsFromDebugBundleState() throws {
+        let storageMaintenanceJSON = """
+        "storage_inventory": {
+          "schema_version": "melix.storage_inventory_receipt.v1",
+          "summary": {
+            "artifact_count": 9,
+            "inventory_byte_size": 96,
+            "retained_byte_size": 32,
+            "cleanable_byte_size": 48,
+            "protected_byte_size": 16,
+            "blocked_byte_size": 0
+          },
+          "metrics": {
+            "storage_inventory_latency_ms": 7,
+            "protected_active_artifact_count": 1
+          }
+        },
+        "storage_cleanup_plan": {
+          "schema_version": "melix.storage_cleanup_plan.v1",
+          "mode": "dry_run",
+          "cleanup_plan_id": "cleanup-plan-1",
+          "summary": {
+            "retained_entry_count": 4,
+            "cleanable_entry_count": 3,
+            "protected_entry_count": 1,
+            "blocked_entry_count": 1,
+            "retained_byte_size": 32,
+            "cleanable_byte_size": 48,
+            "protected_byte_size": 16,
+            "blocked_byte_size": 0
+          },
+          "metrics": {
+            "cleanup_dry_run_latency_ms": 5
+          }
+        },
+        "storage_cleanup_receipt": {
+          "schema_version": "melix.storage_cleanup_receipt.v1",
+          "cleanup_plan_id": "cleanup-plan-1",
+          "summary": {
+            "safe_delete_count": 2,
+            "deleted_byte_size": 40,
+            "protected_entry_count": 1,
+            "failed_entry_count": 0
+          },
+          "metrics": {
+            "cleanup_apply_latency_ms": 9,
+            "cleanup_failure_count": 0
+          }
+        },
+        """
+        let result = try RuntimeDiagnosticsDebugBundleState.decode(
+            json: makeDiagnosticsDebugBundleJSON().replacingOccurrences(
+                of: "\"media_route_receipt\": {",
+                with: "\(storageMaintenanceJSON)\n      \"media_route_receipt\": {"
+            )
+        )
+        let viewModel = RuntimeViewModel(client: FakeControlPlaneXPCClient())
+        viewModel.selectSurface(.tools)
+        viewModel.selectToolSection(.diagnostics)
+        viewModel.applyDiagnosticsDebugBundleResult(result)
+
+        let view = evidenceHostView(
+            DesktopDiagnosticsToolSectionView(
+                viewModel: viewModel,
+                foundation: viewModel.desktopFoundationState
+            ),
+            size: CGSize(width: 1280, height: 2600)
+        )
+        let renderedTexts = evidenceRenderedTextValues(in: view)
+
+        #expect(renderedTexts.contains("Storage Inventory"))
+        #expect(renderedTexts.contains("9 artifacts • 48 B cleanable • 16 B protected"))
+        #expect(renderedTexts.contains("Storage Cleanup Plan"))
+        #expect(renderedTexts.contains("dry_run • 3 cleanable • 4 retained • 1 protected • 1 blocked"))
+        #expect(renderedTexts.contains("Storage Cleanup Result"))
+        #expect(renderedTexts.contains("2 deleted • 40 B reclaimed • 1 protected • 0 failed"))
+    }
+
     @Test("diagnostics renders debug bundle redaction state")
     @MainActor
     func diagnosticsRendersDebugBundleRedactionState() throws {

--- a/docs/plans/2026-07-02-storage-inventory-cleanup-receipts.md
+++ b/docs/plans/2026-07-02-storage-inventory-cleanup-receipts.md
@@ -1,0 +1,154 @@
+# Storage Inventory And Cleanup Receipts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver #1517 by adding shared storage inventory, cleanup dry-run, and cleanup apply receipts for Melix workspace and runtime artifacts.
+
+**Architecture:** The Swift CLI owns one shared storage maintenance builder that scans workspace manifests and Melix-owned runtime roots, emits canonical JSON receipts, and performs guarded deletion only during apply. Desktop consumes the same receipt fields from diagnostic bundle JSON and renders summaries without re-running inventory or cleanup logic.
+
+**Tech Stack:** Swift CLI core, Swift Testing, macOS menubar SwiftUI state tests, JSON receipt contracts from `docs/plans/2026-06-25-desktop-environment-doctor-storage-cleanup.md`.
+
+---
+
+## Governing Context
+
+- Issue: [#1517](https://github.com/Keith-CY/melix/issues/1517)
+- Parent: [#1515](https://github.com/Keith-CY/melix/issues/1515)
+- Roadmap: `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md`
+- Contract: `docs/plans/2026-06-25-desktop-environment-doctor-storage-cleanup.md`
+- Workspace manifest contract: `docs/workspace-manifest-contract.md`
+
+This slice does not change protobuf schemas. It introduces local CLI and
+Desktop receipt handling for the already documented P4.2 storage contract.
+
+## Command Surface
+
+Add these CLI commands:
+
+```bash
+melix storage inventory [--workspace-manifest PATH] [--json]
+melix storage cleanup plan [--workspace-manifest PATH] [--json]
+melix storage cleanup apply [--workspace-manifest PATH] [--json]
+```
+
+`--json` returns the canonical receipt. Text output is a short operator summary
+derived from the same receipt fields.
+
+## Receipt Behavior
+
+Inventory writes schema `melix.storage_inventory_receipt.v1` and includes every
+artifact kind required by #1517:
+
+- `raw_file`
+- `cleaned_segment`
+- `dataset_version`
+- `checkpoint`
+- `adapter_output`
+- `export_intermediate`
+- `runtime_log`
+- `stale_temp_file`
+- `evidence_bundle`
+
+Cleanup dry-run writes schema `melix.storage_cleanup_plan.v1` with mode
+`dry_run`. It reports retained, cleanable, protected, and blocked byte counts
+and never deletes files.
+
+Cleanup apply writes schema `melix.storage_cleanup_receipt.v1`. It creates a
+same-run inventory and plan, rechecks mtime, byte size, path digest, ownership,
+and active-job protection immediately before deletion, then deletes only
+unchanged cleanable Melix-owned artifacts. Each apply writes the receipt under
+`$MELIX_HOME/storage-cleanup/cleanup-receipts/` and returns only a redacted
+receipt path plus a path digest in JSON output.
+
+Debug bundle generation writes `storage-inventory.json` and
+`storage-cleanup-plan.json` from the same storage maintenance builder. When an
+apply receipt already exists under the Melix-owned receipt directory, the debug
+bundle also copies the latest receipt to `storage-cleanup-receipt.json`. The
+manifest embeds the same redacted payloads so Desktop can render inventory,
+plan, and apply-result summaries without re-running storage probes or inferring
+cleanup state from UI.
+
+## Retention Rules
+
+Retained by default:
+
+- raw files
+- dataset versions
+- adapter outputs
+- evidence bundles
+
+Cleanable when Melix-owned or workspace-owned and inactive:
+
+- cleaned segments
+- checkpoints
+- export intermediates
+- runtime logs
+- stale temp files
+
+Blocked:
+
+- missing manifest entries
+- external read-only roots
+- unknown artifact kinds or unsafe paths
+
+Unsafe manifest paths include empty paths, absolute paths, Windows-style drive
+or backslash paths, and relative paths that escape their declared artifact root
+after normalization. Storage maintenance records those entries as blocked
+without stat'ing or deleting the escaped target.
+
+Protected:
+
+- any artifact path equal to or contained under an active run artifact root
+- any artifact path equal to or contained under an active local training queue
+  run directory
+- any artifact that changes between same-run plan generation and apply deletion
+
+## Metrics
+
+Receipts include these metrics where applicable:
+
+- `storage_inventory_latency_ms`
+- `inventory_artifact_count`
+- `inventory_byte_size`
+- `retained_byte_size`
+- `cleanable_byte_size`
+- `protected_active_artifact_count`
+- `cleanup_dry_run_latency_ms`
+- `cleanup_apply_latency_ms`
+- `safe_delete_count`
+- `deleted_byte_size`
+- `cleanup_failure_count`
+
+## Files
+
+- Create `Sources/MelixCLICore/MelixStorageMaintenance.swift`
+- Modify `Sources/MelixCLICore/MelixCLI.swift`
+- Modify `Sources/MelixCLICore/MelixCLICommandCodec.swift`
+- Modify `Sources/MelixCLICore/MelixDiagnostics.swift`
+- Modify `tests/MelixCLITests/MelixCLIParserTests.swift`
+- Modify `tests/MelixCLITests/MelixCLIRunnerTests.swift`
+- Modify `apps/macos-menubar/Sources/AppMain/Models/RuntimeDiagnosticsDebugBundleState.swift`
+- Modify `apps/macos-menubar/Sources/AppMain/Dashboard/DesktopWorkspaceShellView.swift`
+- Modify `apps/macos-menubar/Tests/MenuBarTests/RuntimeEvidenceReportStateTests.swift`
+
+## Verification
+
+Use TDD for each behavior. Focused checks:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIParserTests/parsesRuntimeSettingsAndDiscoveryCommands'
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/storageInventoryCleanupPlanAndApplyShareSafeReceipts'
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/debugBundleEmbedsLatestStorageCleanupReceiptForDesktopResultParity'
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --filter 'MelixCLIRunnerTests/offlineRunRecordCommandsListShowExportAndReportLocalArtifacts'
+HOME="$PWD/.swift-home-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.menubar.noindex" swift test --package-path apps/macos-menubar --filter 'RuntimeEvidenceReportStateTests/diagnosticsRendersStorageCleanupReceiptsFromDebugBundleState'
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" make swift-test
+```
+
+Full pre-PR gate:
+
+```bash
+git diff --check
+make swift-test
+make py-test
+make integration-test
+```

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -23,6 +23,9 @@ struct MelixCLIParserTests {
         #expect(MelixCLIParser.usageText.contains("melix capabilities --json [--model-query MODEL]"))
         #expect(MelixCLIParser.usageText.contains("melix config metadata --json"))
         #expect(MelixCLIParser.usageText.contains("melix workspace preflight --manifest PATH [--output PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix storage inventory [--workspace-manifest PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix storage cleanup plan [--workspace-manifest PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix storage cleanup apply [--workspace-manifest PATH] [--json]"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare ingest --workspace-project-id ID --workspace-manifest PATH --input PATH --output-dir PATH --dataset-preparation-id ID"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare version --workspace-manifest PATH --ingest-receipt PATH --output-root PATH --dataset-id ID"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare retry-failed --workspace-manifest PATH --dataset-version PATH --output-root PATH"))
@@ -54,6 +57,29 @@ struct MelixCLIParserTests {
                 "/tmp/melix-workspace/workspace-preflight-receipt.json",
                 "--json",
             ], "workspace.preflight"),
+            ([
+                "storage",
+                "inventory",
+                "--workspace-manifest",
+                "/tmp/melix-workspace/workspace-manifest.json",
+                "--json",
+            ], "storage.inventory"),
+            ([
+                "storage",
+                "cleanup",
+                "plan",
+                "--workspace-manifest",
+                "/tmp/melix-workspace/workspace-manifest.json",
+                "--json",
+            ], "storage.cleanup.plan"),
+            ([
+                "storage",
+                "cleanup",
+                "apply",
+                "--workspace-manifest",
+                "/tmp/melix-workspace/workspace-manifest.json",
+                "--json",
+            ], "storage.cleanup.apply"),
             ([
                 "dataset",
                 "prepare",
@@ -227,6 +253,15 @@ struct MelixCLIParserTests {
         }
         #expect(throws: MelixCLIError.missingRequired("--manifest is required for melix workspace preflight.")) {
             _ = try MelixCLIParser.parse(["workspace", "preflight", "--json"])
+        }
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            _ = try MelixCLIParser.parse(["storage"])
+        }
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            _ = try MelixCLIParser.parse(["storage", "cleanup"])
+        }
+        #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
+            _ = try MelixCLIParser.parse(["storage", "cleanup", "unknown", "--json"])
         }
         #expect(throws: MelixCLIError.usage(MelixCLIParser.usageText)) {
             _ = try MelixCLIParser.parse(["jobs"])
@@ -700,6 +735,9 @@ struct MelixCLIParserTests {
         #expect(MelixCLIParser.usageText.contains("melix monitor [--from PATH] [--json]"))
         #expect(MelixCLIParser.usageText.contains("melix logs JOB_ID"))
         #expect(MelixCLIParser.usageText.contains("melix debug bundle RUN_OR_JOB_ID"))
+        #expect(MelixCLIParser.usageText.contains("melix storage inventory [--workspace-manifest PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix storage cleanup plan [--workspace-manifest PATH] [--json]"))
+        #expect(MelixCLIParser.usageText.contains("melix storage cleanup apply [--workspace-manifest PATH] [--json]"))
         #expect(MelixCLIParser.usageText.contains("melix convert --model-id MODEL_ID"))
         #expect(MelixCLIParser.usageText.contains("melix quantize --model-id MODEL_ID"))
         #expect(MelixCLIParser.usageText.contains("melix upload --model-id MODEL_ID"))
@@ -730,6 +768,26 @@ struct MelixCLIParserTests {
             "bench-1",
             "--from", "/tmp/melix/jobs",
             "--output", "/tmp/melix-debug/bench-1",
+            "--json",
+        ])
+        let storageInventoryCommand = try MelixCLIParser.parse([
+            "storage",
+            "inventory",
+            "--workspace-manifest", "/tmp/workspace/workspace-manifest.json",
+            "--json",
+        ])
+        let storageCleanupPlanCommand = try MelixCLIParser.parse([
+            "storage",
+            "cleanup",
+            "plan",
+            "--workspace-manifest", "/tmp/workspace/workspace-manifest.json",
+            "--json",
+        ])
+        let storageCleanupApplyCommand = try MelixCLIParser.parse([
+            "storage",
+            "cleanup",
+            "apply",
+            "--workspace-manifest", "/tmp/workspace/workspace-manifest.json",
             "--json",
         ])
         let convertCommand = try MelixCLIParser.parse([
@@ -816,6 +874,12 @@ struct MelixCLIParserTests {
         #expect(debugBundleOptions.sourcePath == "/tmp/melix/jobs")
         #expect(debugBundleOptions.outputPath == "/tmp/melix-debug/bench-1")
         #expect(debugBundleOptions.json)
+        #expect(String(describing: storageInventoryCommand).contains("storageInventory"))
+        #expect(String(describing: storageInventoryCommand).contains("/tmp/workspace/workspace-manifest.json"))
+        #expect(String(describing: storageCleanupPlanCommand).contains("storageCleanupPlan"))
+        #expect(String(describing: storageCleanupPlanCommand).contains("/tmp/workspace/workspace-manifest.json"))
+        #expect(String(describing: storageCleanupApplyCommand).contains("storageCleanupApply"))
+        #expect(String(describing: storageCleanupApplyCommand).contains("/tmp/workspace/workspace-manifest.json"))
         #expect(convertOptions.modelID == "melix-dev-text")
         #expect(convertOptions.outputDir == "/tmp/melix-convert")
         #expect(convertOptions.targetFormat == "melix_model_bundle")

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -296,6 +296,297 @@ struct MelixCLIRunnerTests {
         #expect(findings[0]["severity"] as? String == "warning")
     }
 
+    @Test("storage inventory cleanup plan and apply share safe receipts")
+    func storageInventoryCleanupPlanAndApplyShareSafeReceipts() async throws {
+        let fixture = try makeStorageMaintenanceFixtureForTest()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": fixture.melixHome.path,
+                "MELIX_PROJECT_ROOT": fixture.workspace.path,
+            ]
+        )
+
+        let inventoryCommand = try MelixCLIParser.parse([
+            "storage",
+            "inventory",
+            "--workspace-manifest",
+            fixture.manifest.path,
+            "--json",
+        ])
+        let inventoryOutput = try await runner.run(inventoryCommand)
+        let inventory = try #require(parseJSONObject(inventoryOutput))
+        let inventoryEntries = try #require(inventory["artifact_entries"] as? [[String: Any]])
+        let inventoryEntriesByID = Dictionary(
+            uniqueKeysWithValues: inventoryEntries.compactMap { entry -> (String, [String: Any])? in
+                guard let artifactID = entry["artifact_id"] as? String else {
+                    return nil
+                }
+                return (artifactID, entry)
+            }
+        )
+        let inventoryKinds = Set(inventoryEntries.compactMap { $0["artifact_kind"] as? String })
+        let inventorySummary = try #require(inventory["summary"] as? [String: Any])
+        let inventoryMetrics = try #require(inventory["metrics"] as? [String: Any])
+        let externalEntry = try #require(inventoryEntriesByID["external-raw"])
+        let unknownEntry = try #require(inventoryEntriesByID["unknown-custom"])
+        let missingEntry = try #require(inventoryEntriesByID["missing-cleaned"])
+        let unsafeEntry = try #require(inventoryEntriesByID["unsafe-escape"])
+        let directoryEntry = try #require(inventoryEntriesByID["export-cache-dir"])
+
+        #expect(inventory["schema_version"] as? String == "melix.storage_inventory_receipt.v1")
+        #expect(inventoryKinds.isSuperset(of: [
+            "raw_file",
+            "cleaned_segment",
+            "dataset_version",
+            "checkpoint",
+            "adapter_output",
+            "export_intermediate",
+            "runtime_log",
+            "stale_temp_file",
+            "evidence_bundle",
+            "unknown",
+        ]))
+        #expect((inventorySummary["artifact_count"] as? NSNumber)?.intValue ?? 0 >= 9)
+        #expect((inventoryMetrics["storage_inventory_latency_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+        #expect((inventoryMetrics["inventory_artifact_count"] as? NSNumber)?.intValue ?? 0 >= 9)
+        #expect(externalEntry["cleanup_eligibility"] as? String == "blocked_external")
+        #expect(externalEntry["cleanup_reason"] as? String == "external_read_only_root")
+        #expect(unknownEntry["cleanup_eligibility"] as? String == "blocked_unknown")
+        #expect(unknownEntry["cleanup_reason"] as? String == "unknown_artifact_or_ownership")
+        #expect(missingEntry["cleanup_eligibility"] as? String == "missing")
+        #expect(missingEntry["cleanup_reason"] as? String == "artifact_missing")
+        #expect(unsafeEntry["cleanup_eligibility"] as? String == "blocked_unsafe_path")
+        #expect(unsafeEntry["cleanup_reason"] as? String == "artifact_path_outside_root")
+        #expect((directoryEntry["byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
+        #expect(inventoryOutput.contains(fixture.workspace.path) == false)
+
+        let planCommand = try MelixCLIParser.parse([
+            "storage",
+            "cleanup",
+            "plan",
+            "--workspace-manifest",
+            fixture.manifest.path,
+            "--json",
+        ])
+        let planOutput = try await runner.run(planCommand)
+        let plan = try #require(parseJSONObject(planOutput))
+        let cleanableEntries = try #require(plan["cleanable_entries"] as? [[String: Any]])
+        let protectedEntries = try #require(plan["protected_entries"] as? [[String: Any]])
+        let blockedEntries = try #require(plan["blocked_entries"] as? [[String: Any]])
+        let retainedEntries = try #require(plan["retained_entries"] as? [[String: Any]])
+        let planSummary = try #require(plan["summary"] as? [String: Any])
+        let planMetrics = try #require(plan["metrics"] as? [String: Any])
+
+        #expect(plan["schema_version"] as? String == "melix.storage_cleanup_plan.v1")
+        #expect(plan["mode"] as? String == "dry_run")
+        #expect(cleanableEntries.contains { $0["artifact_kind"] as? String == "cleaned_segment" })
+        #expect(cleanableEntries.contains { $0["artifact_kind"] as? String == "stale_temp_file" })
+        #expect(cleanableEntries.contains { $0["artifact_id"] as? String == "export-cache-dir" })
+        #expect(protectedEntries.contains { $0["artifact_kind"] as? String == "checkpoint" })
+        #expect(blockedEntries.contains { $0["artifact_id"] as? String == "external-raw" })
+        #expect(blockedEntries.contains { $0["artifact_id"] as? String == "unknown-custom" })
+        #expect(blockedEntries.contains { $0["artifact_id"] as? String == "missing-cleaned" })
+        #expect(blockedEntries.contains { $0["artifact_id"] as? String == "unsafe-escape" })
+        #expect(retainedEntries.contains { $0["artifact_kind"] as? String == "raw_file" })
+        #expect((planSummary["cleanable_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
+        #expect((planSummary["retained_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
+        #expect((planSummary["protected_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
+        #expect((planMetrics["cleanup_dry_run_latency_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableCleaned.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableTemp.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.protectedCheckpoint.path))
+
+        let applyCommand = try MelixCLIParser.parse([
+            "storage",
+            "cleanup",
+            "apply",
+            "--workspace-manifest",
+            fixture.manifest.path,
+            "--json",
+        ])
+        let applyOutput = try await runner.run(applyCommand)
+        let receipt = try #require(parseJSONObject(applyOutput))
+        let deletedEntries = try #require(receipt["deleted_entries"] as? [[String: Any]])
+        let receiptProtectedEntries = try #require(receipt["protected_entries"] as? [[String: Any]])
+        let receiptSummary = try #require(receipt["summary"] as? [String: Any])
+        let receiptMetrics = try #require(receipt["metrics"] as? [String: Any])
+
+        #expect(receipt["schema_version"] as? String == "melix.storage_cleanup_receipt.v1")
+        #expect(deletedEntries.contains { $0["artifact_kind"] as? String == "cleaned_segment" })
+        #expect(deletedEntries.contains { $0["artifact_kind"] as? String == "stale_temp_file" })
+        #expect(deletedEntries.contains { $0["artifact_id"] as? String == "export-cache-dir" })
+        #expect(receiptProtectedEntries.contains { $0["artifact_kind"] as? String == "checkpoint" })
+        #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "external-raw" })
+        #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "unknown-custom" })
+        #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "missing-cleaned" })
+        #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "unsafe-escape" })
+        #expect((receiptSummary["safe_delete_count"] as? NSNumber)?.intValue ?? 0 >= 2)
+        #expect((receiptSummary["deleted_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
+        #expect((receiptMetrics["cleanup_apply_latency_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
+        #expect((receiptMetrics["cleanup_failure_count"] as? NSNumber)?.intValue ?? -1 == 0)
+        let receiptPathRedaction = try #require(receipt["receipt_path_redaction"] as? String)
+        let receiptPathDigest = try #require(receipt["receipt_path_digest"] as? String)
+        #expect(receiptPathRedaction.hasPrefix("$MELIX_HOME/storage-cleanup/cleanup-receipts/"))
+        #expect(receiptPathDigest.isEmpty == false)
+        let receiptDirectory = fixture.melixHome
+            .appendingPathComponent("storage-cleanup", isDirectory: true)
+            .appendingPathComponent("cleanup-receipts", isDirectory: true)
+        let receiptFiles = try FileManager.default.contentsOfDirectory(
+            at: receiptDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "json" }
+        #expect(receiptFiles.count == 1)
+        let persistedReceipt = try #require(try parseJSONFile(receiptFiles[0].path))
+        #expect(persistedReceipt["schema_version"] as? String == "melix.storage_cleanup_receipt.v1")
+        #expect(persistedReceipt["cleanup_receipt_id"] as? String == receipt["cleanup_receipt_id"] as? String)
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableCleaned.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableDirectory.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableTemp.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.externalRaw.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.unknownArtifact.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.unsafeEscapeTarget.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.missingCleaned.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.protectedCheckpoint.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.retainedRaw.path))
+        #expect(applyOutput.contains(fixture.workspace.path) == false)
+    }
+
+    @Test("storage cleanup text output summarizes the same safe plan")
+    func storageCleanupTextOutputSummarizesTheSameSafePlan() async throws {
+        let fixture = try makeStorageMaintenanceFixtureForTest()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": fixture.melixHome.path,
+                "MELIX_PROJECT_ROOT": fixture.workspace.path,
+            ]
+        )
+
+        let inventoryText = try await runner.run(
+            try MelixCLIParser.parse([
+                "storage",
+                "inventory",
+                "--workspace-manifest",
+                fixture.manifest.path,
+            ])
+        )
+        #expect(inventoryText.hasPrefix("Storage inventory: "))
+        #expect(inventoryText.contains(" artifacts, "))
+        #expect(inventoryText.contains(" cleanable, "))
+        #expect(inventoryText.contains(" protected."))
+
+        let planText = try await runner.run(
+            try MelixCLIParser.parse([
+                "storage",
+                "cleanup",
+                "plan",
+                "--workspace-manifest",
+                fixture.manifest.path,
+            ])
+        )
+        #expect(planText.hasPrefix("Storage cleanup dry-run: "))
+        #expect(planText.contains(" cleanable, "))
+        #expect(planText.contains(" retained, "))
+        #expect(planText.contains(" protected, "))
+        #expect(planText.contains(" blocked, "))
+        #expect(planText.contains(" reclaimable."))
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableCleaned.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableDirectory.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableTemp.path))
+
+        let applyText = try await runner.run(
+            try MelixCLIParser.parse([
+                "storage",
+                "cleanup",
+                "apply",
+                "--workspace-manifest",
+                fixture.manifest.path,
+            ])
+        )
+        #expect(applyText.hasPrefix("Storage cleanup applied: "))
+        #expect(applyText.contains(" deleted, "))
+        #expect(applyText.contains(" reclaimed, "))
+        #expect(applyText.contains(" protected, "))
+        #expect(applyText.contains(" failed."))
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableCleaned.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableDirectory.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.cleanableTemp.path) == false)
+        #expect(FileManager.default.fileExists(atPath: fixture.externalRaw.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.unknownArtifact.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.unsafeEscapeTarget.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.protectedCheckpoint.path))
+        #expect(applyText.contains(fixture.workspace.path) == false)
+    }
+
+    @Test("debug bundle embeds latest storage cleanup receipt for Desktop result parity")
+    func debugBundleEmbedsLatestStorageCleanupReceiptForDesktopResultParity() async throws {
+        let fixture = try makeStorageMaintenanceFixtureForTest()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": fixture.melixHome.path,
+                "MELIX_PROJECT_ROOT": fixture.workspace.path,
+            ]
+        )
+        let applyOutput = try await runner.run(
+            try MelixCLIParser.parse([
+                "storage",
+                "cleanup",
+                "apply",
+                "--workspace-manifest",
+                fixture.manifest.path,
+                "--json",
+            ])
+        )
+        let applyReceipt = try #require(parseJSONObject(applyOutput))
+        let applyReceiptID = try #require(applyReceipt["cleanup_receipt_id"] as? String)
+        let runRoot = fixture.melixHome
+            .appendingPathComponent("jobs", isDirectory: true)
+            .appendingPathComponent("model-ops", isDirectory: true)
+            .appendingPathComponent("bench", isDirectory: true)
+            .appendingPathComponent("storage-debug-bundle", isDirectory: true)
+        try FileManager.default.createDirectory(at: runRoot, withIntermediateDirectories: true)
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(
+                runID: "storage-debug-bundle",
+                runKind: "benchmark",
+                runRoot: runRoot,
+                startedAtUnixMS: 1_712_100_000_000
+            ),
+            to: runRoot.appendingPathComponent("run-record.json")
+        )
+
+        let bundleRoot = fixture.root.appendingPathComponent("debug-bundle", isDirectory: true)
+        let bundleOutput = try await runner.run(
+            .debugBundle(
+                .init(
+                    runID: "storage-debug-bundle",
+                    outputPath: bundleRoot.path,
+                    json: true
+                )
+            )
+        )
+        let bundle = try #require(parseJSONObject(bundleOutput))
+        let artifacts = try #require(bundle["artifacts"] as? [String: String])
+        let cleanupReceipt = try #require(bundle["storage_cleanup_receipt"] as? [String: Any])
+
+        #expect(artifacts["storage_cleanup_receipt"] == "storage-cleanup-receipt.json")
+        #expect(cleanupReceipt["schema_version"] as? String == "melix.storage_cleanup_receipt.v1")
+        #expect(cleanupReceipt["cleanup_receipt_id"] as? String == applyReceiptID)
+        let receiptFile = try #require(try parseJSONFile(
+            bundleRoot.appendingPathComponent("storage-cleanup-receipt.json").path
+        ))
+        #expect(receiptFile["cleanup_receipt_id"] as? String == applyReceiptID)
+        #expect(bundleOutput.contains(fixture.workspace.path) == false)
+    }
+
     @Test("json v1 wraps command results in a stable envelope")
     func jsonV1WrapsCommandResultsInAStableEnvelope() async throws {
         let client = StubControlPlaneXPCClient()
@@ -12561,6 +12852,8 @@ struct MelixCLIRunnerTests {
             "metrics.json",
             "error.json",
             "environment-diagnostic.json",
+            "storage-inventory.json",
+            "storage-cleanup-plan.json",
             "manifest.json",
         ] {
             #expect(FileManager.default.fileExists(atPath: bundleOutputRoot.appendingPathComponent(filename).path))
@@ -12595,9 +12888,17 @@ struct MelixCLIRunnerTests {
         let manifestProxyVariables = try #require(manifestProxyObserved["variables"] as? [[String: Any]])
         let manifestProxyExpected = try #require(manifestProxyCheck["expected"] as? [String: Any])
         let manifestArtifacts = try #require(bundleManifest["artifacts"] as? [String: String])
+        let manifestStorageInventory = try #require(bundleManifest["storage_inventory"] as? [String: Any])
+        let manifestStorageCleanupPlan = try #require(bundleManifest["storage_cleanup_plan"] as? [String: Any])
         let bundleMediaRouteReceipt = try #require(capabilityReceipts["media_route_receipt"] as? [String: Any])
         let environmentDiagnosticFile = try #require(try parseJSONFile(
             bundleOutputRoot.appendingPathComponent("environment-diagnostic.json").path
+        ))
+        let storageInventoryFile = try #require(try parseJSONFile(
+            bundleOutputRoot.appendingPathComponent("storage-inventory.json").path
+        ))
+        let storageCleanupPlanFile = try #require(try parseJSONFile(
+            bundleOutputRoot.appendingPathComponent("storage-cleanup-plan.json").path
         ))
         #expect(bundleLogs.contains("sk-secret-log") == false)
         #expect(bundleEnv.contains("sk-secret-env") == false)
@@ -12611,8 +12912,16 @@ struct MelixCLIRunnerTests {
         #expect(bundleManifest["debug_jsonl_enabled"] as? Bool == true)
         #expect(bundleManifest["debug_jsonl_event_limit"] as? Int == 256)
         #expect(manifestArtifacts["environment_diagnostic"] == "environment-diagnostic.json")
+        #expect(manifestArtifacts["storage_inventory"] == "storage-inventory.json")
+        #expect(manifestArtifacts["storage_cleanup_plan"] == "storage-cleanup-plan.json")
         #expect(manifestEnvironmentDiagnostic["schema_version"] as? String == "melix.desktop_environment_diagnostic_receipt.v1")
         #expect(environmentDiagnosticFile["schema_version"] as? String == "melix.desktop_environment_diagnostic_receipt.v1")
+        #expect(manifestStorageInventory["schema_version"] as? String == "melix.storage_inventory_receipt.v1")
+        #expect(manifestStorageCleanupPlan["schema_version"] as? String == "melix.storage_cleanup_plan.v1")
+        #expect(manifestStorageCleanupPlan["mode"] as? String == "dry_run")
+        #expect(storageInventoryFile["schema_version"] as? String == "melix.storage_inventory_receipt.v1")
+        #expect(storageCleanupPlanFile["schema_version"] as? String == "melix.storage_cleanup_plan.v1")
+        #expect(storageCleanupPlanFile["mode"] as? String == "dry_run")
         #expect((manifestEnvironmentSummary["check_count"] as? Int ?? 0) >= 10)
         #expect(manifestProxyVariables.allSatisfy { $0["contains_credentials"] is Bool })
         #expect(manifestProxyExpected["secret_values_redacted"] as? Bool == true)
@@ -14526,7 +14835,99 @@ private func requireExecutablePathForTest(_ executableName: String) throws -> St
     throw MelixCLIError.runtime("Required test executable '\(executableName)' was not found in PATH.")
 }
 
-private func writeWorkspaceManifestForPreflightTest(to url: URL) throws {
+private func writeWorkspaceManifestForPreflightTest(
+    to url: URL,
+    extraArtifactRoots: [[String: Any]] = [],
+    extraArtifacts: [[String: Any]] = []
+) throws {
+    let artifactRoots: [[String: Any]] = [
+        [
+            "root_id": "workspace",
+            "kind": "ARTIFACT_ROOT_KIND_WORKSPACE",
+            "path": ".",
+            "uri": "melix-workspace://swift-preflight",
+            "melix_owned": true,
+            "redaction_scope": "relative_path_only",
+        ],
+        [
+            "root_id": "jobs",
+            "kind": "ARTIFACT_ROOT_KIND_JOBS",
+            "path": "jobs",
+            "uri": "melix-workspace://swift-preflight/jobs",
+            "melix_owned": true,
+            "redaction_scope": "relative_path_only",
+        ],
+    ] + extraArtifactRoots
+    let artifacts: [[String: Any]] = [
+        [
+            "artifact_id": "raw-dialogues",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_RAW_INPUTS",
+            "root_id": "workspace",
+            "relative_path": "raw/dialogues.jsonl",
+            "media_type": "application/jsonl",
+            "provenance_ref_ids": ["operator-import"],
+        ],
+        [
+            "artifact_id": "cleaned-dialogues",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_CLEANED_DATA",
+            "root_id": "workspace",
+            "relative_path": "cleaned/dialogues.clean.jsonl",
+            "media_type": "application/jsonl",
+            "provenance_ref_ids": ["operator-import"],
+        ],
+        [
+            "artifact_id": "dataset-v1",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_DATASET_VERSION",
+            "root_id": "workspace",
+            "relative_path": "dataset/20260524T000000Z/manifest.json",
+            "schema_version": "melix.training_dataset_package.v1",
+            "media_type": "application/json",
+            "provenance_ref_ids": ["operator-import", "dataset-generation-v1"],
+        ],
+        [
+            "artifact_id": "adapter-v1",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_ADAPTER",
+            "root_id": "jobs",
+            "relative_path": "train_lora/model-ops-0001/train_lora.adapter.json",
+            "schema_version": "melix.lora_adapter_package.v1",
+            "media_type": "application/json",
+            "provenance_ref_ids": ["dataset-generation-v1", "lora-train-v1"],
+        ],
+        [
+            "artifact_id": "training-log",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_LOG",
+            "root_id": "jobs",
+            "relative_path": "train_lora/model-ops-0001/run.log",
+            "media_type": "text/plain",
+            "provenance_ref_ids": ["lora-train-v1"],
+        ],
+        [
+            "artifact_id": "adapter-export",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EXPORT",
+            "root_id": "workspace",
+            "relative_path": "exports/adapter-v1/export-manifest.json",
+            "media_type": "application/json",
+            "provenance_ref_ids": ["lora-train-v1"],
+        ],
+        [
+            "artifact_id": "evaluation-report",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_REPORT",
+            "root_id": "workspace",
+            "relative_path": "reports/evaluation-summary.json",
+            "media_type": "application/json",
+            "provenance_ref_ids": ["eval-compare-v1"],
+        ],
+        [
+            "artifact_id": "release-evidence",
+            "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EVIDENCE_BUNDLE",
+            "root_id": "workspace",
+            "relative_path": "evidence/release-compare.bundle.json",
+            "schema_version": "melix.run_evidence_bundle.v1",
+            "media_type": "application/json",
+            "provenance_ref_ids": ["eval-compare-v1"],
+        ],
+    ] + extraArtifacts
+
     try writeJSONObjectForTest(
         [
             "schema_version": "melix.workspace_manifest.v1",
@@ -14537,93 +14938,8 @@ private func writeWorkspaceManifestForPreflightTest(to url: URL) throws {
                 "created_at": "2026-05-24T00:00:00Z",
                 "updated_at": "2026-05-24T00:00:00Z",
             ],
-            "artifact_roots": [
-                [
-                    "root_id": "workspace",
-                    "kind": "ARTIFACT_ROOT_KIND_WORKSPACE",
-                    "path": ".",
-                    "uri": "melix-workspace://swift-preflight",
-                    "melix_owned": true,
-                    "redaction_scope": "relative_path_only",
-                ],
-                [
-                    "root_id": "jobs",
-                    "kind": "ARTIFACT_ROOT_KIND_JOBS",
-                    "path": "jobs",
-                    "uri": "melix-workspace://swift-preflight/jobs",
-                    "melix_owned": true,
-                    "redaction_scope": "relative_path_only",
-                ],
-            ],
-            "artifacts": [
-                [
-                    "artifact_id": "raw-dialogues",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_RAW_INPUTS",
-                    "root_id": "workspace",
-                    "relative_path": "raw/dialogues.jsonl",
-                    "media_type": "application/jsonl",
-                    "provenance_ref_ids": ["operator-import"],
-                ],
-                [
-                    "artifact_id": "cleaned-dialogues",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_CLEANED_DATA",
-                    "root_id": "workspace",
-                    "relative_path": "cleaned/dialogues.clean.jsonl",
-                    "media_type": "application/jsonl",
-                    "provenance_ref_ids": ["operator-import"],
-                ],
-                [
-                    "artifact_id": "dataset-v1",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_DATASET_VERSION",
-                    "root_id": "workspace",
-                    "relative_path": "dataset/20260524T000000Z/manifest.json",
-                    "schema_version": "melix.training_dataset_package.v1",
-                    "media_type": "application/json",
-                    "provenance_ref_ids": ["operator-import", "dataset-generation-v1"],
-                ],
-                [
-                    "artifact_id": "adapter-v1",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_ADAPTER",
-                    "root_id": "jobs",
-                    "relative_path": "train_lora/model-ops-0001/train_lora.adapter.json",
-                    "schema_version": "melix.lora_adapter_package.v1",
-                    "media_type": "application/json",
-                    "provenance_ref_ids": ["dataset-generation-v1", "lora-train-v1"],
-                ],
-                [
-                    "artifact_id": "training-log",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_LOG",
-                    "root_id": "jobs",
-                    "relative_path": "train_lora/model-ops-0001/run.log",
-                    "media_type": "text/plain",
-                    "provenance_ref_ids": ["lora-train-v1"],
-                ],
-                [
-                    "artifact_id": "adapter-export",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EXPORT",
-                    "root_id": "workspace",
-                    "relative_path": "exports/adapter-v1/export-manifest.json",
-                    "media_type": "application/json",
-                    "provenance_ref_ids": ["lora-train-v1"],
-                ],
-                [
-                    "artifact_id": "evaluation-report",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_REPORT",
-                    "root_id": "workspace",
-                    "relative_path": "reports/evaluation-summary.json",
-                    "media_type": "application/json",
-                    "provenance_ref_ids": ["eval-compare-v1"],
-                ],
-                [
-                    "artifact_id": "release-evidence",
-                    "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EVIDENCE_BUNDLE",
-                    "root_id": "workspace",
-                    "relative_path": "evidence/release-compare.bundle.json",
-                    "schema_version": "melix.run_evidence_bundle.v1",
-                    "media_type": "application/json",
-                    "provenance_ref_ids": ["eval-compare-v1"],
-                ],
-            ],
+            "artifact_roots": artifactRoots,
+            "artifacts": artifacts,
             "provenance": [
                 [
                     "provenance_ref_id": "operator-import",
@@ -14684,6 +15000,165 @@ private func writeWorkspaceManifestForPreflightTest(to url: URL) throws {
             ] as [String: Any],
         ],
         to: url
+    )
+}
+
+private struct StorageMaintenanceFixtureForTest {
+    let root: URL
+    let workspace: URL
+    let melixHome: URL
+    let manifest: URL
+    let retainedRaw: URL
+    let cleanableCleaned: URL
+    let cleanableDirectory: URL
+    let cleanableTemp: URL
+    let externalRaw: URL
+    let unknownArtifact: URL
+    let missingCleaned: URL
+    let unsafeEscapeTarget: URL
+    let protectedCheckpoint: URL
+}
+
+private func makeStorageMaintenanceFixtureForTest() throws -> StorageMaintenanceFixtureForTest {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("melix-storage-maintenance-\(UUID().uuidString)", isDirectory: true)
+    let workspace = root.appendingPathComponent("workspace", isDirectory: true)
+    let melixHome = root.appendingPathComponent("home", isDirectory: true)
+    let manifest = workspace.appendingPathComponent("workspace-manifest.json")
+    let retainedRaw = workspace.appendingPathComponent("raw/dialogues.jsonl")
+    let cleanableCleaned = workspace.appendingPathComponent("cleaned/dialogues.clean.jsonl")
+    let cleanableDirectory = workspace.appendingPathComponent("exports/cache-dir", isDirectory: true)
+    let cleanableDirectoryFile = cleanableDirectory.appendingPathComponent("chunk.bin")
+    let datasetVersion = workspace.appendingPathComponent("dataset/20260524T000000Z/manifest.json")
+    let adapterManifest = workspace.appendingPathComponent("jobs/train_lora/model-ops-0001/train_lora.adapter.json")
+    let runtimeLog = workspace.appendingPathComponent("jobs/train_lora/model-ops-0001/run.log")
+    let exportManifest = workspace.appendingPathComponent("exports/adapter-v1/export-manifest.json")
+    let report = workspace.appendingPathComponent("reports/evaluation-summary.json")
+    let evidenceBundle = workspace.appendingPathComponent("evidence/release-compare.bundle.json")
+    let externalRaw = root.appendingPathComponent("external/external-source.jsonl")
+    let unknownArtifact = workspace.appendingPathComponent("unknown/custom.bin")
+    let missingCleaned = workspace.appendingPathComponent("missing/missing.clean.jsonl")
+    let unsafeEscapeTarget = root.appendingPathComponent("outside-cache.bin")
+    let cleanableTemp = melixHome
+        .appendingPathComponent("run", isDirectory: true)
+        .appendingPathComponent("stale-temp", isDirectory: true)
+        .appendingPathComponent("download.tmp")
+    let protectedRunRoot = melixHome
+        .appendingPathComponent("jobs", isDirectory: true)
+        .appendingPathComponent("model-ops", isDirectory: true)
+        .appendingPathComponent("bench", isDirectory: true)
+        .appendingPathComponent("active-cleanup", isDirectory: true)
+    let protectedCheckpoint = protectedRunRoot
+        .appendingPathComponent("checkpoint-1", isDirectory: true)
+        .appendingPathComponent("adapters.safetensors")
+    let activeRecordPath = protectedRunRoot.appendingPathComponent("run-record.json")
+    let logsDirectory = melixHome.appendingPathComponent("logs", isDirectory: true)
+    let melixLog = logsDirectory.appendingPathComponent("runtime.log")
+
+    for file in [
+        retainedRaw,
+        cleanableCleaned,
+        cleanableDirectoryFile,
+        datasetVersion,
+        adapterManifest,
+        runtimeLog,
+        exportManifest,
+        report,
+        evidenceBundle,
+        externalRaw,
+        unknownArtifact,
+        unsafeEscapeTarget,
+        cleanableTemp,
+        protectedCheckpoint,
+        melixLog,
+    ] {
+        try FileManager.default.createDirectory(
+            at: file.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "storage-fixture-\(file.lastPathComponent)\n".write(to: file, atomically: true, encoding: .utf8)
+    }
+
+    try writeJSONObjectForTest(
+        makeRunRecordPayloadForTest(
+            runID: "active-cleanup",
+            runKind: "benchmark",
+            runRoot: protectedRunRoot,
+            startedAtUnixMS: 1_712_100_000_000,
+            status: "running"
+        ),
+        to: activeRecordPath
+    )
+    try writeWorkspaceManifestForPreflightTest(
+        to: manifest,
+        extraArtifactRoots: [
+            [
+                "root_id": "external",
+                "kind": "ARTIFACT_ROOT_KIND_WORKSPACE",
+                "path": externalRaw.deletingLastPathComponent().path,
+                "uri": "file://external",
+                "melix_owned": false,
+                "redaction_scope": "absolute_path_hash",
+            ],
+        ],
+        extraArtifacts: [
+            [
+                "artifact_id": "export-cache-dir",
+                "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EXPORT",
+                "root_id": "workspace",
+                "relative_path": "exports/cache-dir",
+                "media_type": "application/octet-stream",
+                "provenance_ref_ids": ["lora-train-v1"],
+            ],
+            [
+                "artifact_id": "external-raw",
+                "artifact_type": "WORKSPACE_ARTIFACT_TYPE_RAW_INPUTS",
+                "root_id": "external",
+                "relative_path": externalRaw.lastPathComponent,
+                "media_type": "application/jsonl",
+                "provenance_ref_ids": ["operator-import"],
+            ],
+            [
+                "artifact_id": "unknown-custom",
+                "artifact_type": "WORKSPACE_ARTIFACT_TYPE_UNSPECIFIED",
+                "root_id": "workspace",
+                "relative_path": "unknown/custom.bin",
+                "media_type": "application/octet-stream",
+                "provenance_ref_ids": ["operator-import"],
+            ],
+            [
+                "artifact_id": "missing-cleaned",
+                "artifact_type": "WORKSPACE_ARTIFACT_TYPE_CLEANED_DATA",
+                "root_id": "workspace",
+                "relative_path": "missing/missing.clean.jsonl",
+                "media_type": "application/jsonl",
+                "provenance_ref_ids": ["operator-import"],
+            ],
+            [
+                "artifact_id": "unsafe-escape",
+                "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EXPORT",
+                "root_id": "workspace",
+                "relative_path": "../outside-cache.bin",
+                "media_type": "application/octet-stream",
+                "provenance_ref_ids": ["operator-import"],
+            ],
+        ]
+    )
+
+    return StorageMaintenanceFixtureForTest(
+        root: root,
+        workspace: workspace,
+        melixHome: melixHome,
+        manifest: manifest,
+        retainedRaw: retainedRaw,
+        cleanableCleaned: cleanableCleaned,
+        cleanableDirectory: cleanableDirectory,
+        cleanableTemp: cleanableTemp,
+        externalRaw: externalRaw,
+        unknownArtifact: unknownArtifact,
+        missingCleaned: missingCleaned,
+        unsafeEscapeTarget: unsafeEscapeTarget,
+        protectedCheckpoint: protectedCheckpoint
     )
 }
 

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -334,6 +334,7 @@ struct MelixCLIRunnerTests {
         let unknownEntry = try #require(inventoryEntriesByID["unknown-custom"])
         let missingEntry = try #require(inventoryEntriesByID["missing-cleaned"])
         let unsafeEntry = try #require(inventoryEntriesByID["unsafe-escape"])
+        let rootAliasEntry = try #require(inventoryEntriesByID["workspace-root-alias"])
         let directoryEntry = try #require(inventoryEntriesByID["export-cache-dir"])
 
         #expect(inventory["schema_version"] as? String == "melix.storage_inventory_receipt.v1")
@@ -360,6 +361,8 @@ struct MelixCLIRunnerTests {
         #expect(missingEntry["cleanup_reason"] as? String == "artifact_missing")
         #expect(unsafeEntry["cleanup_eligibility"] as? String == "blocked_unsafe_path")
         #expect(unsafeEntry["cleanup_reason"] as? String == "artifact_path_outside_root")
+        #expect(rootAliasEntry["cleanup_eligibility"] as? String == "blocked_unsafe_path")
+        #expect(rootAliasEntry["cleanup_reason"] as? String == "artifact_path_outside_root")
         #expect((directoryEntry["byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
         #expect(inventoryOutput.contains(fixture.workspace.path) == false)
 
@@ -390,6 +393,7 @@ struct MelixCLIRunnerTests {
         #expect(blockedEntries.contains { $0["artifact_id"] as? String == "unknown-custom" })
         #expect(blockedEntries.contains { $0["artifact_id"] as? String == "missing-cleaned" })
         #expect(blockedEntries.contains { $0["artifact_id"] as? String == "unsafe-escape" })
+        #expect(blockedEntries.contains { $0["artifact_id"] as? String == "workspace-root-alias" })
         #expect(retainedEntries.contains { $0["artifact_kind"] as? String == "raw_file" })
         #expect((planSummary["cleanable_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
         #expect((planSummary["retained_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
@@ -423,6 +427,7 @@ struct MelixCLIRunnerTests {
         #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "unknown-custom" })
         #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "missing-cleaned" })
         #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "unsafe-escape" })
+        #expect(receiptProtectedEntries.contains { $0["artifact_id"] as? String == "workspace-root-alias" })
         #expect((receiptSummary["safe_delete_count"] as? NSNumber)?.intValue ?? 0 >= 2)
         #expect((receiptSummary["deleted_byte_size"] as? NSNumber)?.intValue ?? 0 > 0)
         #expect((receiptMetrics["cleanup_apply_latency_ms"] as? NSNumber)?.doubleValue ?? -1 >= 0)
@@ -448,6 +453,7 @@ struct MelixCLIRunnerTests {
         #expect(FileManager.default.fileExists(atPath: fixture.externalRaw.path))
         #expect(FileManager.default.fileExists(atPath: fixture.unknownArtifact.path))
         #expect(FileManager.default.fileExists(atPath: fixture.unsafeEscapeTarget.path))
+        #expect(FileManager.default.fileExists(atPath: fixture.workspace.path))
         #expect(FileManager.default.fileExists(atPath: fixture.missingCleaned.path) == false)
         #expect(FileManager.default.fileExists(atPath: fixture.protectedCheckpoint.path))
         #expect(FileManager.default.fileExists(atPath: fixture.retainedRaw.path))
@@ -585,6 +591,66 @@ struct MelixCLIRunnerTests {
         ))
         #expect(receiptFile["cleanup_receipt_id"] as? String == applyReceiptID)
         #expect(bundleOutput.contains(fixture.workspace.path) == false)
+    }
+
+    @Test("debug bundle skips invalid latest storage cleanup receipt")
+    func debugBundleSkipsInvalidLatestStorageCleanupReceipt() async throws {
+        let fixture = try makeStorageMaintenanceFixtureForTest()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let receiptDirectory = fixture.melixHome
+            .appendingPathComponent("storage-cleanup", isDirectory: true)
+            .appendingPathComponent("cleanup-receipts", isDirectory: true)
+        try FileManager.default.createDirectory(at: receiptDirectory, withIntermediateDirectories: true)
+        try "{".write(
+            to: receiptDirectory.appendingPathComponent("invalid-latest.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let runner = MelixCLIRunner(
+            client: StubControlPlaneXPCClient(),
+            environment: [
+                "MELIX_HOME": fixture.melixHome.path,
+                "MELIX_PROJECT_ROOT": fixture.workspace.path,
+            ]
+        )
+        let runRoot = fixture.melixHome
+            .appendingPathComponent("jobs", isDirectory: true)
+            .appendingPathComponent("model-ops", isDirectory: true)
+            .appendingPathComponent("bench", isDirectory: true)
+            .appendingPathComponent("storage-debug-bad-receipt", isDirectory: true)
+        try FileManager.default.createDirectory(at: runRoot, withIntermediateDirectories: true)
+        try writeJSONObjectForTest(
+            makeRunRecordPayloadForTest(
+                runID: "storage-debug-bad-receipt",
+                runKind: "benchmark",
+                runRoot: runRoot,
+                startedAtUnixMS: 1_712_100_000_000
+            ),
+            to: runRoot.appendingPathComponent("run-record.json")
+        )
+
+        let bundleRoot = fixture.root.appendingPathComponent("debug-bundle-bad-receipt", isDirectory: true)
+        let bundleOutput = try await runner.run(
+            .debugBundle(
+                .init(
+                    runID: "storage-debug-bad-receipt",
+                    outputPath: bundleRoot.path,
+                    json: true
+                )
+            )
+        )
+        let bundle = try #require(parseJSONObject(bundleOutput))
+        let artifacts = try #require(bundle["artifacts"] as? [String: String])
+
+        #expect(artifacts["storage_inventory"] == "storage-inventory.json")
+        #expect(artifacts["storage_cleanup_plan"] == "storage-cleanup-plan.json")
+        #expect(artifacts["storage_cleanup_receipt"] == nil)
+        #expect(bundle["storage_cleanup_receipt"] == nil)
+        #expect(FileManager.default.fileExists(
+            atPath: bundleRoot.appendingPathComponent("storage-cleanup-receipt.json").path
+        ) == false)
     }
 
     @Test("json v1 wraps command results in a stable envelope")
@@ -15139,6 +15205,14 @@ private func makeStorageMaintenanceFixtureForTest() throws -> StorageMaintenance
                 "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EXPORT",
                 "root_id": "workspace",
                 "relative_path": "../outside-cache.bin",
+                "media_type": "application/octet-stream",
+                "provenance_ref_ids": ["operator-import"],
+            ],
+            [
+                "artifact_id": "workspace-root-alias",
+                "artifact_type": "WORKSPACE_ARTIFACT_TYPE_EXPORT",
+                "root_id": "workspace",
+                "relative_path": ".",
                 "media_type": "application/octet-stream",
                 "provenance_ref_ids": ["operator-import"],
             ],


### PR DESCRIPTION
## Summary
- Add storage inventory, cleanup plan, and safe apply commands for Melix-owned and workspace-declared artifacts.
- Persist cleanup apply receipts under `MELIX_HOME`, reuse the same inventory/plan model in debug bundles, and surface the storage receipt rows in the desktop diagnostics bundle view.
- Close #1517.

## Plan or Spec
- `docs/plans/2026-07-02-storage-inventory-cleanup-receipts.md`

## Commands Run
```text
swift test --filter 'MelixCLIParserTests/parsesRuntimeSettingsAndDiscoveryCommands'
Result: passed.

swift test --filter 'MelixCLIParserTests/parsesRuntimeSettingsAndDiscoveryCommands|MelixCLIRunnerTests/storageInventoryCleanupPlanAndApplyShareSafeReceipts|MelixCLIRunnerTests/storageCleanupTextOutputSummarizesTheSameSafePlan|MelixCLIRunnerTests/debugBundleEmbedsLatestStorageCleanupReceiptForDesktopResultParity|MelixCLIRunnerTests/offlineRunRecordCommandsListShowExportAndReportLocalArtifacts'
Result: passed, 5 tests.

swift test --package-path apps/macos-menubar --filter 'RuntimeEvidenceReportStateTests/diagnosticsRendersStorageCleanupReceiptsFromDebugBundleState'
Result: passed.

git diff --check
Result: passed.

swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'
Result: passed, 361 tests.

swift test --package-path apps/macos-menubar --enable-code-coverage --filter 'RuntimeEvidenceReportStateTests/diagnosticsRendersStorageCleanupReceiptsFromDebugBundleState'
Result: passed.

.githooks/pre-commit for 514d1857
Result: passed make swift-test, make py-test, make integration-test, scoped performance report.

.githooks/pre-commit for a17aa150
Result: passed make swift-test, make py-test, make integration-test, scoped performance report.

.githooks/pre-commit for dc238828
Result: passed make swift-test, make py-test, make integration-test, scoped performance report.
Latest full gate details: make py-test 4587 passed, 14 skipped, 2 warnings; make integration-test 123 passed, 1 skipped.
```

## Coverage and Metrics
- Changed-scope Swift CLI coverage: 97.06% total changed-line coverage (1484/1529) from `swift test --enable-code-coverage --filter 'MelixCLIParserTests|MelixCLIRunnerTests'`.
- Changed-scope menubar coverage: 100.00% total changed-line coverage (141/141) from the focused menubar coverage command.
- Latest pre-commit scoped performance report: `.runtime/pre-commit-performance/20260702-061403-a17aa150/report/report.md`.
- Performance status: ok; regressions: 0; context regressions: 0; verification failures: 0.
- Probe `swift-cli-json-envelope-encoding`: base 126599.611 ms, head 16678.153 ms, delta -109921.458 ms (-86.83%), status improvement.
- Observability mode: debug. Storage inventory, plan, and apply receipts are opt-in CLI/debug-bundle artifacts; no production runtime sampling was added.
- Probe overhead: N/A because this change does not add runtime metrics or sampled/evidence-mode production probes.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.