### PR TITLE
perf: fast-path dataset version listing fields

### DIFF
--- a/docs/plans/2026-06-22-dataset-version-open-skip-stat.md
+++ b/docs/plans/2026-06-22-dataset-version-open-skip-stat.md
@@ -20,6 +20,20 @@ This slice moves missing/non-file manifest handling to the direct `open(..., "rb
 4. Run changed-scope coverage for the registered probe and require at least 95% on the touched scope.
 5. Run the registered probe locally on Linux against `origin/main` versus the slice branch before creating the PR.
 
+## 2026-07-03 follow-up slice: complete-manifest direct field extraction
+
+This follow-up keeps the same registered `dataset-version-listing-scandir` probe
+and remains limited to `list_dataset_versions(...)`. Complete generated
+`dataset-version.json` manifests are the common path during listing, so the loop
+now extracts the listing fields by direct dictionary lookup and falls back to the
+existing default-preserving `dict.get(...)` path only for incomplete legacy or
+hand-written manifests. Behavior for missing manifest files, directory-valued
+manifest candidates, and malformed JSON is unchanged.
+
+Verification remains the registered focused test command, changed-scope coverage,
+and the local Linux registered probe before PR creation. The CI PR-scoped
+performance report remains the merge gate for the registered probe.
+
 ## Boundary
 
 This is a Linux-verified Python slice. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -397,6 +397,8 @@ def test_dataset_version_listing_skips_missing_or_directory_manifests(tmp_path: 
     )
 
     assert [item["version_id"] for item in listing["versions"]] == ["support-chat-v1"]
+    assert listing["versions"][0]["train_count"] == 0
+    assert listing["versions"][0]["quality_summary_path"] == ""
     assert listing["metrics"]["dataset_version_count"] == 1
 
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -793,20 +793,35 @@ def list_dataset_versions(
                 version = json_loads(handle.read())
         except (FileNotFoundError, IsADirectoryError, NotADirectoryError):
             continue
-        version_get = version.get
-        versions_append(
-            {
-                "dataset_id": version_get("dataset_id", ""),
-                "version_id": version_get("version_id", ""),
-                "created_at": version_get("created_at", ""),
-                "status": version_get("status", ""),
-                "train_count": version_get("train_count", 0),
-                "validation_count": version_get("validation_count", 0),
-                "failed_count": version_get("failed_count", 0),
-                "quality_summary_path": version_get("quality_summary_path", ""),
-                "dataset_version_path": manifest_path,
-            }
-        )
+        try:
+            versions_append(
+                {
+                    "dataset_id": version["dataset_id"],
+                    "version_id": version["version_id"],
+                    "created_at": version["created_at"],
+                    "status": version["status"],
+                    "train_count": version["train_count"],
+                    "validation_count": version["validation_count"],
+                    "failed_count": version["failed_count"],
+                    "quality_summary_path": version["quality_summary_path"],
+                    "dataset_version_path": manifest_path,
+                }
+            )
+        except KeyError:
+            version_get = version.get
+            versions_append(
+                {
+                    "dataset_id": version_get("dataset_id", ""),
+                    "version_id": version_get("version_id", ""),
+                    "created_at": version_get("created_at", ""),
+                    "status": version_get("status", ""),
+                    "train_count": version_get("train_count", 0),
+                    "validation_count": version_get("validation_count", 0),
+                    "failed_count": version_get("failed_count", 0),
+                    "quality_summary_path": version_get("quality_summary_path", ""),
+                    "dataset_version_path": manifest_path,
+                }
+            )
     versions.sort(key=_dataset_version_list_sort_key)
     return {
         "schema_version": DATASET_VERSION_LIST_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary
- Fast-path complete `dataset-version.json` manifests in `list_dataset_versions(...)` with direct dictionary field extraction.
- Preserve the existing default-returning fallback for incomplete legacy or hand-written manifests.
- Extend regression coverage for incomplete manifest defaults and document the follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-22-dataset-version-open-skip-stat.md` (2026-07-03 follow-up slice: complete-manifest direct field extraction)
- Registered probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_skips_missing_or_directory_manifests services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 8 passed in 1.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_is_deterministic_and_reports_latency services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_skips_missing_or_directory_manifests services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# TOTAL 7 0 100%

for repo in /root/.hermes/profiles/coder/workspace/melix /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-version-list-getitem-20260703; do ... MELIX_DATASET_VERSION_LISTING_PROBE_COUNT=5000 MELIX_DATASET_VERSION_LISTING_PROBE_SAMPLES=9 ... scripts/dataset_version_listing_probe.py; done
# origin/main mean over 5 runs: 77.463909 ms
# branch mean over 5 runs: 73.195789 ms
# delta: -4.268120 ms (-5.51%)

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered local probe (`dataset-version-listing-scandir`, 5000 versions, 9 samples/run, 5 runs):
  - `origin/main`: `elapsed_ms_mean=77.463909`
  - branch: `elapsed_ms_mean=73.195789`
  - delta: `-4.268120 ms` (`-5.51%`, lower is better)
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- Linux-local Python validation only; no Swift runtime effect is claimed.
- Local probe results are noisy because they create and read filesystem fixtures, so the registered CI probe remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
