### PR TITLE
perf: bind hub catalog size hint regex search

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md
+++ b/docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md
@@ -33,3 +33,12 @@ The probe repeatedly calls `_size_hint_from_text(...)` across direct card-data h
 - Changed executable line coverage is at least 95% for the touched Python scope.
 - Local base-vs-head probe shows lower `elapsed_ms_mean` with identical structural guard rails.
 - `git diff --check` passes.
+
+## 2026-07-03 Bound Search Slice
+
+This follow-up slice keeps the regex precompile behavior and additionally binds
+precompiled `Pattern.search` methods at module import time. The hot parser now
+selects the already-bound search callable for bare vs explicit size-hint modes,
+avoiding a repeated `Pattern.search` attribute lookup inside
+`_size_hint_from_text(...)` while preserving the accepted regex grammar and
+fallback behavior.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -28,6 +28,8 @@ _SIZE_HINT_MULTIPLIERS = {
 
 _BARE_SIZE_HINT_RE = re.compile(r"(?:model\s+size\s*[:|]?\s*)?(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
 _EXPLICIT_SIZE_HINT_RE = re.compile(r"\bmodel\s+size\s*[:|]?\s*(\d+(?:\.\d+)?)\s*(kb|mb|gb)\b", re.IGNORECASE)
+_BARE_SIZE_HINT_SEARCH = _BARE_SIZE_HINT_RE.search
+_EXPLICIT_SIZE_HINT_SEARCH = _EXPLICIT_SIZE_HINT_RE.search
 _NEXT_LINK_REL_MARKER = 'rel="next"'
 _CURSOR_QUERY_KEY = "cursor="
 _CURSOR_QUERY_KEY_LEN = len(_CURSOR_QUERY_KEY)
@@ -984,8 +986,8 @@ def _starts_with_model_size_label(text: str) -> bool:
 def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
     if not text:
         return 0
-    pattern = _BARE_SIZE_HINT_RE if allow_bare else _EXPLICIT_SIZE_HINT_RE
-    match = pattern.search(text)
+    search_size_hint = _BARE_SIZE_HINT_SEARCH if allow_bare else _EXPLICIT_SIZE_HINT_SEARCH
+    match = search_size_hint(text)
     if not match:
         return 0
     value_text = match.group(1)


### PR DESCRIPTION
## Summary
- Bind the precompiled Hub catalog size-hint regex `search` methods at module import time.
- Use the already-bound callable inside `_size_hint_from_text(...)` to avoid repeated `Pattern.search` attribute lookup in the hot parser.
- Update the governing size-hint performance plan with this follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-05-06-hub-catalog-size-hint-regex-precompile.md` with the 2026-07-03 bound-search slice.
- Registered PR-scoped probe already covers the affected path: `hub-catalog-size-hint-regex-precompile` with focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-catalog-size-hint-bound-search-20260703 --output /tmp/hub_size_hint_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused pytest: 90 passed.
- Changed-scope coverage: 100.00% (`TOTAL 4 0 100%`).
- Local registered probe (`hub-catalog-size-hint-regex-precompile`):
  - `elapsed_ms_mean`: base 1795.572 ms → head 1740.442 ms (delta -55.131 ms, ~3.07% faster).
  - `payload_compatibility_elapsed_ms_mean`: base 204.907 ms → head 194.393 ms (delta -10.514 ms, ~5.13% faster).
  - Guard rails unchanged: `checksum=1545732096.0`, `matched_hint_count=120000.0`, `payload_compatibility_matched_count=160000.0`, `size_hint_calls_mean=0.0`.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Known Gaps
- This is a Python-only Linux-verified micro-optimization; no Swift runtime effect is claimed.
- Local probe results can vary by host load, so the registered CI probe report is the final validation source.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally against base and head.
- [x] `git diff --check` passed.
- [ ] GitHub Actions and PR-scoped performance completed successfully.
