### PR TITLE
perf: bind tool schema required list copy

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -115,6 +115,22 @@ Expected effect:
 - leave registry selection, protobuf config serialization, and tool definitions
   unchanged.
 
+## Follow-up Slice: Required List Local Binding
+
+The 2026-07-02 follow-up keeps `ToolDescriptor.schema_payload()` behavior
+unchanged and still returns an isolated mutable required-argument list, but binds
+the cached required-argument list and the module-level `list.copy` helper to
+locals before constructing the payload. This completes the schema-payload helper
+binding pattern for both property dictionaries and required-argument lists.
+
+Expected effect:
+
+- reduce repeated required-list copy overhead measured by
+  `tool-registry-schema-bytes-cache` `schema_payload_elapsed_ms_mean`;
+- preserve copy-on-return isolation for returned `required` lists;
+- leave registry selection, schema serialization, protobuf config handling, and
+  tool definitions unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -167,12 +167,14 @@ class ToolDescriptor:
 
     def schema_payload(self) -> dict[str, Any]:
         schema_properties = self._cached_schema_properties
+        cached_required_arguments = self._cached_required_arguments_list
         copy_dict = _COPY_DICT
+        copy_list = _COPY_LIST
         return {
             "type": "object",
             "additionalProperties": False,
             "properties": {name: copy_dict(schema) for name, schema in schema_properties},
-            "required": _COPY_LIST(self._cached_required_arguments_list),
+            "required": copy_list(cached_required_arguments),
         }
 
     def json_schema(self) -> str:


### PR DESCRIPTION
## Summary
- Bind the cached required-argument list and `list.copy` helper to locals inside `ToolDescriptor.schema_payload()`.
- Preserve copy-on-return schema payload isolation while reducing repeated schema payload construction overhead.

## Plan or Spec
- Updated `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` with the 2026-07-02 required-list local binding slice.
- Registered probe: `tool-registry-schema-bytes-cache` in `infra/perf/pr_scoped_probes.json` covers the touched Python path and includes focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- Changed-scope coverage: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py`
- Candidate probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_METRICS_ITERATIONS=40000 MELIX_TOOL_REGISTRY_METRICS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_schema_bytes_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 97 passed.
- Changed-scope coverage: `TOTAL 2 0 100%` for touched measurable lines.
- Registered local Linux probe (`tool-registry-schema-bytes-cache`, 40,000 iterations x 5 samples):
  - baseline `schema_payload_elapsed_ms_mean=152.6671592378989`
  - candidate `schema_payload_elapsed_ms_mean=145.24171161465347`
  - delta `-7.425447623245418 ms` / `4.863814628052689%` faster
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- The metric is a small micro-optimization and may be noisy, so the registered CI probe must complete successfully before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed registered PR-scoped probe has focused test, coverage, and probe commands.
- [x] Updated governing plan under `docs/plans/`.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran registered probe locally before and after the slice.
- [ ] GitHub Actions PR-scoped performance completed successfully.
