### PR TITLE
perf: bind failed partition appends

### DIFF
--- a/docs/plans/2026-07-02-dataset-failed-partition-append-locals.md
+++ b/docs/plans/2026-07-02-dataset-failed-partition-append-locals.md
@@ -1,0 +1,30 @@
+# Dataset Failed Segment Partition Append Locals
+
+## Context
+
+The dataset versioning hot path partitions generated source segments into
+successful and failed groups when `fail_segment_ids` is provided. The affected
+code path is covered by the registered PR-scoped performance probe
+`dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`, including
+focused `test_command`, `coverage_command`, and `probe_command` entries. The
+probe emits `failed_partition_elapsed_ms_*` metrics for
+`_partition_failed_segments`.
+
+## Slice
+
+Keep the behavior and data model unchanged while reducing repeated attribute
+lookups in `_partition_failed_segments`:
+
+- keep the existing empty-failures fast path that returns the original segment
+  list unchanged;
+- use direct `segment["segment_id"]` lookup on the common path while retaining
+  missing-key behavior through a `KeyError` fallback;
+- bind the result-list append methods once before the hot loop;
+- keep missing segment identifiers in the successful partition instead of raising.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered
+probe locally on Linux before pushing. Compare the registered probe metrics
+against an `origin/main` baseline gathered from the same worktree before the
+slice.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -136,12 +136,13 @@ def test_dataset_version_failed_segment_partition_preserves_failed_id_semantics(
         {"segment_id": "a", "text": "first"},
         {"segment_id": "b", "text": "second"},
         {"segment_id": "b", "text": "duplicate"},
+        {"text": "missing id"},
         {"segment_id": "c", "text": "third"},
     ]
 
     successful_segments, failed_segments = _partition_failed_segments(segments, ("b",))
 
-    assert successful_segments == [segments[0], segments[3]]
+    assert successful_segments == [segments[0], segments[3], segments[4]]
     assert failed_segments == [segments[1], segments[2]]
 
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -336,11 +336,18 @@ def _partition_failed_segments(
     failed_id_set = set(fail_segment_ids)
     successful_segments: list[dict[str, Any]] = []
     failed_segments: list[dict[str, Any]] = []
+    successful_segments_append = successful_segments.append
+    failed_segments_append = failed_segments.append
     for segment in segments:
-        if segment.get("segment_id") in failed_id_set:
-            failed_segments.append(segment)
+        try:
+            segment_id = segment["segment_id"]
+        except KeyError:
+            successful_segments_append(segment)
+            continue
+        if segment_id in failed_id_set:
+            failed_segments_append(segment)
         else:
-            successful_segments.append(segment)
+            successful_segments_append(segment)
     return successful_segments, failed_segments
 
 


### PR DESCRIPTION
## Summary
- Use direct `segment["segment_id"]` lookup on the common failed-segment partition path, with a `KeyError` fallback preserving missing-id behavior.
- Bind successful/failed result list append methods once in `_partition_failed_segments` to reduce repeated attribute lookup in the hot loop.
- Extend the partition semantics regression test to cover missing `segment_id` records staying in the successful partition and add a focused plan for the registered `dataset-quality-lengths-chain` performance slice.

## Plan or Spec
- `docs/plans/2026-07-02-dataset-failed-partition-append-locals.md`
- Registered probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
```text
# Baseline from origin/main before implementation
MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=9 MELIX_DATASET_FAILED_PARTITION_SEGMENTS=50000 MELIX_DATASET_FAILED_PARTITION_MODULUS=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# exit 0; failed_partition_elapsed_ms_mean=4.567586, min=3.701492, p95=5.112641

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_scans_nonempty_failures_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 8 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_scans_nonempty_failures_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# exit 0; 8 passed; TOTAL 6 0 100%

MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=9 MELIX_DATASET_FAILED_PARTITION_SEGMENTS=50000 MELIX_DATASET_FAILED_PARTITION_MODULUS=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# exit 0; failed_partition_elapsed_ms_mean=4.312452, min=3.989136, p95=4.588878

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# exit 0; registered default local probe: failed_partition_elapsed_ms_mean=1.125419, min=1.070594, p95=1.162486

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Local Linux registered-probe comparison for failed partition path (50k segments, 9 samples): `old_mean=4.567586ms`, `new_mean=4.312452ms`, `speedup=1.0592x`, `delta=-0.255134ms`; p95 improved from `5.112641ms` to `4.588878ms`.
- Default registered local probe after change: `failed_partition_elapsed_ms_mean=1.125419ms`, `min=1.070594ms`, `p95=1.162486ms` for 15k segments / 7 samples.
- CI PR-scoped performance workflow is required for repository registered probe validation before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this small Python hot-path slice.
- Swift/macOS runtime effects are not applicable to this Python-only change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
