### PR TITLE
perf: fast-path hub catalog MLX atom checks

### DIFF
--- a/docs/plans/2026-07-02-hub-catalog-mlx-atom-ord-fastpath.md
+++ b/docs/plans/2026-07-02-hub-catalog-mlx-atom-ord-fastpath.md
@@ -1,0 +1,46 @@
+# Hub Catalog MLX Atom Ord Fast Path
+
+## Goal
+
+Keep Hub catalog MLX compatibility detection behavior unchanged while reducing the
+small hot-path cost of exact `MLX` atom checks. The slice replaces repeated
+single-character membership checks with direct ASCII code comparisons in
+`_is_mlx_atom(...)`, which is used by library-name, tag, and card metadata
+compatibility paths.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+
+No protocol, dependency, or generated artifact changes are part of this slice.
+
+## Registered Performance Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` values and watches:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+Although the probe name originated with size-hint parsing, its script also
+measures `_payload_is_mlx_compatible(...)` across repo-id, library-name, tag,
+and card-tag compatibility branches. This slice uses that existing registered
+coverage rather than introducing a second probe for the same Hub catalog file.
+
+## Linux Verification Plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered local probe on Linux before opening the PR. GitHub Actions
+PR-scoped performance remains the final merge gate.
+
+## Success Metrics
+
+- Focused Hub catalog and PR-scoped performance tests pass.
+- Changed-scope coverage for touched Python scope is at least 95%.
+- Local base-vs-head registered probe shows behavior parity and a non-regressed
+  Hub catalog probe result; the compatibility sub-metric is expected to improve
+  modestly because `_is_mlx_atom(...)` is intentionally tiny.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -475,7 +475,16 @@ def _lowered_tag_set(tags: list[str]) -> set[str]:
 
 
 def _is_mlx_atom(value: str) -> bool:
-    return len(value) == 3 and value[0] in "mM" and value[1] in "lL" and value[2] in "xX"
+    if len(value) != 3:
+        return False
+    first = ord(value[0])
+    second = ord(value[1])
+    third = ord(value[2])
+    return (
+        (first == 77 or first == 109)
+        and (second == 76 or second == 108)
+        and (third == 88 or third == 120)
+    )
 
 
 def _tag_payload_contains_mlx(value: Any) -> bool:


### PR DESCRIPTION
## Summary
- Fast-path Hub catalog exact `MLX` atom detection by replacing repeated one-character membership checks with direct ASCII code comparisons.
- Keep compatibility semantics unchanged for library names, tags, and card metadata.

## Plan or Spec
- `docs/plans/2026-07-02-hub-catalog-mlx-atom-ord-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 90 passed in 1.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 90 passed in 0.49s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"elapsed_ms_mean": 1758.1410562153906, "payload_compatibility_elapsed_ms_mean": 194.6125506190583, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-hub-size-hint-marker-fastpath-20260702 --head-repo "$PWD" --output /tmp/hub_size_hint_probe_compare.json
# ok; base elapsed_ms_mean=1838.6186549905688, head elapsed_ms_mean=1738.3331829914823
# base payload_compatibility_elapsed_ms_mean=199.66983997728676, head=191.8714685831219

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 6 0 100%`).
- Registered probe: `hub-catalog-size-hint-regex-precompile`.
- Local base-vs-head metrics:
  - `elapsed_ms_mean`: 1838.619 ms -> 1738.333 ms (`-100.285 ms`, ~5.45% faster).
  - `payload_compatibility_elapsed_ms_mean`: 199.670 ms -> 191.871 ms (`-7.798 ms`, ~3.91% faster).
  - `size_hint_calls_mean`: 0.0 -> 0.0.
- CI PR-scoped performance is required as the final registered probe validation source before merge.

## Known Gaps
- Local validation is Linux-only Python validation. No Swift runtime path is changed.
- The optimization is intentionally tiny; CI registered probe output is the merge gate for final performance evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
