### PR TITLE
perf: inline export diagnostic pattern scan

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -185,6 +185,15 @@ prefix in the loop. This avoids repeated `len()` calls on the growing output
 list, repeated append attribute lookups, and repeated prefix formatting for
 adjacent bounded log lines from the same source path.
 
+A follow-up 2026-07-03 diagnosis loop binding slice keeps matched codes,
+pattern priority, and evidence pointers unchanged while binding hot loop helpers
+and pattern/source containers once per excerpt scan. The matcher still lowers
+each considered line once, applies the same union-marker prefilter, suppresses
+duplicate codes, and stops after every known diagnosis code has matched. It also
+inlines the per-pattern marker/expression loops inside the excerpt scan so the
+hot path avoids repeated global, method, and helper lookups in the registered
+diagnostic parser probe.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -792,24 +792,42 @@ def _diagnoses_from_excerpt(
     excerpt_path: str,
 ) -> list[dict[str, object]]:
     diagnoses: list[dict[str, object]] = []
+    diagnoses_append = diagnoses.append
     seen_codes: set[str] = set()
+    seen_codes_add = seen_codes.add
+    patterns = _DIAGNOSIS_PATTERNS
+    source_lines_local = source_lines
+    has_diagnosis_marker = _has_diagnosis_marker
     known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
     for index, line_number in line_numbers.items():
         if len(seen_codes) == known_code_count:
             break
-        text = source_lines[index].text
+        text = source_lines_local[index].text
         lowered_text = text.lower()
-        if not _has_diagnosis_marker(lowered_text):
+        if not has_diagnosis_marker(lowered_text):
             continue
-        for pattern in _DIAGNOSIS_PATTERNS:
-            if pattern.code in seen_codes:
+        for pattern in patterns:
+            pattern_code = pattern.code
+            if pattern_code in seen_codes:
                 continue
-            if not pattern.matches(text, lowered_text):
+            marker_matched = not pattern.markers
+            for marker in pattern.markers:
+                if marker in lowered_text:
+                    marker_matched = True
+                    break
+            if not marker_matched:
                 continue
-            seen_codes.add(pattern.code)
-            diagnoses.append(
+            expression_matched = False
+            for expression in pattern.expressions:
+                if expression.search(text):
+                    expression_matched = True
+                    break
+            if not expression_matched:
+                continue
+            seen_codes_add(pattern_code)
+            diagnoses_append(
                 {
-                    "code": pattern.code,
+                    "code": pattern_code,
                     "severity": pattern.severity,
                     "matched_pattern_id": pattern.pattern_id,
                     "operator_message": pattern.operator_message,


### PR DESCRIPTION
## Summary
- Inline the runtime export diagnostic parser's per-pattern marker/expression scan inside the excerpt loop.
- Bind hot-loop helpers and containers once per scan while preserving diagnosis priority, duplicate-code suppression, and evidence pointers.
- Update the governing diagnostic parser plan with this 2026-07-03 performance slice.

## Plan or Spec
- docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
-> {"elapsed_ms_mean": 2665.232966793701, "diagnosis_matching_elapsed_ms_mean": 0.5808731773868203, "diagnostic_latency_ms": 8.695695898495615, "peak_bytes_mean": 202560.8, "diagnostic_parser_coverage": 1.0, ...}

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
-> 77 passed in 0.59s

# Changed-scope coverage
git diff --check
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
-> 77 passed in 1.38s; TOTAL 25 0 100%

# Registered probe on head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
-> {"elapsed_ms_mean": 2650.325739989057, "diagnosis_matching_elapsed_ms_mean": 0.5884794052690268, "diagnostic_latency_ms": 8.687052875757217, "peak_bytes_mean": 201599.8, "diagnostic_parser_coverage": 1.0, ...}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 25 0 100%`.
- Local Linux registered probe comparison:
  - `elapsed_ms_mean`: 2665.232966793701 -> 2650.325739989057 ms (delta -14.90722680464387 ms, ~0.56% faster).
  - `diagnostic_latency_ms`: 8.695695898495615 -> 8.687052875757217 ms (delta -0.008643022738397853 ms).
  - `peak_bytes_mean`: 202560.8 -> 201599.8 bytes (delta -961.0 bytes).
  - `diagnostic_parser_coverage`: 1.0 -> 1.0.
- CI PR-scoped performance workflow must run `runtime-export-diagnostic-parser` and is the merge gate.
- Observability mode: evidence (`runtime-export-diagnostic-parser` PR-scoped probe); probe overhead: N/A, this changes parser hot-loop implementation and not production observability collection.

## Known Gaps
- Local measurement noise is visible in sub-millisecond diagnosis matching timings; CI registered probe report is required before merge.
- No Swift runtime validation is involved in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
