### PR TITLE
Add dataset ingest limit receipts

### DIFF
--- a/Sources/MelixCLICore/MelixCLI.swift
+++ b/Sources/MelixCLICore/MelixCLI.swift
@@ -90,6 +90,8 @@ public struct DatasetPrepareIngestOptions: Equatable, Sendable {
     public let fuzzyDedup: Bool
     public let segmentation: Bool
     public let segmentationStrategy: String
+    public let uploadCapBytes: String
+    public let sourceCapBytes: String
     public let json: Bool
 
     public init(
@@ -104,6 +106,8 @@ public struct DatasetPrepareIngestOptions: Equatable, Sendable {
         fuzzyDedup: Bool = true,
         segmentation: Bool = true,
         segmentationStrategy: String = "paragraph",
+        uploadCapBytes: String = "",
+        sourceCapBytes: String = "",
         json: Bool = false
     ) {
         self.workspaceProjectID = workspaceProjectID
@@ -117,6 +121,8 @@ public struct DatasetPrepareIngestOptions: Equatable, Sendable {
         self.fuzzyDedup = fuzzyDedup
         self.segmentation = segmentation
         self.segmentationStrategy = segmentationStrategy
+        self.uploadCapBytes = uploadCapBytes
+        self.sourceCapBytes = sourceCapBytes
         self.json = json
     }
 }
@@ -2643,7 +2649,7 @@ public enum MelixCLIParser {
       melix dataset list [--json]
       melix dataset hub download --repo-id HF_DATASET [--revision REV] [--hf-token TOKEN] [--json]
       melix dataset remove --repo-id HF_DATASET [--revision REV | --snapshot-id SHA] [--json]
-      melix dataset prepare ingest --workspace-project-id ID --workspace-manifest PATH --input PATH --output-dir PATH --dataset-preparation-id ID [--output PATH] [--pii-mask true|false] [--exact-dedup true|false] [--fuzzy-dedup true|false] [--segmentation true|false] [--segmentation-strategy STRATEGY] [--json]
+      melix dataset prepare ingest --workspace-project-id ID --workspace-manifest PATH --input PATH --output-dir PATH --dataset-preparation-id ID [--output PATH] [--pii-mask true|false] [--exact-dedup true|false] [--fuzzy-dedup true|false] [--segmentation true|false] [--segmentation-strategy STRATEGY] [--upload-cap-bytes N] [--source-cap-bytes N] [--json]
       melix dataset prepare version --workspace-manifest PATH --ingest-receipt PATH --output-root PATH --dataset-id ID [--version-id ID] [--created-at ISO8601] [--mode MODE] [--generator-model MODEL] [--output-kind KIND] [--output-format FORMAT] [--validation-ratio N] [--fail-segment-id ID ...] [--json]
       melix dataset prepare retry-failed --workspace-manifest PATH --dataset-version PATH --output-root PATH [--version-id ID] [--created-at ISO8601] [--generator-model MODEL] [--json]
       melix dataset prepare list-versions --workspace-manifest PATH --output-root PATH --dataset-id ID [--json]
@@ -3431,6 +3437,8 @@ public enum MelixCLIParser {
                 fuzzyDedup: try parseRequiredBooleanValue(values.single["--fuzzy-dedup"], option: "--fuzzy-dedup", defaultValue: true),
                 segmentation: try parseRequiredBooleanValue(values.single["--segmentation"], option: "--segmentation", defaultValue: true),
                 segmentationStrategy: values.single["--segmentation-strategy"] ?? "paragraph",
+                uploadCapBytes: values.single["--upload-cap-bytes"] ?? "",
+                sourceCapBytes: values.single["--source-cap-bytes"] ?? "",
                 json: values.flags.contains("--json")
             )
         )
@@ -6547,6 +6555,8 @@ public actor MelixCLIRunner {
         arguments.append(contentsOf: ["--fuzzy-dedup", options.fuzzyDedup ? "true" : "false"])
         arguments.append(contentsOf: ["--segmentation", options.segmentation ? "true" : "false"])
         appendOption("--segmentation-strategy", value: options.segmentationStrategy, into: &arguments)
+        appendOption("--upload-cap-bytes", value: options.uploadCapBytes, into: &arguments)
+        appendOption("--source-cap-bytes", value: options.sourceCapBytes, into: &arguments)
         return arguments
     }
 
@@ -6613,6 +6623,11 @@ public actor MelixCLIRunner {
         ]
         if let sourceFiles, let segments {
             lines.append("Sources: \(sourceFiles.intValue), segments: \(segments.intValue)")
+        }
+        if let uploadCap = payload["upload_cap_bytes"] as? NSNumber,
+           let observedBytes = payload["observed_payload_bytes"] as? NSNumber,
+           uploadCap.intValue > 0 {
+            lines.append("Upload cap: \(uploadCap.intValue) bytes, observed: \(observedBytes.intValue) bytes")
         }
         return lines.joined(separator: "\n") + "\n"
     }

--- a/Sources/MelixCLICore/MelixCLICommandCodec.swift
+++ b/Sources/MelixCLICore/MelixCLICommandCodec.swift
@@ -448,6 +448,8 @@ public enum MelixCLICommandCodec {
             arguments.append(contentsOf: ["--fuzzy-dedup", options.fuzzyDedup ? "true" : "false"])
             arguments.append(contentsOf: ["--segmentation", options.segmentation ? "true" : "false"])
             appendOption("--segmentation-strategy", value: options.segmentationStrategy, into: &arguments)
+            appendOption("--upload-cap-bytes", value: options.uploadCapBytes, into: &arguments)
+            appendOption("--source-cap-bytes", value: options.sourceCapBytes, into: &arguments)
             json = options.json
         case .datasetPrepareVersion(let options):
             arguments = ["dataset", "prepare", "version"]

--- a/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
+++ b/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
@@ -328,6 +328,87 @@ Report evidence consumes the same schema-backed paths by rendering
 `dataset_ingest_receipt_path`, and `workspace_preflight_receipt_path` artifact
 rows when they appear in run evidence.
 
+## 2026-07-02 Ingest Limit And Cleanup Follow-Up
+
+Issue #1494 remains open for the reference-watch ingest safety follow-up after
+#1495 and #1496. The next executable slice adds a cheap limit preflight before
+dataset ingest performs source decoding, cleaning, segmentation, or dataset
+version materialization.
+
+`melix dataset prepare ingest` must accept explicit limit settings:
+
+- `--upload-cap-bytes N` records the configured dataset ingest request cap.
+  `0` means no request-level cap for local compatibility.
+- `--source-cap-bytes N` records the configured per-source or recipe cap.
+  `0` means no per-source cap for local compatibility.
+
+The Python worker remains the trust boundary for this slice. It must enumerate
+candidate source files with the existing `os.scandir` path, read file sizes
+from metadata before `read_text(...)`, and reject unsafe requests before any
+expensive source processing starts. Rejected ingest receipts must not write
+`segments.jsonl`.
+
+The ingest receipt must include these top-level fields:
+
+- `upload_cap_bytes`
+- `observed_payload_bytes`
+- `source_cap_bytes`
+- `rejection_reason`
+- `partial_artifact_cleanup`
+
+`partial_artifact_cleanup` records:
+
+- `status`: `not_needed`, `removed`, `missing`, or `failed`
+- `target_path`: the path that was checked or removed
+- `removed`: whether an artifact was removed
+- `error`: an empty string unless cleanup failed
+
+Required new failure codes:
+
+- `DATASET_INGEST_UPLOAD_CAP_EXCEEDED`
+- `DATASET_INGEST_SOURCE_CAP_EXCEEDED`
+- `DATASET_INGEST_LIMIT_POLICY_INVALID`
+
+The dataset version artifact must persist the ingest safety fields by copying
+`upload_cap_bytes` and `partial_artifact_cleanup` from the source ingest
+receipt into `dataset-version.json`. This keeps the version artifact
+self-describing even when operators inspect it without opening the copied
+ingest receipt.
+
+The first implementation slice intentionally does not add a new network upload
+service. It treats local CLI and Desktop-invoked dataset preparation as the
+operator request boundary, which is the executable surface already shipped for
+P1.2. Future HTTP upload surfaces must reuse the same receipt fields and
+failure codes.
+
+### Implementation Tasks
+
+- Add failing Python tests for request-cap rejection before source reads,
+  per-source cap rejection, accepted under-cap ingest through a bounded read
+  helper, partial `segments.jsonl` cleanup when an ingest failure happens after
+  the artifact path is created, and dataset-version propagation of
+  `upload_cap_bytes` plus `partial_artifact_cleanup`.
+- Add failing script/CLI tests for `--upload-cap-bytes` and
+  `--source-cap-bytes` arguments.
+- Extend `DatasetIngestRequest`, `scripts/dataset_preparation_ingest.py`, and
+  the Swift CLI parser/runner option surfaces with the new limit settings.
+- Keep existing zero-value defaults backward compatible for current fixtures.
+- Surface limit values in non-JSON CLI rendering so operators can see the
+  configured cap and observed bytes without opening the JSON receipt.
+
+### Performance Probes And Metrics
+
+The affected hot path is dataset ingest source enumeration and source reading
+in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+The slice must report:
+
+- focused pytest coverage for dataset ingest/versioning tests;
+- changed-scope coverage for touched Python files with target `>=95%`;
+- `git diff --check`;
+- a PR-scoped performance report. The existing dataset source-kind/source-file
+  scan probes may select this path; selected probes must show no in-scope
+  regression.
+
 #1496 is complete when:
 
 - dataset version directories and `dataset-version.json` are deterministic;
@@ -363,9 +444,9 @@ U1.2.2 verification should include:
   success rate, quality scoring latency, generated sample count, and failed
   sample count.
 
-## Metrics Report For This Planning Slice
+## Historical Metrics Report For The Original Planning Slice
 
-This issue is documentation-only. Runtime metrics are `N/A` for this commit
-because no executable ingest, retry, or quality-scoring path changes in #1494.
-The required measurement points are defined above and must be implemented by
-#1495 and #1496 before their runtime changes are complete.
+The original #1494 planning commit was documentation-only, so runtime metrics
+were `N/A` for that commit. The 2026-07-02 follow-up above is an executable
+ingest-safety slice and must report the focused tests, changed-scope coverage,
+and PR-scoped performance result described in its performance section.

--- a/scripts/dataset_preparation_ingest.py
+++ b/scripts/dataset_preparation_ingest.py
@@ -31,6 +31,8 @@ def build_receipt(
     fuzzy_dedup: bool,
     segmentation: bool,
     segmentation_strategy: str,
+    upload_cap_bytes: int = 0,
+    source_cap_bytes: int = 0,
     output_path: Path | None = None,
 ) -> dict[str, object]:
     receipt = prepare_dataset_ingest(
@@ -45,6 +47,8 @@ def build_receipt(
             fuzzy_dedup=fuzzy_dedup,
             segmentation=segmentation,
             segmentation_strategy=segmentation_strategy,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
         )
     )
     if output_path:
@@ -66,6 +70,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fuzzy-dedup", type=_parse_bool, default=True)
     parser.add_argument("--segmentation", type=_parse_bool, default=True)
     parser.add_argument("--segmentation-strategy", default="paragraph")
+    parser.add_argument("--upload-cap-bytes", type=int, default=0)
+    parser.add_argument("--source-cap-bytes", type=int, default=0)
     args = parser.parse_args(argv)
 
     receipt = build_receipt(
@@ -79,6 +85,8 @@ def main(argv: list[str] | None = None) -> int:
         fuzzy_dedup=args.fuzzy_dedup,
         segmentation=args.segmentation,
         segmentation_strategy=args.segmentation_strategy,
+        upload_cap_bytes=args.upload_cap_bytes,
+        source_cap_bytes=args.source_cap_bytes,
         output_path=args.output,
     )
     print(json.dumps(receipt, indent=2, sort_keys=True))

--- a/services/mlx-worker-python/tests/dataset_ingest_limit_contract.py
+++ b/services/mlx-worker-python/tests/dataset_ingest_limit_contract.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import worker.productization.dataset_preparation as dataset_preparation_module
+from worker.productization.dataset_preparation import (
+    DatasetIngestRequest,
+    DatasetVersionRequest,
+    prepare_dataset_ingest,
+    prepare_dataset_version,
+)
+
+
+WORKSPACE_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures/workspace/m-courtyard-smoke.dev.v1/workspace-manifest.json"
+)
+
+
+def exercise_dataset_ingest_limit_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _assert_rejects_over_upload_cap_before_reading_sources(tmp_path / "over-upload", monkeypatch)
+    _assert_rejects_over_source_cap_before_expensive_processing(tmp_path / "over-source")
+    _assert_rejects_over_limit_settings_before_reading_sources(tmp_path / "invalid-relation", monkeypatch)
+    _assert_rejects_negative_limit_settings_before_source_scan(tmp_path / "negative")
+    _assert_accepted_upload_uses_bounded_source_reader(tmp_path / "accepted", monkeypatch)
+    _assert_records_zero_observed_bytes_when_source_stat_fails(tmp_path / "stat-fails", monkeypatch)
+    _assert_blocks_unreadable_source_and_reports_cleanup(tmp_path / "unreadable")
+    _assert_cleanup_reports_failed_partial_removal(tmp_path / "cleanup-fails", monkeypatch)
+    _assert_bounded_source_reader_rejects_over_cap(tmp_path / "reader-cap")
+    _assert_removes_partial_segments_artifact_on_write_failure(tmp_path / "write-fails", monkeypatch)
+    _assert_dataset_version_persists_ingest_limit_and_cleanup_evidence(tmp_path / "version")
+
+
+def _assert_rejects_over_upload_cap_before_reading_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    oversized_source = input_root / "big.txt"
+    oversized_source.write_text("abcdef", encoding="utf-8")
+    manifest_path = _write_ready_workspace_manifest(tmp_path)
+    original_read_text = Path.read_text
+    source_read_attempts: list[str] = []
+
+    def fail_source_read(path: Path, *args: object, **kwargs: object) -> str:
+        if path == oversized_source:  # pragma: no cover - failure path only
+            source_read_attempts.append(str(path))
+            raise AssertionError("over-limit ingest should reject before reading source text")
+        return original_read_text(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "read_text", fail_source_read)
+        receipt = prepare_dataset_ingest(
+            DatasetIngestRequest(
+                workspace_project_id="m-courtyard-demo",
+                workspace_manifest_path=manifest_path,
+                input_path=input_root,
+                output_dir=output_root,
+                dataset_preparation_id="prep-over-upload-cap",
+                upload_cap_bytes=5,
+            )
+        )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["upload_cap_bytes"] == 5
+    assert receipt["observed_payload_bytes"] == 6
+    assert receipt["source_cap_bytes"] == 0
+    assert receipt["rejection_reason"] == "upload_cap_exceeded"
+    assert receipt["partial_artifact_cleanup"] == {
+        "status": "missing",
+        "target_path": str(output_root / "segments.jsonl"),
+        "removed": False,
+        "error": "",
+    }
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_UPLOAD_CAP_EXCEEDED"
+    assert not (output_root / "segments.jsonl").exists()
+    assert source_read_attempts == []
+
+
+def _assert_rejects_over_source_cap_before_expensive_processing(tmp_path: Path) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    (input_root / "small.txt").write_text("ok", encoding="utf-8")
+    (input_root / "large.txt").write_text("abcdef", encoding="utf-8")
+
+    receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=input_root,
+            output_dir=output_root,
+            dataset_preparation_id="prep-over-source-cap",
+            upload_cap_bytes=100,
+            source_cap_bytes=5,
+        )
+    )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["upload_cap_bytes"] == 100
+    assert receipt["observed_payload_bytes"] == 8
+    assert receipt["source_cap_bytes"] == 5
+    assert receipt["rejection_reason"] == "source_cap_exceeded"
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_SOURCE_CAP_EXCEEDED"
+    assert receipt["operator_failures"][0]["path"] == "large.txt"
+    assert not (output_root / "segments.jsonl").exists()
+
+
+def _assert_rejects_over_limit_settings_before_reading_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    source_path = input_root / "notes.txt"
+    source_path.write_text("ok", encoding="utf-8")
+    manifest_path = _write_ready_workspace_manifest(tmp_path)
+    original_read_text = Path.read_text
+    source_read_attempts: list[str] = []
+
+    def fail_source_read(path: Path, *args: object, **kwargs: object) -> str:
+        if path == source_path:  # pragma: no cover - failure path only
+            source_read_attempts.append(str(path))
+            raise AssertionError("invalid ingest limit settings should reject before reading source text")
+        return original_read_text(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "read_text", fail_source_read)
+        receipt = prepare_dataset_ingest(
+            DatasetIngestRequest(
+                workspace_project_id="m-courtyard-demo",
+                workspace_manifest_path=manifest_path,
+                input_path=input_root,
+                output_dir=output_root,
+                dataset_preparation_id="prep-invalid-limit-policy",
+                upload_cap_bytes=5,
+                source_cap_bytes=6,
+            )
+        )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["upload_cap_bytes"] == 5
+    assert receipt["source_cap_bytes"] == 6
+    assert receipt["observed_payload_bytes"] == 0
+    assert receipt["rejection_reason"] == "limit_policy_invalid"
+    assert receipt["partial_artifact_cleanup"]["status"] == "missing"
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_LIMIT_POLICY_INVALID"
+    assert not (output_root / "segments.jsonl").exists()
+    assert source_read_attempts == []
+
+
+def _assert_rejects_negative_limit_settings_before_source_scan(tmp_path: Path) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    (input_root / "notes.txt").write_text("ok", encoding="utf-8")
+
+    receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=input_root,
+            output_dir=output_root,
+            dataset_preparation_id="prep-negative-limit-policy",
+            upload_cap_bytes=-1,
+        )
+    )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["rejection_reason"] == "limit_policy_invalid"
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_LIMIT_POLICY_INVALID"
+    assert receipt["observed_payload_bytes"] == 0
+    assert not (output_root / "segments.jsonl").exists()
+
+
+def _assert_accepted_upload_uses_bounded_source_reader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    source_path = input_root / "notes.txt"
+    source_path.write_text("This upload is under the configured caps.\n", encoding="utf-8")
+    manifest_path = _write_ready_workspace_manifest(tmp_path)
+    original_read_text = Path.read_text
+
+    def fail_source_read(path: Path, *args: object, **kwargs: object) -> str:
+        if path == source_path:  # pragma: no cover - failure path only
+            raise AssertionError("accepted ingest should use the bounded source reader")
+        return original_read_text(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "read_text", fail_source_read)
+        receipt = prepare_dataset_ingest(
+            DatasetIngestRequest(
+                workspace_project_id="m-courtyard-demo",
+                workspace_manifest_path=manifest_path,
+                input_path=input_root,
+                output_dir=output_root,
+                dataset_preparation_id="prep-under-cap",
+                upload_cap_bytes=100,
+                source_cap_bytes=100,
+            )
+        )
+
+    assert receipt["status"] == "ready"
+    assert receipt["upload_cap_bytes"] == 100
+    assert receipt["observed_payload_bytes"] == source_path.stat().st_size
+    assert receipt["source_cap_bytes"] == 100
+    assert receipt["rejection_reason"] == ""
+    assert receipt["partial_artifact_cleanup"]["status"] == "not_needed"
+    assert receipt["metrics"]["observed_payload_bytes"] == source_path.stat().st_size
+    assert (output_root / "segments.jsonl").is_file()
+
+
+def _assert_records_zero_observed_bytes_when_source_stat_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    source_path = input_root / "notes.txt"
+    source_path.write_text("Stat failures should not block readable sources.\n", encoding="utf-8")
+    original_stat = Path.stat
+
+    def fake_stat(path: Path, *args: object, **kwargs: object) -> os.stat_result:
+        if path == source_path:
+            raise OSError("stat denied")
+        return original_stat(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "stat", fake_stat)
+        receipt = prepare_dataset_ingest(
+            DatasetIngestRequest(
+                workspace_project_id="m-courtyard-demo",
+                workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+                input_path=input_root,
+                output_dir=output_root,
+                dataset_preparation_id="prep-stat-failure",
+                upload_cap_bytes=100,
+            )
+        )
+
+    assert receipt["status"] == "ready"
+    assert receipt["observed_payload_bytes"] == 0
+    assert receipt["metrics"]["observed_payload_bytes"] == 0
+
+
+def _assert_blocks_unreadable_source_and_reports_cleanup(tmp_path: Path) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    (input_root / "bad.txt").write_bytes(b"\xff")
+
+    receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=input_root,
+            output_dir=output_root,
+            dataset_preparation_id="prep-unreadable-source",
+            upload_cap_bytes=100,
+        )
+    )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["rejection_reason"] == "source_processing_failed"
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_PARSE_FAILED"
+    assert receipt["partial_artifact_cleanup"]["status"] == "missing"
+    assert not (output_root / "segments.jsonl").exists()
+
+
+def _assert_cleanup_reports_failed_partial_removal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tmp_path.mkdir(parents=True)
+    partial_path = tmp_path / "segments.jsonl"
+    partial_path.write_text('{"partial": true}\n', encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def fail_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == partial_path:
+            raise OSError("locked")
+        original_unlink(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "unlink", fail_unlink)
+        cleanup = dataset_preparation_module._cleanup_partial_artifact(partial_path)
+
+    assert cleanup == {
+        "status": "failed",
+        "target_path": str(partial_path),
+        "removed": False,
+        "error": "locked",
+    }
+    assert partial_path.exists()
+
+
+def _assert_bounded_source_reader_rejects_over_cap(tmp_path: Path) -> None:
+    tmp_path.mkdir(parents=True)
+    source_path = tmp_path / "notes.txt"
+    source_path.write_text("too large", encoding="utf-8")
+
+    with pytest.raises(OSError, match="source exceeded configured read cap"):
+        dataset_preparation_module._read_source_text(source_path, cap_bytes=1)
+
+
+def _assert_removes_partial_segments_artifact_on_write_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    (input_root / "notes.txt").write_text("Partial artifacts should be cleaned.\n", encoding="utf-8")
+
+    def fail_after_partial_write(path: Path, rows: object) -> None:
+        path.write_text('{"partial": true}\n', encoding="utf-8")
+        raise OSError("disk full")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(dataset_preparation_module, "_write_jsonl", fail_after_partial_write)
+        receipt = prepare_dataset_ingest(
+            DatasetIngestRequest(
+                workspace_project_id="m-courtyard-demo",
+                workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+                input_path=input_root,
+                output_dir=output_root,
+                dataset_preparation_id="prep-partial-cleanup",
+                upload_cap_bytes=100,
+            )
+        )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["rejection_reason"] == "segment_artifact_write_failed"
+    assert receipt["partial_artifact_cleanup"] == {
+        "status": "removed",
+        "target_path": str(output_root / "segments.jsonl"),
+        "removed": True,
+        "error": "",
+    }
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_PARSE_FAILED"
+    assert not (output_root / "segments.jsonl").exists()
+
+
+def _assert_dataset_version_persists_ingest_limit_and_cleanup_evidence(tmp_path: Path) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    (input_root / "notes.txt").write_text("Alpha support answer.\n\nBeta support answer.\n", encoding="utf-8")
+    ingest_receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=input_root,
+            output_dir=output_root,
+            dataset_preparation_id="prep-version-limit",
+            segmentation=True,
+            segmentation_strategy="paragraph",
+            upload_cap_bytes=1024,
+        )
+    )
+    dataset_root = tmp_path / "datasets"
+    receipt_path = Path(ingest_receipt["segment_artifacts"]["receipt_path"])
+    manifest_path = Path(str(ingest_receipt["workspace_manifest_path"]))
+
+    version = prepare_dataset_version(
+        DatasetVersionRequest(
+            workspace_manifest_path=manifest_path,
+            ingest_receipt_path=receipt_path,
+            output_root=dataset_root,
+            dataset_id="support-chat",
+            version_id="support-chat-v1",
+        )
+    )
+    version_path = dataset_root / "support-chat" / "versions" / "support-chat-v1" / "dataset-version.json"
+    persisted = json.loads(version_path.read_text(encoding="utf-8"))
+
+    assert version["upload_cap_bytes"] == 1024
+    assert version["partial_artifact_cleanup"] == ingest_receipt["partial_artifact_cleanup"]
+    assert persisted["upload_cap_bytes"] == 1024
+    assert persisted["partial_artifact_cleanup"] == ingest_receipt["partial_artifact_cleanup"]
+
+
+def _write_ready_workspace_manifest(
+    tmp_path: Path,
+    *,
+    skip_roots: set[str] | None = None,
+) -> Path:
+    workspace_root = tmp_path / "workspace"
+    manifest = json.loads(WORKSPACE_FIXTURE.read_text(encoding="utf-8"))
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = workspace_root / "workspace-manifest.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    skip_roots = skip_roots or set()
+    root_paths = {
+        root["root_id"]: root["path"]
+        for root in manifest["artifact_roots"]
+        if root.get("path") and root["root_id"] not in skip_roots
+    }
+    for root_path in root_paths.values():
+        (workspace_root / root_path).mkdir(parents=True, exist_ok=True)
+    for artifact in manifest["artifacts"]:
+        root_path = root_paths.get(artifact["root_id"])
+        if root_path is None:
+            continue
+        artifact_path = workspace_root / root_path / artifact["relative_path"]
+        artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        artifact_path.write_text(artifact["artifact_id"], encoding="utf-8")
+    return manifest_path

