### PR TITLE
perf: check supported dataset preview files first

### DIFF
--- a/docs/plans/2026-07-03-dataset-preview-supported-file-stat-order-performance.md
+++ b/docs/plans/2026-07-03-dataset-preview-supported-file-stat-order-performance.md
@@ -1,0 +1,40 @@
+# Dataset Preview Supported-File Stat Order Performance Slice
+
+## Scope
+
+Optimize the dataset registry preview scanner used by
+`read_hf_dataset_snapshot_rows(..., limit=N)` when it gathers the first few
+supported dataset files from a snapshot directory.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-registry-preview-limit-short-circuit` in
+`infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- focused tests for dataset preview limiting and scan edge cases,
+- changed-scope coverage for `worker/dataset_registry/catalog.py`, and
+- `scripts/dataset_registry_preview_limit_probe.py` for local and CI metrics.
+
+## Slice
+
+For supported dataset filenames discovered during limited preview scans, check
+`DirEntry.is_file(follow_symlinks=False)` before falling back to the directory
+check. This avoids the prior directory-type check on the common path where the
+entry is already a supported regular dataset file, while still preserving the
+existing directory recursion behavior and OSError handling for unsupported names
+and nested directories.
+
+## Success Metrics
+
+Use the registered probe metrics:
+
+- `elapsed_ms_mean` lower is better,
+- `multi_limit_elapsed_ms_mean` lower is better,
+- `peak_bytes_mean` informational for this slice.
+
+The change is accepted only if focused tests pass and the registered probe shows
+an improved or neutral elapsed-time direction in the local Linux run and in the
+PR-scoped CI report.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -546,6 +546,13 @@ def _supported_scan_entry_records(
         name = entry.name
         if name <= after:
             continue
+        if name not in _README_NAMES and _is_supported_dataset_file_name(name):
+            try:
+                if entry.is_file(follow_symlinks=False):
+                    yield name, entry.path, False, True
+                    continue
+            except OSError:
+                pass
         try:
             is_dir = entry.is_dir(follow_symlinks=False)
             if is_dir:
@@ -555,12 +562,6 @@ def _supported_scan_entry_records(
             continue
         if name in _README_NAMES or not _is_supported_dataset_file_name(name):
             continue
-        try:
-            is_file = entry.is_file(follow_symlinks=False)
-        except OSError:
-            continue
-        if is_file:
-            yield name, entry.path, False, True
 
 
 def _first_supported_dataset_file(directory: Path) -> Path | None:


### PR DESCRIPTION
## Summary
- Optimize limited dataset preview scans by checking supported dataset filenames with `DirEntry.is_file(follow_symlinks=False)` before the directory fallback.
- Preserve depth-first directory recursion and OSError handling for unsupported entries while avoiding the prior directory-type check on the common supported-file path.

## Plan or Spec
- `docs/plans/2026-07-03-dataset-preview-supported-file-stat-order-performance.md`
- Registered PR-scoped probe: `dataset-registry-preview-limit-short-circuit`

## Commands Run
```text
# Baseline probe from origin/main (3 runs, temporary detached worktree)
PYTHONPATH="$dir:$dir/services/mlx-worker-python" uv run --project "$dir/services/mlx-worker-python" python3 "$dir/scripts/dataset_registry_preview_limit_probe.py"
old elapsed_ms_mean: 97.102352, 98.306270, 95.888590
old multi_limit_elapsed_ms_mean: 140.851201, 144.575412, 142.977165

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_preview_scan_streams_multiple_files_without_sorted_walk services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_first_preview_file_preserves_sorted_depth_first_edges
3 passed in 0.09s

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...dataset-registry-preview-limit-short-circuit registered test set...
28 passed in 0.17s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...focused scan tests...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py
TOTAL 7 0 100%

# Registered probe, local Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
new elapsed_ms_mean: 97.508884
new multi_limit_elapsed_ms_mean: 141.717808

# Diff hygiene
git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `services/mlx-worker-python/worker/dataset_registry/catalog.py`.
- Local registered probe comparison:
  - old `elapsed_ms_mean` mean across 3 probe runs: `(97.102352 + 98.306270 + 95.888590) / 3 = 97.765737 ms`
  - new `elapsed_ms_mean`: `97.508884 ms` (`-0.256853 ms`, about `0.26%` faster)
  - old `multi_limit_elapsed_ms_mean` mean across 3 probe runs: `(140.851201 + 144.575412 + 142.977165) / 3 = 142.801259 ms`
  - new `multi_limit_elapsed_ms_mean`: `141.717808 ms` (`-1.083451 ms`, about `0.76%` faster)
- CI PR-scoped registered probe validation is required before merge.

## Known Gaps
- Linux local probes validate the Python path only. CI is still required for the repository's registered PR-scoped performance report and full GitHub checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
