### PR TITLE
perf: use positional video URI hash cache keys

### DIFF
--- a/docs/plans/2026-07-02-video-uri-identity-hash-positional.md
+++ b/docs/plans/2026-07-02-video-uri-identity-hash-positional.md
@@ -1,0 +1,43 @@
+# Video URI identity hash positional cache key
+
+## Scope
+
+This Python-only performance slice is limited to the URI branch of
+`prepare_video_input(...)` in
+`services/mlx-worker-python/worker/runtime/video_preprocessing.py`.
+The hot path prepares repeated remote video references and derives a stable
+identity hash from the URI, resolved format, filename, byte length, and temporal
+bounds.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`video-preprocessing-uri-byte-length-reuse` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and watches the
+video preprocessing source, focused tests, probe selection tests, and
+`scripts/video_preprocessing_uri_probe.py`.
+
+## Change
+
+The slice keeps identity-hash behavior unchanged while calling the cached
+`_uri_identity_hash(...)` helper with positional arguments instead of keyword
+arguments. The helper signature now accepts the same fields positionally, which
+avoids repeated keyword call/key construction overhead in the remote-video
+preprocessing loop without changing the framed payload or SHA-256 digest.
+
+## Verification plan
+
+1. Run the registered focused test command for
+   `video-preprocessing-uri-byte-length-reuse`.
+2. Run the registered changed-scope coverage command and require at least 95%
+   measured coverage for the touched scope.
+3. Run the registered probe locally on Linux and compare against the baseline
+   from `origin/main`; primary metric is `elapsed_ms_mean` (lower is better),
+   while `byte_length_getattrs_per_call` and `parse_calls_per_call` must remain
+   unchanged.
+
+## Validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+behavior changes are included.

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -109,15 +109,15 @@ def prepare_video_input(part) -> PreparedVideoInput:
         start_ms=start_ms,
         end_ms=end_ms,
         sha256_hex=_uri_identity_hash(
-            uri=uri,
-            mime_type=mime_type,
-            format_name=resolved_format,
-            filename=resolved_filename,
-            byte_length=byte_length,
-            duration_ms=duration_ms,
-            frame_budget=frame_budget,
-            start_ms=start_ms,
-            end_ms=end_ms,
+            uri,
+            mime_type,
+            resolved_format,
+            resolved_filename,
+            byte_length,
+            duration_ms,
+            frame_budget,
+            start_ms,
+            end_ms,
         ),
     )
 
@@ -291,7 +291,6 @@ def _filename_from_reference(reference: str | ParsedVideoReference) -> str:
 
 @lru_cache(maxsize=VIDEO_REFERENCE_PARSE_CACHE_SIZE)
 def _uri_identity_hash(
-    *,
     uri: str,
     mime_type: str,
     format_name: str,


### PR DESCRIPTION
## Summary
- Use positional arguments for the cached video URI identity hash helper to avoid repeated keyword call/key overhead in the remote-video preprocessing hot path.
- Add a focused plan documenting the slice and the registered `video-preprocessing-uri-byte-length-reuse` probe boundary.

## Plan or Spec
- `docs/plans/2026-07-02-video-uri-identity-hash-positional.md`
- Registered probe: `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json` (has `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `git fetch origin main`
- `git worktree add -b perf/embedding-core-response-init-20260702 /root/.hermes/profiles/coder/workspace/worktrees/melix-embedding-core-response-init-20260702 origin/main`
- `git branch -m perf/video-uri-hash-positional-20260702`
- Baseline: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py`
- Baseline: `for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py; done`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics`
- `for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py; done`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 38 passed.
- Changed-scope coverage: `TOTAL 0 0 100%` (no measurable changed executable lines reported for the signature/call-site slice; command exited 0).
- Local baseline probe (origin/main, 3 runs): `elapsed_ms_mean` = 515.843969, 558.647950, 525.357978 ms; mean 533.283299 ms.
- Local new probe (3 runs): `elapsed_ms_mean` = 507.387388, 524.117977, 503.961724 ms; mean 511.822363 ms.
- Local delta: -21.460936 ms mean (-4.03%); `byte_length_getattrs_per_call=1.0` and `parse_calls_per_call=1.0` unchanged.
- Registered PR-scoped performance CI must validate the probe on GitHub before merge.

## Known Gaps
- Linux local validation covers this Python-only slice; no Swift runtime behavior changed.
- CI PR-scoped performance report is required before merging.

## Evidence Checklist
- [x] Registered probe exists and includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage command passed.
- [x] Local registered probe shows neutral-to-improved metrics.
- [ ] GitHub Actions completed successfully, including PR-scoped performance.