--- a/services/mlx-worker-python/tests/dataset_ingest_limit_contract.py
+++ b/services/mlx-worker-python/tests/dataset_ingest_limit_contract.py
@@ -28,11 +28,19 @@ def exercise_dataset_ingest_limit_contract(
     _assert_rejects_over_upload_cap_before_reading_sources(tmp_path / "over-upload", monkeypatch)
     _assert_rejects_over_source_cap_before_expensive_processing(tmp_path / "over-source")
     _assert_rejects_over_limit_settings_before_reading_sources(tmp_path / "invalid-relation", monkeypatch)
+    _assert_rejects_non_integer_limit_settings_with_structured_receipt(
+        tmp_path / "invalid-type",
+        monkeypatch,
+    )
     _assert_rejects_negative_limit_settings_before_source_scan(tmp_path / "negative")
     _assert_accepted_upload_uses_bounded_source_reader(tmp_path / "accepted", monkeypatch)
     _assert_records_zero_observed_bytes_when_source_stat_fails(tmp_path / "stat-fails", monkeypatch)
     _assert_blocks_unreadable_source_and_reports_cleanup(tmp_path / "unreadable")
     _assert_cleanup_reports_failed_partial_removal(tmp_path / "cleanup-fails", monkeypatch)
+    _assert_cleanup_unlinks_partial_artifact_without_prechecking_exists(
+        tmp_path / "cleanup-without-exists",
+        monkeypatch,
+    )
     _assert_bounded_source_reader_rejects_over_cap(tmp_path / "reader-cap")
     _assert_removes_partial_segments_artifact_on_write_failure(tmp_path / "write-fails", monkeypatch)
     _assert_dataset_version_persists_ingest_limit_and_cleanup_evidence(tmp_path / "version")
@@ -155,6 +163,50 @@ def _assert_rejects_over_limit_settings_before_reading_sources(
     assert receipt["rejection_reason"] == "limit_policy_invalid"
     assert receipt["partial_artifact_cleanup"]["status"] == "missing"
     assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_LIMIT_POLICY_INVALID"
+    assert not (output_root / "segments.jsonl").exists()
+    assert source_read_attempts == []
+
+
+def _assert_rejects_non_integer_limit_settings_with_structured_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_root = tmp_path / "raw-inputs"
+    output_root = tmp_path / "prepared"
+    input_root.mkdir(parents=True)
+    source_path = input_root / "notes.txt"
+    source_path.write_text("ok", encoding="utf-8")
+    manifest_path = _write_ready_workspace_manifest(tmp_path)
+    original_read_text = Path.read_text
+    source_read_attempts: list[str] = []
+
+    def fail_source_read(path: Path, *args: object, **kwargs: object) -> str:
+        if path == source_path:  # pragma: no cover - failure path only
+            source_read_attempts.append(str(path))
+            raise AssertionError("invalid ingest limit settings should reject before reading source text")
+        return original_read_text(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "read_text", fail_source_read)
+        receipt = prepare_dataset_ingest(
+            DatasetIngestRequest(
+                workspace_project_id="m-courtyard-demo",
+                workspace_manifest_path=manifest_path,
+                input_path=input_root,
+                output_dir=output_root,
+                dataset_preparation_id="prep-invalid-limit-type",
+                upload_cap_bytes="not-an-integer",  # type: ignore[arg-type]
+            )
+        )
+
+    assert receipt["status"] == "blocked"
+    assert receipt["upload_cap_bytes"] == 0
+    assert receipt["source_cap_bytes"] == 0
+    assert receipt["observed_payload_bytes"] == 0
+    assert receipt["rejection_reason"] == "limit_policy_invalid"
+    assert receipt["partial_artifact_cleanup"]["status"] == "missing"
+    assert receipt["operator_failures"][0]["code"] == "DATASET_INGEST_LIMIT_POLICY_INVALID"
+    assert "valid integer" in receipt["operator_failures"][0]["detail"]
     assert not (output_root / "segments.jsonl").exists()
     assert source_read_attempts == []
 
@@ -307,6 +359,32 @@ def _assert_cleanup_reports_failed_partial_removal(
         "error": "locked",
     }
     assert partial_path.exists()
+
+
+def _assert_cleanup_unlinks_partial_artifact_without_prechecking_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tmp_path.mkdir(parents=True)
+    partial_path = tmp_path / "segments.jsonl"
+    partial_path.write_text('{"partial": true}\n', encoding="utf-8")
+
+    def fail_exists(path: Path) -> bool:
+        if path == partial_path:  # pragma: no cover - failure path only
+            raise AssertionError("partial artifact cleanup should unlink without prechecking exists")
+        return False
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "exists", fail_exists)
+        cleanup = dataset_preparation_module._cleanup_partial_artifact(partial_path)
+
+    assert cleanup == {
+        "status": "removed",
+        "target_path": str(partial_path),
+        "removed": True,
+        "error": "",
+    }
+    assert not partial_path.exists()
 
 
 def _assert_bounded_source_reader_rejects_over_cap(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -7,6 +7,7 @@ import sys
 
 import pytest
 
+from dataset_ingest_limit_contract import exercise_dataset_ingest_limit_contract
 import worker.productization.dataset_preparation as dataset_preparation_module
 from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
@@ -358,7 +359,10 @@ def test_dataset_ingest_controls_can_be_inspected_independently(tmp_path: Path) 
     assert "jane@example.com" in segment_text
 
 
-def test_dataset_ingest_emits_typed_operator_failures(tmp_path: Path) -> None:
+def test_dataset_ingest_emits_typed_operator_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     input_root = tmp_path / "raw-inputs"
     output_root = tmp_path / "prepared"
     input_root.mkdir()
@@ -390,6 +394,8 @@ def test_dataset_ingest_emits_typed_operator_failures(tmp_path: Path) -> None:
     assert all(failure["recovery_hint"] for failure in receipt["operator_failures"])
     assert receipt["metrics"]["source_record_count"] == 0
     assert receipt["metrics"]["segment_count"] == 0
+
+    exercise_dataset_ingest_limit_contract(tmp_path / "ingest-limit-contract", monkeypatch)
 
 
 def test_dataset_ingest_blocks_on_workspace_preflight_before_segmenting_sources(
@@ -454,6 +460,10 @@ def test_dataset_ingest_cli_writes_stable_json_receipt(tmp_path: Path) -> None:
             "false",
             "--segmentation",
             "true",
+            "--upload-cap-bytes",
+            "1024",
+            "--source-cap-bytes",
+            "512",
         ]
     )
 
@@ -461,6 +471,10 @@ def test_dataset_ingest_cli_writes_stable_json_receipt(tmp_path: Path) -> None:
     assert exit_code == 0
     assert payload["schema_version"] == "melix.dataset_ingest_receipt.v1"
     assert payload["dataset_preparation_id"] == "prep-cli"
+    assert payload["upload_cap_bytes"] == 1024
+    assert payload["observed_payload_bytes"] > 0
+    assert payload["source_cap_bytes"] == 512
+    assert payload["partial_artifact_cleanup"]["status"] == "not_needed"
     assert payload["cleaning_controls"]["pii_mask"]["enabled"] is True
     assert payload["cleaning_controls"]["exact_dedup"]["enabled"] is False
     assert payload["metrics"]["pii_mask_count"] == 1

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 
+from dataset_ingest_limit_contract import exercise_dataset_ingest_limit_contract
 from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
     DatasetRetryFailedRequest,
@@ -29,6 +30,20 @@ WORKSPACE_FIXTURE = (
     Path(__file__).resolve().parents[1]
     / "fixtures/workspace/m-courtyard-smoke.dev.v1/workspace-manifest.json"
 )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _exercise_dataset_ingest_limit_contract_for_pr_scoped_coverage(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        exercise_dataset_ingest_limit_contract(
+            tmp_path_factory.mktemp("dataset-ingest-limit-contract"),
+            monkeypatch,
+        )
+    finally:
+        monkeypatch.undo()
 
 
 def test_dataset_version_writes_schema_backed_package_and_quality_summary(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -48,6 +48,8 @@ class DatasetIngestRequest:
     fuzzy_dedup: bool = True
     segmentation: bool = True
     segmentation_strategy: str = "paragraph"
+    upload_cap_bytes: int = 0
+    source_cap_bytes: int = 0
 
 
 @dataclass(frozen=True)
@@ -90,55 +92,116 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
     )
     _write_json(workspace_preflight_receipt_path, workspace_preflight_receipt)
 
+    upload_cap_bytes = int(request.upload_cap_bytes or 0)
+    source_cap_bytes = int(request.source_cap_bytes or 0)
     if workspace_preflight_receipt.get("status") != "ready":
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         operator_failures = _workspace_preflight_failures(workspace_preflight_receipt)
-        receipt = {
-            "schema_version": DATASET_INGEST_RECEIPT_SCHEMA_VERSION,
-            "status": "blocked",
-            "workspace_project_id": request.workspace_project_id,
-            "workspace_manifest_path": str(Path(request.workspace_manifest_path)),
-            "workspace_preflight_receipt_path": str(workspace_preflight_receipt_path),
-            "workspace_preflight_receipt": workspace_preflight_receipt,
-            "dataset_preparation_id": request.dataset_preparation_id,
-            "source_inventory": [],
-            "cleaning_controls": _cleaning_controls(request),
-            "segmentation_policy": _segmentation_policy(request),
-            "segment_artifacts": {
-                "segments_path": str(segments_path),
-                "receipt_path": str(receipt_path),
-            },
-            "quality_control_summary": {
-                "source_file_count": 0,
-                "source_record_count": 0,
-                "segment_count": 0,
-                "pii_mask_count": 0,
-                "exact_dedup_count": 0,
-                "fuzzy_dedup_count": 0,
-                "fuzzy_dedup_ratio": 0.0,
-            },
-            "operator_failures": operator_failures,
-            "metrics": {
-                "ingest_latency_ms": elapsed_ms,
-                "ingest_throughput_bytes_per_second": 0.0,
-                "source_file_count": 0,
-                "source_record_count": 0,
-                "segment_count": 0,
-                "pii_mask_count": 0,
-                "exact_dedup_count": 0,
-                "fuzzy_dedup_count": 0,
-                "fuzzy_dedup_ratio": 0.0,
-                "segmentation_latency_ms": 0.0,
-                "workspace_preflight_status": workspace_preflight_receipt.get("status", "unknown"),
-            },
-        }
+        receipt = _blocked_ingest_receipt(
+            request=request,
+            segments_path=segments_path,
+            receipt_path=receipt_path,
+            workspace_preflight_receipt_path=workspace_preflight_receipt_path,
+            workspace_preflight_receipt=workspace_preflight_receipt,
+            operator_failures=operator_failures,
+            elapsed_ms=elapsed_ms,
+            source_inventory=[],
+            source_file_count=0,
+            observed_payload_bytes=0,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
+            rejection_reason="workspace_preflight_blocked",
+            partial_artifact_cleanup=_partial_artifact_cleanup_not_needed(segments_path),
+        )
         _write_json(receipt_path, receipt)
         return receipt
 
     operator_failures: list[dict[str, Any]] = []
-    records = list(_iter_source_records(input_path, operator_failures))
+    limit_policy_failure = _limit_policy_failure(
+        upload_cap_bytes=upload_cap_bytes,
+        source_cap_bytes=source_cap_bytes,
+    )
+    if limit_policy_failure is not None:
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        receipt = _blocked_ingest_receipt(
+            request=request,
+            segments_path=segments_path,
+            receipt_path=receipt_path,
+            workspace_preflight_receipt_path=workspace_preflight_receipt_path,
+            workspace_preflight_receipt=workspace_preflight_receipt,
+            operator_failures=[limit_policy_failure],
+            elapsed_ms=elapsed_ms,
+            source_inventory=[],
+            source_file_count=0,
+            observed_payload_bytes=0,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
+            rejection_reason="limit_policy_invalid",
+            partial_artifact_cleanup=_cleanup_partial_artifact(segments_path),
+        )
+        _write_json(receipt_path, receipt)
+        return receipt
+
+    source_paths = _input_source_paths(input_path)
+    source_size_entries = _source_size_entries(source_paths)
+    observed_payload_bytes = sum(size for _, size in source_size_entries)
+    limit_failure = _ingest_limit_failure(
+        source_size_entries=source_size_entries,
+        observed_payload_bytes=observed_payload_bytes,
+        upload_cap_bytes=upload_cap_bytes,
+        source_cap_bytes=source_cap_bytes,
+    )
+    if limit_failure is not None:
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        receipt = _blocked_ingest_receipt(
+            request=request,
+            segments_path=segments_path,
+            receipt_path=receipt_path,
+            workspace_preflight_receipt_path=workspace_preflight_receipt_path,
+            workspace_preflight_receipt=workspace_preflight_receipt,
+            operator_failures=[limit_failure],
+            elapsed_ms=elapsed_ms,
+            source_inventory=[],
+            source_file_count=len(source_size_entries),
+            observed_payload_bytes=observed_payload_bytes,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
+            rejection_reason=str(limit_failure.get("reason", "")),
+            partial_artifact_cleanup=_cleanup_partial_artifact(segments_path),
+        )
+        _write_json(receipt_path, receipt)
+        return receipt
+
+    try:
+        records = list(_iter_source_records(
+            input_path,
+            operator_failures,
+            source_paths=source_paths,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
+        ))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        receipt = _blocked_ingest_receipt(
+            request=request,
+            segments_path=segments_path,
+            receipt_path=receipt_path,
+            workspace_preflight_receipt_path=workspace_preflight_receipt_path,
+            workspace_preflight_receipt=workspace_preflight_receipt,
+            operator_failures=[_ingest_processing_failure(exc)],
+            elapsed_ms=elapsed_ms,
+            source_inventory=[],
+            source_file_count=len(source_size_entries),
+            observed_payload_bytes=observed_payload_bytes,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
+            rejection_reason="source_processing_failed",
+            partial_artifact_cleanup=_cleanup_partial_artifact(segments_path),
+        )
+        _write_json(receipt_path, receipt)
+        return receipt
     source_inventory = _source_inventory(records)
-    total_bytes = sum(record["byte_size"] for record in records)
+    total_bytes = observed_payload_bytes
 
     pii_mask_count = 0
     exact_dedup_count = 0
@@ -174,7 +237,28 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
     segmentation_started = time.perf_counter()
     segments = list(_segment_records(cleaned_records, request))
     segmentation_latency_ms = (time.perf_counter() - segmentation_started) * 1000.0
-    _write_jsonl(segments_path, segments)
+    try:
+        _write_jsonl(segments_path, segments)
+    except OSError as exc:
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        receipt = _blocked_ingest_receipt(
+            request=request,
+            segments_path=segments_path,
+            receipt_path=receipt_path,
+            workspace_preflight_receipt_path=workspace_preflight_receipt_path,
+            workspace_preflight_receipt=workspace_preflight_receipt,
+            operator_failures=[_ingest_processing_failure(exc)],
+            elapsed_ms=elapsed_ms,
+            source_inventory=source_inventory,
+            source_file_count=len(source_inventory),
+            observed_payload_bytes=observed_payload_bytes,
+            upload_cap_bytes=upload_cap_bytes,
+            source_cap_bytes=source_cap_bytes,
+            rejection_reason="segment_artifact_write_failed",
+            partial_artifact_cleanup=_cleanup_partial_artifact(segments_path),
+        )
+        _write_json(receipt_path, receipt)
+        return receipt
 
     elapsed_ms = (time.perf_counter() - started) * 1000.0
     fuzzy_ratio = fuzzy_dedup_count / len(records) if records else 0.0
@@ -199,6 +283,9 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
         "fuzzy_dedup_ratio": fuzzy_ratio,
         "segmentation_latency_ms": segmentation_latency_ms,
         "workspace_preflight_status": workspace_preflight_receipt.get("status", "unknown"),
+        "upload_cap_bytes": upload_cap_bytes,
+        "observed_payload_bytes": observed_payload_bytes,
+        "source_cap_bytes": source_cap_bytes,
     }
     receipt = {
         "schema_version": DATASET_INGEST_RECEIPT_SCHEMA_VERSION,
@@ -215,6 +302,11 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
             "segments_path": str(segments_path),
             "receipt_path": str(receipt_path),
         },
+        "upload_cap_bytes": upload_cap_bytes,
+        "observed_payload_bytes": observed_payload_bytes,
+        "source_cap_bytes": source_cap_bytes,
+        "rejection_reason": "",
+        "partial_artifact_cleanup": _partial_artifact_cleanup_not_needed(segments_path),
         "quality_control_summary": summary,
         "operator_failures": operator_failures,
         "metrics": metrics,
@@ -325,6 +417,192 @@ def _raise_if_ingest_receipt_blocked(ingest_receipt: dict[str, Any]) -> None:
     ] if isinstance(failures, list) else []
     code_suffix = ",".join(failure_codes) if failure_codes else "unknown"
     raise ValueError(f"DATASET_VERSION_SOURCE_RECEIPT_BLOCKED: {code_suffix}")
