### PR TITLE
perf: fast path dataset completion length lookups

### DIFF
--- a/docs/plans/2026-07-02-dataset-quality-completion-lookup-fastpath.md
+++ b/docs/plans/2026-07-02-dataset-quality-completion-lookup-fastpath.md
@@ -1,0 +1,44 @@
+# Dataset Quality Completion Lookup Fast Path
+
+## Scope
+
+This performance slice targets the registered Python path covered by the
+`dataset-quality-lengths-chain` PR-scoped probe in
+`infra/perf/pr_scoped_probes.json`.
+
+Affected code:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Current Behavior
+
+Dataset quality scoring derives output-length statistics for generated sample
+rows. Most training rows in the registered probe use a top-level `completion`
+field. The existing loop checks membership and then performs a second dictionary
+lookup for `completion` before falling back to message aggregation.
+
+## Proposed Slice
+
+Use a single guarded `row["completion"]` lookup for the completion fast path and
+fall back to the existing message semantics only on `KeyError`. For already-string
+completion/message content values, use direct `len()` and only call `str()` for
+non-string compatibility cases. This keeps the same behavior for completions,
+message rows, malformed message containers, and non-mapping message items while
+reducing dictionary and coercion work on the dominant completion-row path.
+
+## Probe and Validation
+
+The affected path is already registered as `dataset-quality-lengths-chain` with
+focused `test_command`, `coverage_command`, and `probe_command` entries. This
+slice will run:
+
+1. The registered focused test command.
+2. The registered changed-scope coverage command.
+3. The registered local probe on Linux before and after the change.
+
+## Acceptance
+
+Accept only if focused tests and coverage pass and the registered probe shows a
+clear elapsed-time improvement without semantic drift.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -129,9 +129,9 @@ def test_dataset_version_writes_schema_backed_package_and_quality_summary(
     assert quality["dedup_ratio"] == 0
     assert quality["metrics"]["quality_scoring_latency_ms"] >= 0
     assert _sample_output_lengths(
-        [{"messages": "not-a-list"}],
-        [{"messages": [{"content": "hello"}, "skip-me"]}],
-    ) == [0, 5]
+        [{"completion": 12345}, {"messages": "not-a-list"}],
+        [{"messages": [{"content": "hello"}, {"content": 678}, "skip-me"]}],
+    ) == [5, 0, 8]
 
 
 def test_dataset_version_failed_segment_partition_fast_paths_empty_failures() -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1462,23 +1462,32 @@ def _append_rows_output_lengths(
     rows: list[dict[str, Any]],
 ) -> None:
     append = lengths.append
+    len_ = len
     str_ = str
     for row in rows:
-        if "completion" in row:
-            append(len(str_(row["completion"])))
-            continue
-        messages = row.get("messages", [])
-        if not isinstance(messages, list):
-            append(0)
-            continue
-        total = 0
-        for item in messages:
-            try:
-                content = item.get("content", "")
-            except AttributeError:
+        try:
+            completion = row["completion"]
+        except KeyError:
+            messages = row.get("messages", [])
+            if not isinstance(messages, list):
+                append(0)
                 continue
-            total += len(str_(content))
-        append(total)
+            total = 0
+            for item in messages:
+                try:
+                    content = item.get("content", "")
+                except AttributeError:
+                    continue
+                if type(content) is str:
+                    total += len_(content)
+                else:
+                    total += len_(str_(content))
+            append(total)
+        else:
+            if type(completion) is str:
+                append(len_(completion))
+            else:
+                append(len_(str_(completion)))
 
 
 def _p95(values: list[int]) -> int:


### PR DESCRIPTION
## Summary
- Optimizes dataset quality output-length scanning by using one guarded `completion` lookup for completion rows before falling back to message aggregation.
- Keeps message-row, malformed-message, and empty-input semantics unchanged.

## Plan or Spec
- Added `docs/plans/2026-07-02-dataset-quality-completion-lookup-fastpath.md`.
- Affected path is covered by the registered `dataset-quality-lengths-chain` PR-scoped performance probe with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_writes_schema_backed_package_and_quality_summary services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_fast_paths_empty_failures services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_preserves_failed_id_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_failed_segment_partition_scans_nonempty_failures_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py` (baseline and post-change)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 8 passed.
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Registered local probe baseline: `elapsed_ms_mean=3.368176`, `elapsed_ms_min=2.375336`, `elapsed_ms_p95=3.686045`; failed partition mean `1.316705`.
- Registered local probe post-change: `elapsed_ms_mean=2.555547`, `elapsed_ms_min=2.408408`, `elapsed_ms_p95=2.680138`; failed partition mean `1.398494`.
- Primary quality-length mean delta: `-0.812629 ms` (~24.13% faster). CI PR-scoped performance report remains the source of registered probe validation for merge.

## Known Gaps
- Linux local validation only for this Python slice; no Swift runtime behavior changed.
- Failed-partition metric is emitted by the shared probe but is not the optimized path for this slice.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement on the optimized metric.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
