### PR TITLE
perf: bind audio PCM chunk appends

### DIFF
--- a/services/mlx-worker-python/worker/runtime/wav_helpers.py
+++ b/services/mlx-worker-python/worker/runtime/wav_helpers.py
@@ -45,6 +45,7 @@ def _drain_chunk_to_bytes(chunk: array.array) -> bytes:
 
 def audio_to_pcm_chunks(audio, *, chunk_sample_limit: int):
     chunk = array.array("h")
+    chunk_append = chunk.append
     limit = max(1, int(chunk_sample_limit))
 
     for value in iter_samples(audio):
@@ -52,7 +53,7 @@ def audio_to_pcm_chunks(audio, *, chunk_sample_limit: int):
             value = 1.0
         elif value < -1.0:
             value = -1.0
-        chunk.append(int(value * 32767.0))
+        chunk_append(int(value * 32767.0))
         if len(chunk) >= limit:
             pcm_bytes = _drain_chunk_to_bytes(chunk)
             del chunk[:]


### PR DESCRIPTION
## Summary
- Bind `array.array.append` once per PCM chunk stream so the audio WAV conversion hot loop avoids repeated method lookup.
- Keep PCM clipping, chunk draining, byte order, and WAV output behavior unchanged.

## Plan or Spec
- Registered probe: `mlx-audio-wav-streaming-pcm` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/runtime/wav_helpers.py` with focused tests, changed-scope coverage, and `scripts/mlx_audio_wav_streaming_probe.py`.
- No governing behavior/spec update is needed because this is an internal hot-loop optimization with unchanged API and output semantics.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py` (rejected earlier event-json experiment; no code retained)
- Baseline audio probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_wav_streaming_probe.py`
- Candidate audio probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_audio_wav_streaming_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_streams_nested_samples_and_clamps_values services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_does_not_materialize_flat_sample_list services/mlx-worker-python/tests/test_mlx_audio_runtime.py::test_audio_to_wav_bytes_writes_little_endian_chunks_on_big_endian_hosts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_audio_wav_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_audio_wav_streaming_probe_script_emits_metrics`
- Changed-scope coverage: same test set through `coverage run`, `coverage json -o coverage.json`, then `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/mlx_audio_runtime.py services/mlx-worker-python/worker/runtime/wav_helpers.py services/mlx-worker-python/tests/test_mlx_audio_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_audio_wav_streaming_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `6 passed in 4.09s`.
- Changed-scope coverage: `TOTAL 2 0 100%` for changed measurable lines.
- Registered local probe baseline (`origin/main`): `elapsed_ms_mean=325.276960`, `elapsed_ms_min=306.514361`, `peak_bytes_mean=699680.6`, `sample_count=240000`, `wav_bytes=480044`.
- Registered local probe candidate: `elapsed_ms_mean=294.608350`, `elapsed_ms_min=292.957812`, `peak_bytes_mean=699760.6`, `sample_count=240000`, `wav_bytes=480044`.
- Delta: `elapsed_ms_mean` improved by `30.668610 ms` (`9.43%` faster); `peak_bytes_mean` changed by `+80 bytes` (`0.01%`, effectively flat).

## Known Gaps
- Linux local verification covers the Python WAV conversion helper and registered probe only.
- CI must still run the PR-scoped performance workflow and report the registered `mlx-audio-wav-streaming-pcm` probe before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused Python tests passed locally on Linux.
- [x] Changed-scope coverage passed locally on Linux.
- [x] Registered Python probe ran locally on Linux with a positive elapsed-time delta.
- [x] `git diff --check` passed.
- [ ] GitHub Actions completed successfully, including the PR-scoped performance workflow.