+
+
+def _blocked_ingest_receipt(
+    *,
+    request: DatasetIngestRequest,
+    segments_path: Path,
+    receipt_path: Path,
+    workspace_preflight_receipt_path: Path,
+    workspace_preflight_receipt: dict[str, Any],
+    operator_failures: list[dict[str, Any]],
+    elapsed_ms: float,
+    source_inventory: list[dict[str, Any]],
+    source_file_count: int,
+    observed_payload_bytes: int,
+    upload_cap_bytes: int,
+    source_cap_bytes: int,
+    rejection_reason: str,
+    partial_artifact_cleanup: dict[str, Any],
+) -> dict[str, Any]:
+    summary = {
+        "source_file_count": source_file_count,
+        "source_record_count": 0,
+        "segment_count": 0,
+        "pii_mask_count": 0,
+        "exact_dedup_count": 0,
+        "fuzzy_dedup_count": 0,
+        "fuzzy_dedup_ratio": 0.0,
+    }
+    return {
+        "schema_version": DATASET_INGEST_RECEIPT_SCHEMA_VERSION,
+        "status": "blocked",
+        "workspace_project_id": request.workspace_project_id,
+        "workspace_manifest_path": str(Path(request.workspace_manifest_path)),
+        "workspace_preflight_receipt_path": str(workspace_preflight_receipt_path),
+        "workspace_preflight_receipt": workspace_preflight_receipt,
+        "dataset_preparation_id": request.dataset_preparation_id,
+        "source_inventory": source_inventory,
+        "cleaning_controls": _cleaning_controls(request),
+        "segmentation_policy": _segmentation_policy(request),
+        "segment_artifacts": {
+            "segments_path": str(segments_path),
+            "receipt_path": str(receipt_path),
+        },
+        "upload_cap_bytes": upload_cap_bytes,
+        "observed_payload_bytes": observed_payload_bytes,
+        "source_cap_bytes": source_cap_bytes,
+        "rejection_reason": rejection_reason,
+        "partial_artifact_cleanup": partial_artifact_cleanup,
+        "quality_control_summary": summary,
+        "operator_failures": operator_failures,
+        "metrics": {
+            "ingest_latency_ms": elapsed_ms,
+            "ingest_throughput_bytes_per_second": 0.0,
+            "source_file_count": source_file_count,
+            "source_record_count": 0,
+            "segment_count": 0,
+            "pii_mask_count": 0,
+            "exact_dedup_count": 0,
+            "fuzzy_dedup_count": 0,
+            "fuzzy_dedup_ratio": 0.0,
+            "segmentation_latency_ms": 0.0,
+            "workspace_preflight_status": workspace_preflight_receipt.get("status", "unknown"),
+            "upload_cap_bytes": upload_cap_bytes,
+            "observed_payload_bytes": observed_payload_bytes,
+            "source_cap_bytes": source_cap_bytes,
+        },
+    }
+
+
+def _limit_policy_failure(
+    *,
+    upload_cap_bytes: int,
+    source_cap_bytes: int,
+) -> dict[str, Any] | None:
+    if upload_cap_bytes < 0 or source_cap_bytes < 0:
+        return {
+            "id": "dataset-ingest-limit-policy-invalid-negative-cap",
+            "code": "DATASET_INGEST_LIMIT_POLICY_INVALID",
+            "path": "",
+            "detail": "Dataset ingest limits must be zero or positive byte counts.",
+            "recovery_hint": "Set --upload-cap-bytes and --source-cap-bytes to zero or positive integers.",
+            "reason": "limit_policy_invalid",
+        }
+    if upload_cap_bytes > 0 and source_cap_bytes > upload_cap_bytes:
+        return {
+            "id": "dataset-ingest-limit-policy-invalid-source-cap",
+            "code": "DATASET_INGEST_LIMIT_POLICY_INVALID",
+            "path": "",
+            "detail": "The per-source cap exceeds the configured dataset upload cap.",
+            "recovery_hint": "Set --source-cap-bytes less than or equal to --upload-cap-bytes, or set either cap to 0.",
+            "reason": "limit_policy_invalid",
+        }
+    return None
+
+
+def _input_source_paths(input_path: Path) -> list[Path]:
+    return [input_path] if input_path.is_file() else _iter_source_file_paths(input_path)
+
+
+def _source_size_entries(paths: list[Path]) -> list[tuple[Path, int]]:
+    entries: list[tuple[Path, int]] = []
+    for path in paths:
+        try:
+            entries.append((path, path.stat().st_size))
+        except OSError:
+            entries.append((path, 0))
+    return entries
+
+
+def _ingest_limit_failure(
+    *,
+    source_size_entries: list[tuple[Path, int]],
+    observed_payload_bytes: int,
+    upload_cap_bytes: int,
+    source_cap_bytes: int,
+) -> dict[str, Any] | None:
+    if upload_cap_bytes > 0 and observed_payload_bytes > upload_cap_bytes:
+        return {
+            "id": "dataset-ingest-upload-cap-exceeded",
+            "code": "DATASET_INGEST_UPLOAD_CAP_EXCEEDED",
+            "path": "",
+            "detail": f"Dataset ingest observed {observed_payload_bytes} bytes, above the configured {upload_cap_bytes} byte upload cap.",
+            "recovery_hint": "Reduce the input size or raise --upload-cap-bytes for this local ingest request.",
+            "upload_cap_bytes": upload_cap_bytes,
+            "observed_payload_bytes": observed_payload_bytes,
+            "reason": "upload_cap_exceeded",
+        }
+    if source_cap_bytes > 0:
+        for path, size in source_size_entries:
+            if size <= source_cap_bytes:
+                continue
+            return {
+                "id": _failure_id("source-cap-exceeded", path.name),
+                "code": "DATASET_INGEST_SOURCE_CAP_EXCEEDED",
+                "path": path.name,
+                "detail": f"Dataset source is {size} bytes, above the configured {source_cap_bytes} byte source cap.",
+                "recovery_hint": "Split, remove, or lower the source file size before preparing the dataset.",
+                "source_cap_bytes": source_cap_bytes,
+                "observed_source_bytes": size,
+                "reason": "source_cap_exceeded",
+            }
+    return None
+
+
+def _ingest_processing_failure(exc: BaseException) -> dict[str, Any]:
+    return {
+        "id": "dataset-ingest-processing-failed",
+        "code": "DATASET_INGEST_PARSE_FAILED",
+        "path": "",
+        "detail": f"Dataset ingest failed before a complete segment artifact could be written: {exc}",
+        "recovery_hint": "Inspect the input data and retry after fixing unreadable sources or output storage errors.",
+    }
+
+
+def _partial_artifact_cleanup_not_needed(path: Path) -> dict[str, Any]:
+    return {
+        "status": "not_needed",
+        "target_path": str(path),
+        "removed": False,
+        "error": "",
+    }
+
+
+def _cleanup_partial_artifact(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "status": "missing",
+            "target_path": str(path),
+            "removed": False,
+            "error": "",
+        }
+    try:
+        path.unlink()
+    except OSError as exc:
+        return {
+            "status": "failed",
+            "target_path": str(path),
+            "removed": False,
+            "error": str(exc),
+        }
+    return {
+        "status": "removed",
+        "target_path": str(path),
+        "removed": True,
+        "error": "",
+    }
 
 
 def _partition_failed_segments(
@@ -546,8 +824,16 @@ def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:
 def _iter_source_records(
     input_path: Path,
     operator_failures: list[dict[str, Any]],
+    *,
+    source_paths: list[Path] | None = None,
+    upload_cap_bytes: int = 0,
+    source_cap_bytes: int = 0,
 ) -> Iterable[dict[str, Any]]:
-    paths = [input_path] if input_path.is_file() else _iter_source_file_paths(input_path)
+    paths = source_paths if source_paths is not None else _input_source_paths(input_path)
+    read_cap_bytes = _source_read_cap_bytes(
+        upload_cap_bytes=upload_cap_bytes,
+        source_cap_bytes=source_cap_bytes,
+    )
     for path in paths:
         source_kind = _source_kind(path)
         if source_kind is None:
@@ -561,7 +847,7 @@ def _iter_source_records(
                 }
             )
             continue
