### PR TITLE
perf: bind metrics snapshot mtime lookups

### DIFF
--- a/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
+++ b/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
@@ -67,3 +67,16 @@ and testing entries that cannot match any unresolved source.
 The behavior contract remains unchanged: argument and environment precedence are
 preserved, partially unresolved calls still perform one runtime scan, and missing
 runtime directories still return unresolved source paths without raising.
+
+## 2026-07-02 follow-up slice: bind latest mtime lookup
+
+This Python-only follow-up keeps the same registered
+`melix-metrics-snapshot-runtime-scandir` probe and narrows to the hot per-entry
+update path in `discover_latest_metrics_paths(...)`. The implementation binds the
+latest-mtime dictionary lookup once before the scan loop, matching the existing
+bound setter pattern and reducing repeated method resolution while preserving the
+single-scan runtime discovery behavior.
+
+The behavior contract remains unchanged: exact, prefix/suffix, empty-prefix, and
+multi-wildcard runtime pattern matches still select the newest regular file per
+source, and configured sources still bypass runtime scanning.

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -105,6 +105,7 @@ def discover_latest_metrics_paths(runtime_dir: Path | None, source_names: tuple[
         latest_paths: dict[str, str | None] = {name: None for name in source_names}
         latest_mtimes: dict[str, float | None] = {name: None for name in source_names}
         latest_paths_set = latest_paths.__setitem__
+        latest_mtimes_get = latest_mtimes.get
         latest_mtimes_set = latest_mtimes.__setitem__
         empty_prefix_matchers = prefix_matchers_by_initial.get("", ())
         with os.scandir(os.fspath(runtime_dir.expanduser())) as entries:
@@ -145,13 +146,13 @@ def discover_latest_metrics_paths(runtime_dir: Path | None, source_names: tuple[
                     continue
                 mtime = entry.stat().st_mtime
                 if matched_source_names is None:
-                    latest_mtime = latest_mtimes[matched_source_name]
+                    latest_mtime = latest_mtimes_get(matched_source_name)
                     if latest_mtime is None or mtime > latest_mtime:
                         latest_paths_set(matched_source_name, entry.path)
                         latest_mtimes_set(matched_source_name, mtime)
                     continue
                 for source_name in matched_source_names:
-                    latest_mtime = latest_mtimes[source_name]
+                    latest_mtime = latest_mtimes_get(source_name)
                     if latest_mtime is None or mtime > latest_mtime:
                         latest_paths_set(source_name, entry.path)
                         latest_mtimes_set(source_name, mtime)


### PR DESCRIPTION
## Summary
- Bind the metrics snapshot latest-mtime dictionary lookup once before the runtime scan loop.
- Keep the existing single-scan source discovery behavior and update the governing metrics snapshot plan with this follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md` with the 2026-07-02 latest-mtime lookup binding slice.
- Registered probe: `melix-metrics-snapshot-runtime-scandir` in `infra/perf/pr_scoped_probes.json` already covers `scripts/melix_metrics_snapshot.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_skips_runtime_scan_when_all_sources_are_configured tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/melix_metrics_snapshot.py scripts/melix_metrics_snapshot_discovery_probe.py tests/test_melix_metrics_snapshot.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id melix-metrics-snapshot-runtime-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-metrics-snapshot-mtime-get-bind-20260702 --head-repo "$PWD" --output /tmp/melix_metrics_snapshot_mtime_get_bind_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 11 passed.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local registered probe (`melix-metrics-snapshot-runtime-scandir`):
  - `elapsed_ms_mean`: base `12.052391` ms, head `10.303738` ms, delta `-1.748653` ms, speedup `1.17x`.
  - `elapsed_ms_min`: base `11.92183` ms, head `9.807847` ms, delta `-2.113983` ms.
  - `configured_elapsed_ms_mean`: base `0.026522` ms, head `0.02303` ms.
  - `configured_elapsed_ms_min`: base `0.013726` ms, head `0.013805` ms.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Linux-local verification only; this slice touches Python CLI/runtime discovery code and does not claim Swift/macOS runtime performance effects.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally against `origin/main` and this branch.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
