### PR TITLE
Contain training run artifact paths

### DIFF
--- a/Sources/MelixCLICore/LocalTrainingQueueStore.swift
+++ b/Sources/MelixCLICore/LocalTrainingQueueStore.swift
@@ -612,7 +612,11 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
         guard !safeComponents.isEmpty else {
             return "model"
         }
-        if rawComponents.contains(where: { $0 == "." || $0 == ".." }) {
+        let hasTraversal = rawComponents.contains { component in
+            let normalized = component.trimmingCharacters(in: .whitespacesAndNewlines)
+            return normalized == "." || normalized == ".."
+        }
+        if hasTraversal {
             return safeComponents.last ?? "model"
         }
         return safeComponents.joined(separator: "-")
@@ -652,7 +656,8 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
     private static func isPath(_ candidate: URL, containedBy root: URL) -> Bool {
         let candidatePath = candidate.standardizedFileURL.path
         let rootPath = root.standardizedFileURL.path
-        return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
+        let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        return candidatePath == rootPath || candidatePath.hasPrefix(rootPrefix)
     }
 }
 

--- a/Sources/MelixCLICore/LocalTrainingQueueStore.swift
+++ b/Sources/MelixCLICore/LocalTrainingQueueStore.swift
@@ -179,6 +179,7 @@ public struct LocalTrainingQueueAdmissionRequest: Sendable {
     public var trainingMode: String
     public var resourceClass: String
     public var runDirectory: String
+    public var managedOutputRoot: String
     public var parameters: [String: String]
 
     public init(
@@ -188,6 +189,7 @@ public struct LocalTrainingQueueAdmissionRequest: Sendable {
         trainingMode: String = "",
         resourceClass: String = "exclusive_local_training",
         runDirectory: String = "",
+        managedOutputRoot: String = "",
         parameters: [String: String] = [:]
     ) {
         self.modelID = modelID
@@ -196,6 +198,7 @@ public struct LocalTrainingQueueAdmissionRequest: Sendable {
         self.trainingMode = trainingMode
         self.resourceClass = resourceClass
         self.runDirectory = runDirectory
+        self.managedOutputRoot = managedOutputRoot
         self.parameters = parameters
     }
 }
@@ -210,6 +213,26 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
     public init(melixHome: MelixHome, fileManager: FileManager = .default) {
         self.melixHome = melixHome
         self.fileManager = fileManager
+    }
+
+    public static func defaultTrainingRunName(modelRef: String) -> String {
+        let identity = modelRunIdentity(modelRef)
+        let normalized = identity
+            .folding(options: [.diacriticInsensitive, .widthInsensitive], locale: Locale(identifier: "en_US_POSIX"))
+            .lowercased()
+        let characters = normalized.unicodeScalars.map { scalar -> Character in
+            if isASCIILetterOrDigit(scalar) {
+                return Character(scalar)
+            }
+            return "-"
+        }
+        var candidate = String(characters)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        if candidate.isEmpty {
+            candidate = "model"
+        }
+        return boundedRunName(candidate)
     }
 
     public func list() throws -> [LocalTrainingQueueJob] {
@@ -244,9 +267,12 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
 
             let now = currentUnixMilliseconds()
             let jobID = nextJobID(document.jobs)
-            let runDirectory = normalizedRunDirectory(
+            let managedOutputRoot = normalizedManagedOutputRoot(request.managedOutputRoot)
+            let runDirectory = try normalizedRunDirectory(
                 request.runDirectory,
-                jobID: jobID
+                jobID: jobID,
+                modelRef: request.modelID,
+                managedOutputRoot: managedOutputRoot
             )
             let job = LocalTrainingQueueJob(
                 jobID: jobID,
@@ -456,15 +482,41 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
         try? fileManager.removeItem(at: url)
     }
 
-    private func normalizedRunDirectory(_ value: String, jobID: String) -> String {
+    private func normalizedRunDirectory(
+        _ value: String,
+        jobID: String,
+        modelRef: String,
+        managedOutputRoot: URL
+    ) throws -> String {
+        let root = managedOutputRoot.standardizedFileURL
+        let candidateRunName = Self.defaultTrainingRunName(modelRef: modelRef)
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {
-            return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath).path
+            let candidate = URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)
+                .standardizedFileURL
+            guard Self.isPath(candidate, containedBy: root) else {
+                throw MelixCLIError.requestFailed(
+                    code: "path_escape_detected",
+                    message: "Training run directory escapes the managed output root. path_escape_detected=true sanitized_run_name=\(candidateRunName) requested_path=\(candidate.path) managed_output_root=\(root.path)"
+                )
+            }
+            return candidate.path
+        }
+        return root
+            .appendingPathComponent("\(candidateRunName)-\(jobID)", isDirectory: true)
+            .standardizedFileURL
+            .path
+    }
+
+    private func normalizedManagedOutputRoot(_ value: String) -> URL {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath, isDirectory: true)
+                .standardizedFileURL
         }
         return melixHome.modelOpsJobsRootURL
             .appendingPathComponent("train_lora", isDirectory: true)
-            .appendingPathComponent(jobID, isDirectory: true)
-            .path
+            .standardizedFileURL
     }
 
     private func isExclusive(_ resourceClass: String) -> Bool {
@@ -539,6 +591,69 @@ public final class LocalTrainingQueueStore: @unchecked Sendable {
     }()
 
     private static let decoder = JSONDecoder()
+
+    private static func modelRunIdentity(_ modelRef: String) -> String {
+        let trimmed = modelRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return "model"
+        }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        if expanded.hasPrefix("/") || trimmed.hasPrefix("~") {
+            let url = URL(fileURLWithPath: expanded)
+            let last = url.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+            return last.isEmpty ? "model" : last
+        }
+
+        let rawComponents = trimmed.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        let safeComponents = rawComponents.filter { component in
+            let normalized = component.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !normalized.isEmpty && normalized != "." && normalized != ".."
+        }
+        guard !safeComponents.isEmpty else {
+            return "model"
+        }
+        if rawComponents.contains(where: { $0 == "." || $0 == ".." }) {
+            return safeComponents.last ?? "model"
+        }
+        return safeComponents.joined(separator: "-")
+    }
+
+    private static func isASCIILetterOrDigit(_ scalar: UnicodeScalar) -> Bool {
+        (scalar.value >= 48 && scalar.value <= 57)
+            || (scalar.value >= 65 && scalar.value <= 90)
+            || (scalar.value >= 97 && scalar.value <= 122)
+    }
+
+    private static func boundedRunName(_ candidate: String) -> String {
+        let maxLength = 80
+        guard candidate.count > maxLength else {
+            return candidate
+        }
+        let digest = stableHexDigest(candidate)
+        let suffix = "-\(digest.prefix(12))"
+        let prefixLength = maxLength - suffix.count
+        let prefix = String(candidate.prefix(prefixLength))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        if prefix.isEmpty {
+            return "model\(suffix)"
+        }
+        return "\(prefix)\(suffix)"
+    }
+
+    private static func stableHexDigest(_ value: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(format: "%016llx", hash)
+    }
+
+    private static func isPath(_ candidate: URL, containedBy root: URL) -> Bool {
+        let candidatePath = candidate.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
+    }
 }
 
 private struct LocalTrainingQueueDocument: Codable, Equatable, Sendable {

--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -7271,7 +7271,8 @@ public actor MelixCLIRunner {
     private func runLoraTrainOperation(
         _ options: LoraTrainOptions,
         outputDir: String = "",
-        trainingModeOverride: String = ""
+        trainingModeOverride: String = "",
+        managedOutputRoot: String = ""
     ) async throws -> Melix_Controlplane_V1_ModelOperationResult {
         var ext = options.parameters
         if options.preflightFitCheck {
@@ -7306,6 +7307,7 @@ public actor MelixCLIRunner {
                 adapterName: options.adapterName,
                 trainingMode: trainingMode,
                 runDirectory: outputDir,
+                managedOutputRoot: managedOutputRoot,
                 parameters: ext
             )
         )
@@ -7317,7 +7319,7 @@ public actor MelixCLIRunner {
             let result = try await performModelOperation(
                 modelID: options.modelID,
                 operation: "train_lora",
-                outputDir: outputDir,
+                outputDir: admitted.runDirectory,
                 ext: ext
             )
             _ = try? queue.markSucceeded(jobID: admitted.jobID)
@@ -7373,7 +7375,8 @@ public actor MelixCLIRunner {
         let trainResult = try await runLoraTrainOperation(
             options.training,
             outputDir: trainOutputDir.path,
-            trainingModeOverride: resolvedTrainingMode
+            trainingModeOverride: resolvedTrainingMode,
+            managedOutputRoot: outputRoot.path
         )
         let adapterManifestPath = try Self.resolveLoraAdapterManifestPath(
             from: trainResult,

--- a/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
+++ b/docs/plans/2026-05-24-training-parameter-safety-and-queueing.md
@@ -169,6 +169,16 @@ known trainability guardrail is marked failed without an explicit remediation,
 the store may fill the default guardrail remediation so CLI and Desktop expose a
 single operator-facing recovery path.
 
+Training admission must distinguish source model references from generated run
+artifact names. A source `model_id` may be a Hugging Face repository ID or a
+local absolute path outside the managed workspace, but default writable run
+directories are derived from a sanitized `defaultTrainingRunName(modelRef:)`
+candidate under the configured training output root. Explicit run directories
+must be normalized and proven contained by that configured root before queue
+persistence or worker launch. Escaping paths fail with the typed
+`path_escape_detected` operator error and include `path_escape_detected=true`
+plus the sanitized candidate name in the refusal evidence.
+
 Required queue error codes are:
 
 - `training_queue_busy`
@@ -177,6 +187,7 @@ Required queue error codes are:
 - `training_queue_restore_failed`
 - `training_queue_cancel_failed`
 - `training_queue_admission_failed`
+- `path_escape_detected`
 
 Metrics:
 
@@ -191,6 +202,9 @@ Verification:
 
 - Swift store tests for queue round-trip, restore, exclusive admission,
   cancellation persistence, and malformed document handling.
+- Swift store tests for sanitized default run names, local absolute source
+  paths, long model references, traversal strings, and escaping output path
+  refusals.
 - CLI parser/runner tests for queue status and admission surfaces.
 - Desktop state and detail rendering tests proving queued and running jobs
   survive app reconstruction from the same `MELIX_HOME` and expose recovery

--- a/docs/plans/2026-07-02-training-run-artifact-path-containment.md
+++ b/docs/plans/2026-07-02-training-run-artifact-path-containment.md
@@ -1,0 +1,99 @@
+# Training Run Artifact Path Containment
+
+## Goal
+
+Close the remaining issue #1498 follow-up by making local training admission
+derive managed run artifact directories from sanitized model identity and by
+refusing operator-supplied training output directories that escape the managed
+Melix model-ops root before worker launch.
+
+## Non-Goals
+
+- Do not redesign the durable local training queue schema.
+- Do not move trainability guardrail ownership out of the Python worker.
+- Do not change completed #1499/#1500 guardrail or queue semantics beyond the
+  path-containment admission gap.
+- Do not copy reference implementation code from M-Courtyard.
+
+## Context
+
+- Relevant specs:
+  - `docs/reference-scans/m-courtyard-lessons.md`
+  - `docs/plans/2026-05-24-m-courtyard-improvement-roadmap.md`
+  - `docs/plans/2026-05-24-training-parameter-safety-and-queueing.md`
+- Relevant code paths:
+  - `Sources/MelixCLICore/LocalTrainingQueueStore.swift`
+  - `Sources/MelixCLICore/MelixCLI.swift`
+  - `tests/MelixCLITests/LoraTrainingJobStoreTests.swift`
+  - `tests/MelixCLITests/MelixCLIRunnerTests.swift`
+- Current constraints:
+  - The Swift control plane owns durable queue admission before worker launch.
+  - Python worker trainability rules stay the source of truth for model and
+    dataset execution safety.
+  - `MELIX_HOME` may be worktree-local; generated training artifacts must stay
+    under that configured home's model-ops jobs root unless a later spec
+    explicitly introduces a trusted external artifact root.
+
+## Assumptions
+
+- `modelID` in `LocalTrainingQueueAdmissionRequest` is the source model
+  reference for both Hugging Face repository IDs and local absolute paths.
+- Local absolute model paths may point outside `MELIX_HOME`; that is allowed for
+  source reads, but generated run directories must not inherit raw absolute path
+  components.
+- Existing CLI `--output-dir` values for `melix lora train` are operator-supplied
+  generated artifact paths and therefore must be contained under the managed
+  model-ops training root.
+
+## Work Plan
+
+1. Add red tests for a pure `defaultTrainingRunName(modelRef:)` helper covering
+   repository IDs, external local paths, very long names, and traversal strings.
+2. Add red queue-admission tests proving default run directories stay under the
+   managed training root and explicit escaping output paths fail with typed
+   `path_escape_detected` evidence before worker launch.
+3. Implement the helper and route queue default run directory construction
+   through it while preserving stable queue IDs.
+4. Add path-containment validation for explicit training output directories,
+   including the sanitized candidate name in the typed refusal.
+5. Verify focused Swift tests, changed-scope coverage, full pre-commit gate, and
+   the scoped performance probe before PR update.
+
+## Verification
+
+```bash
+swift test --filter 'LoraTrainingJobStoreTests/localTrainingQueueDerivesContainedRunNamesFromModelReferences|LoraTrainingJobStoreTests/localTrainingQueueRejectsEscapingRunDirectoriesWithTypedEvidence|MelixCLIRunnerTests/loraTrainUsesContainedDefaultOutputDirForLocalModelPaths'
+swift test --filter 'MelixCLIRunnerTests/loraTrainPersistsDurableQueueAdmissionBeforeWorkerLaunch|MelixCLIRunnerTests/loraTrainRejectsBusyDurableQueueBeforeWorkerLaunch'
+make swift-test
+make py-test
+make integration-test
+```
+
+Expected evidence:
+
+- Focused tests fail before implementation and pass after implementation.
+- Existing queue and LoRA train behavior remains green.
+- Full local gates pass before commit.
+- PR scoped performance report has `Status: ok`, `Regressions: 0`, and
+  `Verification failures: 0`.
+
+## Acceptance Criteria
+
+- A public pure helper derives safe, bounded default training run artifact names
+  from repository IDs and local paths without preserving raw absolute path
+  components.
+- Default admitted training queue run directories remain under
+  `MELIX_HOME/jobs/model-ops/train_lora`.
+- Explicit training output directories that escape the managed root return a
+  typed `path_escape_detected` refusal before queue persistence or worker
+  launch.
+- Refusal evidence includes `path_escape_detected=true` and the sanitized
+  candidate run name.
+- Unit and CLI runner tests cover repository IDs, local absolute paths, long
+  model names, traversal strings, and worker no-launch behavior.
+
+## Rollback or Safe Exit
+
+- Revert the helper, queue validation, and tests together. The previous queue
+  behavior uses queue IDs for default directories and accepts explicit output
+  directories unchanged.

--- a/tests/MelixCLITests/LoraTrainingJobStoreTests.swift
+++ b/tests/MelixCLITests/LoraTrainingJobStoreTests.swift
@@ -279,6 +279,10 @@ struct LoraTrainingJobStoreTests {
             LocalTrainingQueueStore.defaultTrainingRunName(modelRef: "../escape/../../Qwen 3.5")
                 == "qwen-3-5"
         )
+        #expect(
+            LocalTrainingQueueStore.defaultTrainingRunName(modelRef: "repo/ .. /Qwen 3.5")
+                == "qwen-3-5"
+        )
         let longName = LocalTrainingQueueStore.defaultTrainingRunName(
             modelRef: "mlx-community/\(String(repeating: "VeryLongModelName", count: 12))"
         )
@@ -331,6 +335,26 @@ struct LoraTrainingJobStoreTests {
         }
 
         #expect(!FileManager.default.fileExists(atPath: home.localTrainingQueueFileURL.path))
+    }
+
+    @Test("local training queue containment accepts absolute run paths under filesystem root")
+    func localTrainingQueueContainmentAcceptsAbsoluteRunPathsUnderFilesystemRoot() throws {
+        let home = temporaryMelixHome()
+        defer { try? FileManager.default.removeItem(at: home.rootURL) }
+        let store = LocalTrainingQueueStore(melixHome: home)
+        let runDirectory = home.rootURL.appendingPathComponent("root-contained-run", isDirectory: true)
+
+        let admitted = try store.admit(
+            LocalTrainingQueueAdmissionRequest(
+                modelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                datasetURI: "/tmp/datasets/alpaca.jsonl",
+                adapterName: "demo-adapter",
+                runDirectory: runDirectory.path,
+                managedOutputRoot: "/"
+            )
+        )
+
+        #expect(URL(fileURLWithPath: admitted.runDirectory).standardizedFileURL.path == runDirectory.standardizedFileURL.path)
     }
 
     @Test("local training queue rejects malformed queue schema with typed restore error")

--- a/tests/MelixCLITests/LoraTrainingJobStoreTests.swift
+++ b/tests/MelixCLITests/LoraTrainingJobStoreTests.swift
@@ -260,6 +260,79 @@ struct LoraTrainingJobStoreTests {
         #expect(metrics["admission_refusal_count"] as? Int == 1)
     }
 
+    @Test("local training queue derives contained run names from model references")
+    func localTrainingQueueDerivesContainedRunNamesFromModelReferences() throws {
+        let home = temporaryMelixHome()
+        defer { try? FileManager.default.removeItem(at: home.rootURL) }
+        let store = LocalTrainingQueueStore(melixHome: home)
+        let managedRoot = home.modelOpsJobsRootURL.appendingPathComponent("train_lora", isDirectory: true)
+
+        #expect(
+            LocalTrainingQueueStore.defaultTrainingRunName(modelRef: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit")
+                == "mlx-community-qwen3-5-0-8b-optiq-4bit"
+        )
+        #expect(
+            LocalTrainingQueueStore.defaultTrainingRunName(modelRef: "/Volumes/External Models/raw/Qwen 3.5 9B Instruct")
+                == "qwen-3-5-9b-instruct"
+        )
+        #expect(
+            LocalTrainingQueueStore.defaultTrainingRunName(modelRef: "../escape/../../Qwen 3.5")
+                == "qwen-3-5"
+        )
+        let longName = LocalTrainingQueueStore.defaultTrainingRunName(
+            modelRef: "mlx-community/\(String(repeating: "VeryLongModelName", count: 12))"
+        )
+        #expect(longName.count <= 80)
+        #expect(longName.hasPrefix("mlx-community-verylongmodelname"))
+
+        let admitted = try store.admit(
+            LocalTrainingQueueAdmissionRequest(
+                modelID: "/Volumes/External Models/raw/Qwen 3.5 9B Instruct",
+                datasetURI: "/tmp/datasets/alpaca.jsonl",
+                adapterName: "demo-adapter",
+                resourceClass: "background_training"
+            )
+        )
+        let runDirectory = URL(fileURLWithPath: admitted.runDirectory).standardizedFileURL.path
+
+        #expect(runDirectory.hasPrefix(managedRoot.standardizedFileURL.path + "/"))
+        #expect(runDirectory.hasSuffix("/qwen-3-5-9b-instruct-training-queue-0001"))
+        #expect(!runDirectory.lowercased().contains("volumes"))
+        #expect(!runDirectory.lowercased().contains("external-models"))
+    }
+
+    @Test("local training queue rejects escaping run directories with typed evidence")
+    func localTrainingQueueRejectsEscapingRunDirectoriesWithTypedEvidence() throws {
+        let home = temporaryMelixHome()
+        defer { try? FileManager.default.removeItem(at: home.rootURL) }
+        let store = LocalTrainingQueueStore(melixHome: home)
+        let escaped = home.modelOpsJobsRootURL
+            .appendingPathComponent("train_lora", isDirectory: true)
+            .appendingPathComponent("../escaped-run", isDirectory: true)
+
+        do {
+            _ = try store.admit(
+                LocalTrainingQueueAdmissionRequest(
+                    modelID: "mlx-community/Qwen3.5-0.8B-OptiQ-4bit",
+                    datasetURI: "/tmp/datasets/alpaca.jsonl",
+                    adapterName: "demo-adapter",
+                    runDirectory: escaped.path
+                )
+            )
+            Issue.record("Expected escaping training run directory to be rejected.")
+        } catch let error as MelixCLIError {
+            guard case .requestFailed(let code, let message) = error else {
+                Issue.record("Unexpected escaping path error: \(error).")
+                return
+            }
+            #expect(code == "path_escape_detected")
+            #expect(message.contains("path_escape_detected=true"))
+            #expect(message.contains("sanitized_run_name=mlx-community-qwen3-5-0-8b-optiq-4bit"))
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: home.localTrainingQueueFileURL.path))
+    }
+
     @Test("local training queue rejects malformed queue schema with typed restore error")
     func localTrainingQueueRejectsMalformedQueueSchemaWithTypedRestoreError() throws {
         let home = temporaryMelixHome()
@@ -321,7 +394,7 @@ struct LoraTrainingJobStoreTests {
         #expect(first.datasetID == "explicit-dataset")
         #expect(first.recoveryPolicy == "custom_policy")
         #expect(first.preflightReceiptPath == "/tmp/preflight-receipt.json")
-        #expect(first.runDirectory.hasSuffix("/jobs/model-ops/train_lora/training-queue-0001"))
+        #expect(first.runDirectory.hasSuffix("/jobs/model-ops/train_lora/mlx-community-qwen3-5-0-8b-optiq-4bit-training-queue-0001"))
         #expect(second.jobID == "training-queue-0002")
         #expect(failed.status == .failed)
         #expect(failed.operatorErrors == [
@@ -424,7 +497,10 @@ struct LoraTrainingJobStoreTests {
         defer { try? FileManager.default.removeItem(at: home.rootURL) }
         let store = LocalTrainingQueueStore(melixHome: home)
         try FileManager.default.createDirectory(at: home.rootURL, withIntermediateDirectories: true)
-        let blockedRunDirectory = home.rootURL.appendingPathComponent("blocked-run-directory")
+        let blockedRunDirectory = home.modelOpsJobsRootURL
+            .appendingPathComponent("train_lora", isDirectory: true)
+            .appendingPathComponent("blocked-run-directory", isDirectory: true)
+        try FileManager.default.createDirectory(at: blockedRunDirectory.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data("not a directory".utf8).write(to: blockedRunDirectory)
         let admitted = try store.admit(
             LocalTrainingQueueAdmissionRequest(

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -8397,6 +8397,45 @@ struct MelixCLIRunnerTests {
         #expect(queueJob["dataset_version_id"] as? String == "dataset-v2")
     }
 
+    @Test("lora train uses contained default output dir for local model paths")
+    func loraTrainUsesContainedDefaultOutputDirForLocalModelPaths() async throws {
+        let client = StubControlPlaneXPCClient()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("melix-lora-train-local-path-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let home = MelixHome(environment: ["MELIX_HOME": root.path])
+        await client.setModelOperationResult(makeModelOperationResult(outputPath: "/tmp/melix/train_lora/local-path-job"))
+
+        _ = try await MelixCLIRunner(
+            client: client,
+            environment: ["MELIX_HOME": root.path]
+        ).run(
+            .loraTrain(
+                .init(
+                    modelID: "/Volumes/External Models/raw/Qwen 3.5 9B Instruct",
+                    datasetSourceKind: "local_package",
+                    datasetURI: "/tmp/datasets/alpaca.jsonl",
+                    adapterName: "demo-adapter",
+                    trainingMode: "lora",
+                    json: true
+                )
+            )
+        )
+        let call = try #require(await client.lastModelOperationCall)
+        let queuePayload = try #require(try parseJSONFile(home.localTrainingQueueFileURL.path))
+        let jobs = try #require(queuePayload["jobs"] as? [[String: Any]])
+        let queueJob = try #require(jobs.first)
+        let runDirectory = try #require(queueJob["run_directory"] as? String)
+        let managedRoot = home.modelOpsJobsRootURL.appendingPathComponent("train_lora", isDirectory: true)
+
+        #expect(call.operation == "train_lora")
+        #expect(call.outputDir == runDirectory)
+        #expect(URL(fileURLWithPath: runDirectory).standardizedFileURL.path.hasPrefix(managedRoot.standardizedFileURL.path + "/"))
+        #expect(runDirectory.hasSuffix("/qwen-3-5-9b-instruct-training-queue-0001"))
+        #expect(!runDirectory.lowercased().contains("volumes"))
+        #expect(!runDirectory.lowercased().contains("external-models"))
+    }
+
     @Test("lora train rejects busy durable queue before worker launch")
     func loraTrainRejectsBusyDurableQueueBeforeWorkerLaunch() async throws {
         let client = StubControlPlaneXPCClient()


### PR DESCRIPTION
## Summary
- Adds a pure `defaultTrainingRunName(modelRef:)` admission helper for repository IDs, absolute local model paths, long names, and traversal-shaped input.
- Routes LoRA training queue defaults and worker output directories through managed, sanitized artifact paths under the configured output root.
- Rejects explicit run directories that escape the managed output root before worker launch with `path_escape_detected=true` and the sanitized candidate name.

Closes #1498.

## Plan or Spec
- `docs/plans/2026-05-24-training-parameter-safety-and-queueing.md`
- `docs/plans/2026-07-02-training-run-artifact-path-containment.md`

## Commands Run
```text
swift test --filter 'LoraTrainingJobStoreTests/localTrainingQueueDerivesContainedRunNamesFromModelReferences|LoraTrainingJobStoreTests/localTrainingQueueRejectsEscapingRunDirectoriesWithTypedEvidence|MelixCLIRunnerTests/loraTrainUsesContainedDefaultOutputDirForLocalModelPaths'
PASS: 3 tests.

swift test --filter 'LoraTrainingJobStoreTests/localTrainingQueuePersistsAdmissionRunningCancellationAndMetrics|LoraTrainingJobStoreTests/localTrainingQueueRecordsNonexclusiveDefaultsFailuresAndTerminalCancelErrors|LoraTrainingJobStoreTests/localTrainingQueueKeepsStatusUnchangedWhenCancelRequestCannotBeWritten|MelixCLIRunnerTests/loraTrainPersistsDurableQueueAdmissionBeforeWorkerLaunch|MelixCLIRunnerTests/loraTrainRejectsBusyDurableQueueBeforeWorkerLaunch|MelixCLIRunnerTests/loraRun'
PASS: 9 tests.

swift test --filter LoraTrainingJobStoreTests
PASS: 19 tests.

swift test --filter 'MelixCLIRunnerTests/loraTrain|MelixCLIRunnerTests/loraRun'
PASS: 14 tests.

swift test --filter 'LoraTrainingJobStoreTests/localTrainingQueueDerivesContainedRunNamesFromModelReferences|LoraTrainingJobStoreTests/localTrainingQueueContainmentAcceptsAbsoluteRunPathsUnderFilesystemRoot'
RED: failed before the review fix on whitespace-trimmed traversal and filesystem-root containment.

swift test --filter 'LoraTrainingJobStoreTests/localTrainingQueueDerivesContainedRunNamesFromModelReferences|LoraTrainingJobStoreTests/localTrainingQueueContainmentAcceptsAbsoluteRunPathsUnderFilesystemRoot'
PASS: 2 tests after the review fix.

swift test --filter LoraTrainingJobStoreTests
PASS: 20 tests.

swift test --filter 'MelixCLIRunnerTests/loraTrain|MelixCLIRunnerTests/loraRun'
PASS: 14 tests after the review fix.

git diff --check
PASS.

git diff --check HEAD~1 HEAD
PASS.

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-bodies/issue-1498.md
PASS: PR evidence looks valid.

git commit -m "fix: contain training run artifact paths"
PASS: pre-commit hook completed and created commit 4bb18bfa. The hook ran make swift-test, make py-test, make integration-test, scoped changed-scope verification, and PR-scoped performance reporting.

git commit -m "fix: handle training path review edge cases"
PASS: pre-commit hook completed and created commit df1796cb. The hook ran make swift-test, make py-test, make integration-test, and PR-scoped performance reporting.
make swift-test: PASS.
make py-test: PASS, 4587 passed, 14 skipped, 2 warnings.
make integration-test: PASS, 123 passed, 1 skipped.
```

## Coverage and Metrics
- Changed-scope coverage: `PASS` via the pre-commit PR-scoped performance row (`coverage_ok=true`).
- Metrics report: `.runtime/pre-commit-performance/20260702-090627-3a07d9aa/report/report.md`
- Report status: `ok`; changed files: `6`; selected probes: `1`; direct/gated probes: `1`; regressions: `0`; context regressions: `0`; verification failures: `0`.
- Probe: `Swift CLI JSON envelope encoding`; targeted tests: `pass`; coverage: `pass`.
- `elapsed_ms_mean`: base `127022.668`, head `13961.906`, delta `-113060.762` (`-89.01%`), status `improvement`.
- Review-fix metrics report: `.runtime/pre-commit-performance/20260702-094656-4bb18bfa/report/report.md`
- Review-fix report status: `ok`; changed files: `2`; selected probes: `0`; regressions: `0`; context regressions: `0`; verification failures: `0`.
- Observability mode: `minimal`; no runtime observability behavior changed.
- Probe overhead: `N/A`; this change uses existing admission tests and existing PR-scoped performance probes.
- Protocol/dependency artifacts: `N/A`; this change does not modify schemas or dependencies.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
