### PR TITLE
perf: speed event actor cache key materialization

### DIFF
--- a/docs/plans/2026-07-03-event-actor-field-cache-key-tuple.md
+++ b/docs/plans/2026-07-03-event-actor-field-cache-key-tuple.md
@@ -1,0 +1,37 @@
+# Event Actor Field Cache Key Tuple Copy Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.event_extraction._event_field_cache_key()`, which runs on
+semantic actor-field extraction before the cached group-actor alias expansion.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe
+`event-extraction-group-actor-alias-cache` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_actor_alias_probe.py`
+
+## Implementation plan
+
+1. Preserve validation semantics for actor field values: `None` maps to an empty
+   cache key, non-list values fail, and non-string list items fail.
+2. After validation, materialize the cache key with `tuple(value)` instead of a
+   Python-level append loop. This keeps the same immutable cache key while moving
+   the copy to CPython's tuple constructor.
+3. Run the registered focused tests, changed-scope coverage, and the registered
+   probe locally on Linux.
+4. Use GitHub Actions PR-scoped performance as the merge gate after opening the
+   PR.
+
+## Metrics
+
+The registered probe reports `elapsed_ms_mean`, `normalize_calls_mean`, and
+`peak_bytes_mean`. Local Linux probe output is recorded in the PR; GitHub Actions
+remains the authoritative registered probe report before merge.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -1786,13 +1786,10 @@ def _event_field_cache_key(value: object) -> tuple[str, ...]:
         return ()
     if not isinstance(value, list):
         raise ValueError("event field values must be null or a list of strings")
-    values: list[str] = []
-    values_append = values.append
     for item in value:
         if not isinstance(item, str):
             raise ValueError("event field values must be null or a list of strings")
-        values_append(item)
-    return tuple(values)
+    return tuple(value)
 
 
 @lru_cache(maxsize=1024)


### PR DESCRIPTION
## Summary
- Speeds event-extraction actor field cache-key materialization by validating the list and then using `tuple(value)` instead of a Python append loop.
- Keeps semantic actor alias behavior and validation errors unchanged.

## Plan or Spec
- Added `docs/plans/2026-07-03-event-actor-field-cache-key-tuple.md` for this Python-only performance slice.
- Registered probe: `event-extraction-group-actor-alias-cache` in `infra/perf/pr_scoped_probes.json` covers the changed path and includes focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_reuses_cached_group_actor_aliases services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_caches_repeated_group_actor_expansion services/mlx-worker-python/tests/test_event_extraction.py::test_semantic_field_values_normalizes_and_deduplicates_in_one_pass services/mlx-worker-python/tests/test_event_extraction.py::test_evaluate_event_extraction_semantic_expands_group_actor_aliases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_actor_alias_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_actor_alias_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_actor_alias_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-group-actor-alias-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/event_actor_alias_probe_compare.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `7 passed in 1.78s`.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Direct local probe: `elapsed_ms_mean=1.907055638730526`, `normalize_calls_mean=0.6`, `peak_bytes_mean=3994.0`.
- Local registered base-vs-head probe:
  - base `elapsed_ms_mean=3.460497595369816`, `peak_bytes_mean=5362.0`
  - head `elapsed_ms_mean=2.774614794179797`, `peak_bytes_mean=3994.0`
  - delta `-0.685882801190019 ms` (`19.82%` faster)
- GitHub Actions PR-scoped performance report is required as the final registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed.
- Probe measurements are synthetic and should be confirmed by the PR-scoped performance workflow on GitHub Actions.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met 100% for changed measurable lines.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions checks completed.
- [ ] PR-scoped performance report completed successfully.
