### PR TITLE
perf: bind export diagnosis matcher locals

### DIFF
--- a/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
+++ b/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
@@ -108,3 +108,35 @@ Local 2026-06-29 probe decision for this diagnosis-marker dispatch slice:
 - Post-change `peak_bytes_mean`: `204847.0`, `203285.2`, `203169.0` bytes; mean `203767.06666666665` bytes (`+819.5333333333256` bytes, within the registered 5% warning boundary).
 
 Decision: accepted because the targeted registered diagnosis-matching submetric improved over three local Linux probe runs, path redaction also improved, and the end-to-end elapsed/peak-memory movement stayed within the registered 5% warning boundary. `diagnostic_latency_ms` was noisy (`+0.5255787012477704` ms mean, `+5.96%`) and remains a CI-observed risk for this PR-scoped probe.
+
+## 2026-07-03 follow-up: diagnosis local bindings
+
+This Python-only follow-up stays inside the same
+`runtime-export-diagnostic-parser` registered probe and narrows to
+`_diagnoses_from_excerpt(...)`. The diagnosis matcher now binds the immutable
+pattern tuple, marker helper, result append, and seen-code insertion once per
+call, and reuses the matched `code` value when building the diagnosis payload.
+This preserves the existing matching order, first-match-per-line behavior, and
+all known-code early-stop semantics while reducing repeated global/method lookup
+work in the diagnosis matching loop.
+
+Validation remains the registered focused pytest selection, changed-scope
+coverage, and the registered local/CI probe for runtime export diagnostic
+parsing.
+
+Local 2026-07-03 probe decision for this diagnosis local-bindings slice:
+
+- Baseline `elapsed_ms_mean`: `2685.6642472324893`, `2612.476917402819`, `2616.904921992682` ms; mean `2638.3486955426635` ms.
+- Post-change `elapsed_ms_mean`: `2621.045644627884`, `2658.575273421593`, `2688.9616494067013` ms; mean `2656.1941891520596` ms (`+17.84549360939618` ms, within the registered 5% warning boundary).
+- Baseline `diagnosis_matching_elapsed_ms_mean`: `0.656659621745348`, `0.5976887652650476`, `0.6268176017329097` ms; mean `0.6270553295811018` ms.
+- Post-change `diagnosis_matching_elapsed_ms_mean`: `0.614061183296144`, `0.6148329935967922`, `0.6404992192983627` ms; mean `0.6231311320637663` ms (`-0.003924197517335516` ms, `1.0063x` faster).
+- Baseline `diagnostic_latency_ms`: `8.66139295976609`, `8.858373737893999`, `8.562006056308746` ms; mean `8.693924251322945` ms.
+- Post-change `diagnostic_latency_ms`: `8.328807074576616`, `8.544051903299987`, `9.234769968315959` ms; mean `8.702542982064188` ms (`+0.008618730741243085` ms, within the registered 5% warning boundary).
+- Baseline `peak_bytes_mean`: `203311.2`, `204043.2`, `202703.0` bytes; mean `203352.46666666667` bytes.
+- Post-change `peak_bytes_mean`: `204749.8`, `204262.8`, `204080.4` bytes; mean `204364.33333333334` bytes (`+1011.8666666666686` bytes, within the registered 5% warning boundary).
+
+Decision: accepted because the targeted diagnosis-matching submetric improved
+across the local Linux probe triplet while parser coverage stayed at 1.0, and
+the end-to-end elapsed, diagnostic latency, and peak-memory movement stayed
+inside the registered warning boundary. CI remains the registered PR-scoped
+probe gate for the final repository signal.

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -794,22 +794,27 @@ def _diagnoses_from_excerpt(
     diagnoses: list[dict[str, object]] = []
     seen_codes: set[str] = set()
     known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
+    diagnosis_patterns = _DIAGNOSIS_PATTERNS
+    has_diagnosis_marker = _has_diagnosis_marker
+    append_diagnosis = diagnoses.append
+    add_seen_code = seen_codes.add
     for index, line_number in line_numbers.items():
         if len(seen_codes) == known_code_count:
             break
         text = source_lines[index].text
         lowered_text = text.lower()
-        if not _has_diagnosis_marker(lowered_text):
+        if not has_diagnosis_marker(lowered_text):
             continue
-        for pattern in _DIAGNOSIS_PATTERNS:
-            if pattern.code in seen_codes:
+        for pattern in diagnosis_patterns:
+            code = pattern.code
+            if code in seen_codes:
                 continue
             if not pattern.matches(text, lowered_text):
                 continue
-            seen_codes.add(pattern.code)
-            diagnoses.append(
+            add_seen_code(code)
+            append_diagnosis(
                 {
-                    "code": pattern.code,
+                    "code": code,
                     "severity": pattern.severity,
                     "matched_pattern_id": pattern.pattern_id,
                     "operator_message": pattern.operator_message,


### PR DESCRIPTION
## Summary
- Bind runtime export diagnosis matcher hot-loop locals in `_diagnoses_from_excerpt(...)`.
- Reuse the matched diagnosis `code` value when building receipt payloads.
- Record the local Linux probe decision in the export diagnostics performance plan.

## Plan or Spec
- Updated `docs/plans/2026-06-28-export-diagnostics-source-line-extension.md` with the 2026-07-03 diagnosis local-bindings slice, local baseline/post metrics, and CI validation boundary.
- Affected path is covered by registered PR-scoped probe `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_diagnosis_marker_fast_path_matches_registered_markers services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_stops_after_all_known_codes_match services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics`
- Baseline probe x3: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- Post-change probe x3: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- Registered focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- Registered coverage command equivalent: `coverage run ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...`
- Registered probe command equivalent: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 12 passed.
- Registered focused tests: 77 passed.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Baseline `diagnosis_matching_elapsed_ms_mean`: mean `0.6270553295811018` ms.
- Post-change `diagnosis_matching_elapsed_ms_mean`: mean `0.6231311320637663` ms (`-0.003924197517335516` ms, `1.0063x` faster).
- Baseline `elapsed_ms_mean`: mean `2638.3486955426635` ms.
- Post-change `elapsed_ms_mean`: mean `2656.1941891520596` ms (`+17.84549360939618` ms, within registered warning boundary).
- Final local registered-probe spot check: parser coverage `1.0`, `elapsed_ms_mean=2612.414795975201`, `diagnosis_matching_elapsed_ms_mean=0.6412718212231994`.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- The registered PR-scoped performance workflow on GitHub Actions remains the final CI validation gate.

## Evidence Checklist
- [x] Synced from `origin/main` before branch work.
- [x] Confirmed registered PR-scoped probe covers the affected path.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran registered probe locally.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