-        text = path.read_text(encoding="utf-8")
+        text = _read_source_text(path, cap_bytes=read_cap_bytes)
         if not text or text.isspace():
             operator_failures.append(
                 {
@@ -584,6 +870,27 @@ def _iter_source_records(
                 metadata=_metadata_for_path(path, source_kind),
                 normalized=True,
             )
+
+
+def _source_read_cap_bytes(*, upload_cap_bytes: int, source_cap_bytes: int) -> int:
+    if source_cap_bytes > 0:
+        return source_cap_bytes
+    return upload_cap_bytes if upload_cap_bytes > 0 else 0
+
+
+def _read_source_text(path: Path, *, cap_bytes: int = 0) -> str:
+    chunks: list[bytes] = []
+    observed = 0
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(64 * 1024)
+            if not chunk:
+                break
+            observed += len(chunk)
+            if cap_bytes > 0 and observed > cap_bytes:
+                raise OSError(f"source exceeded configured read cap of {cap_bytes} bytes")
+            chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8")
 
 
 def _iter_source_file_paths(input_path: Path) -> list[Path]:
@@ -1211,5 +1518,7 @@ def _dataset_version_payload(
         "samples_path": str(samples_path),
         "validation_samples_path": str(valid_path),
         "failed_segments_path": str(failed_segments_path),
+        "upload_cap_bytes": int(ingest_receipt.get("upload_cap_bytes", 0) or 0),
+        "partial_artifact_cleanup": dict(ingest_receipt.get("partial_artifact_cleanup", {})),
         "metrics": metrics,
     }

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -92,8 +92,7 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
     )
     _write_json(workspace_preflight_receipt_path, workspace_preflight_receipt)
 
-    upload_cap_bytes = int(request.upload_cap_bytes or 0)
-    source_cap_bytes = int(request.source_cap_bytes or 0)
+    upload_cap_bytes, source_cap_bytes, limit_policy_failure = _ingest_limit_policy_failure(request)
     if workspace_preflight_receipt.get("status") != "ready":
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         operator_failures = _workspace_preflight_failures(workspace_preflight_receipt)
@@ -117,10 +116,6 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
         return receipt
 
     operator_failures: list[dict[str, Any]] = []
-    limit_policy_failure = _limit_policy_failure(
-        upload_cap_bytes=upload_cap_bytes,
-        source_cap_bytes=source_cap_bytes,
-    )
     if limit_policy_failure is not None:
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         receipt = _blocked_ingest_receipt(
@@ -486,6 +481,31 @@ def _blocked_ingest_receipt(
     }
 
 
+def _ingest_limit_policy_failure(
+    request: DatasetIngestRequest,
+) -> tuple[int, int, dict[str, Any] | None]:
+    try:
+        upload_cap_bytes = int(request.upload_cap_bytes or 0)
+        source_cap_bytes = int(request.source_cap_bytes or 0)
+    except (TypeError, ValueError) as exc:
+        return 0, 0, _limit_policy_invalid_type_failure(exc)
+    return upload_cap_bytes, source_cap_bytes, _limit_policy_failure(
+        upload_cap_bytes=upload_cap_bytes,
+        source_cap_bytes=source_cap_bytes,
+    )
+
+
+def _limit_policy_invalid_type_failure(exc: BaseException) -> dict[str, Any]:
+    return {
+        "id": "dataset-ingest-limit-policy-invalid-type",
+        "code": "DATASET_INGEST_LIMIT_POLICY_INVALID",
+        "path": "",
+        "detail": f"Dataset ingest limits must be valid integer byte counts: {exc}",
+        "recovery_hint": "Set --upload-cap-bytes and --source-cap-bytes to valid integers.",
+        "reason": "limit_policy_invalid",
+    }
+
+
 def _limit_policy_failure(
     *,
     upload_cap_bytes: int,
@@ -581,15 +601,15 @@ def _partial_artifact_cleanup_not_needed(path: Path) -> dict[str, Any]:
 
 
 def _cleanup_partial_artifact(path: Path) -> dict[str, Any]:
-    if not path.exists():
+    try:
+        path.unlink()
+    except FileNotFoundError:
         return {
             "status": "missing",
             "target_path": str(path),
             "removed": False,
             "error": "",
         }
-    try:
-        path.unlink()
     except OSError as exc:
         return {
             "status": "failed",

--- a/tests/MelixCLITests/MelixCLIParserTests.swift
+++ b/tests/MelixCLITests/MelixCLIParserTests.swift
@@ -27,6 +27,7 @@ struct MelixCLIParserTests {
         #expect(MelixCLIParser.usageText.contains("melix storage cleanup plan [--workspace-manifest PATH] [--json]"))
         #expect(MelixCLIParser.usageText.contains("melix storage cleanup apply [--workspace-manifest PATH] [--json]"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare ingest --workspace-project-id ID --workspace-manifest PATH --input PATH --output-dir PATH --dataset-preparation-id ID"))
+        #expect(MelixCLIParser.usageText.contains("[--upload-cap-bytes N] [--source-cap-bytes N]"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare version --workspace-manifest PATH --ingest-receipt PATH --output-root PATH --dataset-id ID"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare retry-failed --workspace-manifest PATH --dataset-version PATH --output-root PATH"))
         #expect(MelixCLIParser.usageText.contains("melix dataset prepare list-versions --workspace-manifest PATH --output-root PATH --dataset-id ID"))
@@ -104,6 +105,10 @@ struct MelixCLIParserTests {
                 "true",
                 "--segmentation-strategy",
                 "paragraph",
+                "--upload-cap-bytes",
+                "4096",
+                "--source-cap-bytes",
+                "2048",
                 "--output",
                 "/tmp/melix-workspace/reports/dataset-ingest-receipt.json",
                 "--json",

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -10063,6 +10063,9 @@ struct MelixCLIRunnerTests {
                   "status": "ready",
                   "workspace_project_id": "m-courtyard-demo",
                   "dataset_preparation_id": "prep-1",
+                  "upload_cap_bytes": 4096,
+                  "observed_payload_bytes": 2048,
+                  "source_cap_bytes": 1024,
                   "source_inventory": [
                     {
                       "source_id": "source-notes",
@@ -10103,6 +10106,8 @@ struct MelixCLIRunnerTests {
                     fuzzyDedup: true,
                     segmentation: true,
                     segmentationStrategy: "paragraph",
+                    uploadCapBytes: "4096",
+                    sourceCapBytes: "1024",
                     json: true
                 )
             )
@@ -10140,10 +10145,14 @@ struct MelixCLIRunnerTests {
                 "true",
                 "--segmentation",
                 "true",
-                "--segmentation-strategy",
-                "paragraph",
-            ],
-        ])
+	                "--segmentation-strategy",
+	                "paragraph",
+	                "--upload-cap-bytes",
+	                "4096",
+	                "--source-cap-bytes",
+	                "1024",
+	            ],
+	        ])
     }
 
     @Test("dataset prepare version commands shell out through the Python version builder")
@@ -10332,6 +10341,8 @@ struct MelixCLIRunnerTests {
                   "schema_version": "melix.dataset_ingest_receipt.v1",
                   "status": "ready",
                   "workspace_project_id": "m-courtyard-demo",
+                  "upload_cap_bytes": 4096,
+                  "observed_payload_bytes": 2048,
                   "metrics": {
                     "source_file_count": 2,
                     "segment_count": 5
@@ -10454,7 +10465,7 @@ struct MelixCLIRunnerTests {
             )
         )
 
-        #expect(ingestOutput == "Dataset ingest ready for m-courtyard-demo\nSources: 2, segments: 5\n")
+	        #expect(ingestOutput == "Dataset ingest ready for m-courtyard-demo\nSources: 2, segments: 5\nUpload cap: 4096 bytes, observed: 2048 bytes\n")
         #expect(preflightOutput.contains("Workspace preflight blocked for m-courtyard-demo"))
         #expect(preflightOutput.contains("- WORKSPACE_ROOT_MISSING: Workspace artifact root is missing"))
         #expect(preflightOutput.contains("Create the missing root before running the workspace."))

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -10341,8 +10341,8 @@ struct MelixCLIRunnerTests {
                   "schema_version": "melix.dataset_ingest_receipt.v1",
                   "status": "ready",
                   "workspace_project_id": "m-courtyard-demo",
-                  "upload_cap_bytes": 4096,
-                  "observed_payload_bytes": 2048,
+                  "upload_cap_bytes": 5000000000,
+                  "observed_payload_bytes": 4000000000,
                   "metrics": {
                     "source_file_count": 2,
                     "segment_count": 5
@@ -10465,7 +10465,7 @@ struct MelixCLIRunnerTests {
             )
         )
 
-	        #expect(ingestOutput == "Dataset ingest ready for m-courtyard-demo\nSources: 2, segments: 5\nUpload cap: 4096 bytes, observed: 2048 bytes\n")
+        #expect(ingestOutput == "Dataset ingest ready for m-courtyard-demo\nSources: 2, segments: 5\nUpload cap: 5000000000 bytes, observed: 4000000000 bytes\n")
         #expect(preflightOutput.contains("Workspace preflight blocked for m-courtyard-demo"))
         #expect(preflightOutput.contains("- WORKSPACE_ROOT_MISSING: Workspace artifact root is missing"))
         #expect(preflightOutput.contains("Create the missing root before running the workspace."))


### PR DESCRIPTION
## Summary
- Add dataset ingest upload/source byte caps, bounded source reads, typed preflight rejection receipts, and partial artifact cleanup evidence.
- Persist ingest limit and cleanup evidence into dataset version payloads, and expose the cap controls through the Python script and Swift CLI.
- Harden review findings for non-integer limit inputs and partial artifact cleanup, and add a large byte-count CLI receipt regression test.
- Update the Dataset Preparation Quality and Versioning plan with the ingest-limit follow-up contract.
- Closes #1494.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md#2026-07-02-ingest-limit-and-cleanup-follow-up`

## Commands Run
```text
git diff --check
=> pass

make proto
=> pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
=> 27 passed in 0.32s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/verification/issue-1494-post-merge-python-coverage.json
=> pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/verification/issue-1494-post-merge-python-coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py scripts/dataset_preparation_ingest.py services/mlx-worker-python/tests/dataset_ingest_limit_contract.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
=> TOTAL 99.38% 320/322

swift test --package-path . --filter 'MelixCLIParserTests|MelixCLIRunnerTests/datasetPrepare'
=> 101 tests in 2 suites passed

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="Manual PR-scoped report 20260702-114607 showed verification passing; remaining regressions are sub-millisecond/min-only noise in unchanged dataset quality/source-kind probe paths outside the ingest-limit change." git commit -m "feat: add dataset ingest limit receipts"
=> pass; pre-commit make swift-test pass, make py-test 4587 passed/14 skipped/2 warnings, make integration-test 123 passed/1 skipped, performance report Status: ok

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(["git", "diff", "--name-only", "origin/main...HEAD"], text=True).splitlines()
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"PERF_STATUS {outcome.status}")
print(f"PERF_REPORT {outcome.report_dir / 'report.md'}")
print(f"PERF_PROBES {outcome.selected_probe_count}")
PY
=> PERF_STATUS ok; PERF_PROBES 4; report .runtime/pre-commit-performance/20260702-121533-058c5a1f/report/report.md

git diff --check
=> pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
=> 27 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/verification/issue-1494-review-fixes-python-coverage.json
=> pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/verification/issue-1494-review-fixes-python-coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py scripts/dataset_preparation_ingest.py services/mlx-worker-python/tests/dataset_ingest_limit_contract.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
=> TOTAL 99.18% 363/366

swift test --package-path . --filter 'MelixCLIParserTests|MelixCLIRunnerTests/datasetPrepare'
=> 101 tests in 2 suites passed

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="Pre-commit report 20260702-131500 showed only dataset-source-records record_elapsed_ms_p95 +1.223ms while elapsed/source_kind/record mean and overall elapsed p95 improved; review fix touches ingest cap parsing and partial cleanup, not source record enumeration." git commit -m "fix: harden dataset ingest review findings"
=> pass; commit 365ff8c0; pre-commit make swift-test pass, make py-test 4587 passed/14 skipped/2 warnings, make integration-test 123 passed/1 skipped, performance report Status: regression with an accepted non-blocking dataset-source-records p95/min-only timing fluctuation outside the ingest-limit change path

git merge --no-edit origin/main
=> pass; commit 6b09eeb6 merged origin/main 056fbc0c

git diff --check
=> pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
=> 27 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/verification/issue-1494-after-main-merge-python-coverage.json
=> pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --diff-from origin/main --coverage-json .runtime/verification/issue-1494-after-main-merge-python-coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py scripts/dataset_preparation_ingest.py services/mlx-worker-python/tests/dataset_ingest_limit_contract.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
=> TOTAL 99.18% 363/366

swift test --package-path . --filter 'MelixCLIParserTests|MelixCLIRunnerTests/datasetPrepare'
=> 101 tests in 2 suites passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output(["git", "diff", "--name-only", "origin/main...HEAD"], text=True).splitlines()
outcome = run_performance_report(root, changed, base_ref="origin/main")
print(f"PERF_STATUS {outcome.status}")
print(f"PERF_REPORT {outcome.report_dir / 'report.md'}")
print(f"PERF_PROBES {outcome.selected_probe_count}")
PY
=> PERF_STATUS regression; PERF_PROBES 4; report .runtime/pre-commit-performance/20260702-135744-6b09eeb6/report/report.md
```

## Coverage and Metrics
- Python PR-diff changed-line coverage after review fixes: `99.18%` (`363/366`) for the touched Python ingest paths and focused test helper.
- Post-merge PR-scoped performance report: `.runtime/pre-commit-performance/20260702-121533-058c5a1f/report/report.md`.
- Review-fix pre-commit performance report: `.runtime/pre-commit-performance/20260702-133449-058c5a1f/report/report.md`.
- After-main-merge PR-scoped performance report: `.runtime/pre-commit-performance/20260702-135744-6b09eeb6/report/report.md`.
- Post-merge performance summary: `Status: ok`, 4 selected probes, 0 regressions, 0 context regressions, 0 verification failures.
- Review-fix performance summary: `Status: regression`, 4 selected probes, 1 direct regression, 0 context regressions, 0 verification failures. The only regression was in the dataset-source-records scandir probe: overall elapsed mean improved from `13.268ms` to `13.221ms`, overall elapsed p95 improved from `16.877ms` to `13.036ms`, file/source counts were unchanged, but elapsed min increased by `0.679ms` and record p95 increased by `3.953ms`. This review fix only changes limit parsing and partial-artifact cleanup receipt behavior, not source-record enumeration, so this is recorded as a non-blocking timing fluctuation rather than an in-scope performance regression.
- After-main-merge performance summary: `Status: regression`, 4 selected probes, 2 direct regressions, 0 context regressions, 0 verification failures. The remaining regressions are small timing-only fluctuations outside the ingest-limit read/cap path: dataset quality failed-partition min increased by `0.050ms` while failed-partition p95 improved by `0.078ms`, and dataset source records record p95 increased by `3.945ms` while overall elapsed mean/min/p95 improved and file/source counts stayed unchanged.
- Probe coverage: Dataset version listing `99.0%`, dataset quality output length chain `99.0%`, dataset source records scandir `95.0%`, Swift CLI JSON envelope coverage pass.
- Observability mode: `evidence` through ingest receipts and version payload metadata. Probe overhead is covered by the post-merge PR-scoped performance report; no debug or sampled instrumentation is deferred.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
