### PR TITLE
perf: elide benchmark queue stat int coercions

### DIFF
--- a/docs/plans/2026-07-02-benchmark-queue-stat-metadata-key.md
+++ b/docs/plans/2026-07-02-benchmark-queue-stat-metadata-key.md
@@ -1,0 +1,28 @@
+# Benchmark Queue Stat Metadata Key Fast Path
+
+This Python-only performance slice is limited to `BenchmarkQueueStore._metadata_key_from_stat()` in `services/mlx-worker-python/worker/productization/benchmark_queue.py`.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_benchmark_queue.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Slice
+
+`os.stat_result` exposes integer metadata fields for `st_mtime_ns`, `st_size`, `st_ino`, and `st_dev`. The queue scanner already obtains one `DirEntry.stat()` result per candidate JSON record and passes it into `_metadata_key_from_stat()`. This slice removes redundant `int(...)` coercions from that hot metadata-key path while preserving the same tuple shape and cache-invalidation semantics.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and the registered benchmark queue probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.
+
+Expected local commands:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_benchmark_queue_cache as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
+```

--- a/services/mlx-worker-python/tests/test_benchmark_queue.py
+++ b/services/mlx-worker-python/tests/test_benchmark_queue.py
@@ -51,6 +51,19 @@ def test_benchmark_queue_record_uses_slots_without_instance_dict() -> None:
     assert hasattr(record, "__dict__") is False
 
 
+def test_metadata_key_from_stat_reuses_integer_fields(tmp_path: Path) -> None:
+    record_path = tmp_path / "queue-item.json"
+    record_path.write_text("{}", encoding="utf-8")
+    stat_result = record_path.stat()
+
+    assert BenchmarkQueueStore._metadata_key_from_stat(stat_result) == (
+        stat_result.st_mtime_ns,
+        stat_result.st_size,
+        stat_result.st_ino,
+        stat_result.st_dev,
+    )
+
+
 def test_benchmark_queue_record_from_dict_preserves_string_fast_path_and_coerces_fallback() -> None:
     record = BenchmarkQueueRecord.from_dict(
         {

--- a/services/mlx-worker-python/worker/productization/benchmark_queue.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_queue.py
@@ -227,8 +227,8 @@ class BenchmarkQueueStore:
     @staticmethod
     def _metadata_key_from_stat(stat_result: os.stat_result) -> tuple[int, int, int, int]:
         return (
-            int(stat_result.st_mtime_ns),
-            int(stat_result.st_size),
-            int(stat_result.st_ino),
-            int(stat_result.st_dev),
+            stat_result.st_mtime_ns,
+            stat_result.st_size,
+            stat_result.st_ino,
+            stat_result.st_dev,
         )


### PR DESCRIPTION
## Summary
- Remove redundant `int(...)` coercions from `BenchmarkQueueStore._metadata_key_from_stat()` on the benchmark queue record scan/cache path.
- Add a focused regression guard that the metadata key preserves the `os.stat_result` integer fields directly.
- Document the one-slice Python performance plan for the registered benchmark queue probe.

## Plan or Spec
- `docs/plans/2026-07-02-benchmark-queue-stat-metadata-key.md`
- Registered probe: `benchmark-queue-decoded-record-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count
# 29 passed in 14.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_benchmark_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_benchmark_queue_cache_rejects_unexpected_record_count && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_queue.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_benchmark_queue.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 29 passed in 48.93s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-queue-decoded-record-cache --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-benchmark-queue-stat-metadata-key-20260702 --head-repo "$PWD" --output /tmp/benchmark_queue_stat_metadata_probe.json
# head verification ok; base probe ok; head probe ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe `benchmark-queue-decoded-record-cache`:
  - `cold_elapsed_ms`: base `6.863282`, head `3.325753`, delta `-3.537529 ms`, improvement `51.543%`.
  - `warm_elapsed_ms_mean`: base `1.053058`, head `0.61368`, delta `-0.439378 ms`, improvement `41.724%`.
  - `cold_json_loads`: base/head `128.0`.
  - `warm_json_loads_mean`: base/head `0.0`.
- CI PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only for this slice; no Swift runtime effect is claimed.
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR relies on the focused registered commands plus GitHub Actions for broader coverage.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
