### PR TITLE
perf: bind model load executable scan helper

### DIFF
--- a/docs/plans/2026-07-03-model-load-executable-scan-local-bind-performance.md
+++ b/docs/plans/2026-07-03-model-load-executable-scan-local-bind-performance.md
@@ -1,0 +1,37 @@
+# Model Load Executable Scan Local Binding Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.model_load_trust._detect_executable_model_files()`, the fallback scan
+that detects executable Python model files when `config.json` does not already
+prove a custom loader via `auto_map`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`. The entry
+watches `services/mlx-worker-python/worker/model_load_trust.py`, the focused
+model-load trust tests, `scripts/model_load_config_json_bytes_probe.py`, and the
+probe registry itself. It includes focused `test_command`, `coverage_command`,
+and `probe_command` entries for local Linux and PR-scoped CI validation.
+
+## Slice
+
+Bind `_is_executable_model_file_entry` to a local variable before the
+`os.scandir()` generator filters directory entries. This preserves the same
+filename, prefix, and non-symlink regular-file checks while avoiding a global
+lookup per scanned entry in the executable-file fallback path.
+
+## Success Metrics
+
+Use the registered probe metrics:
+
+- `elapsed_ms_mean` lower is better,
+- `elapsed_ms_min` informational,
+- `peak_bytes_mean` lower is better,
+- `rejections_mean` informational for parity.
+
+The change is accepted only if focused tests pass, changed-scope coverage passes,
+and the registered probe shows an improved or neutral elapsed-time direction
+locally on Linux and in PR-scoped CI.

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -282,13 +282,14 @@ def _detect_executable_model_files(model_spec: common_pb2.ModelSpec) -> tuple[st
         scan_path: str | os.PathLike[str] = Path(model_path).expanduser()
     else:
         scan_path = model_path
+    is_executable_model_file_entry = _is_executable_model_file_entry
     try:
         with os.scandir(scan_path) as entries:
             return tuple(
                 sorted(
                     entry.name
                     for entry in entries
-                    if _is_executable_model_file_entry(entry)
+                    if is_executable_model_file_entry(entry)
                 )
             )
     except OSError:


### PR DESCRIPTION
## Summary
- Bind the executable model file entry helper locally before the model-load trust fallback `os.scandir()` filter.
- Add the governing performance-slice plan for the registered `model-load-config-json-bytes` probe.

## Plan or Spec
- `docs/plans/2026-07-03-model-load-executable-scan-local-bind-performance.md`
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_load_config_json_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-load-config-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/model_load_pr_probe_compare.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 37 passed in 2.18s.
- Changed-scope coverage: 100% for changed line in `services/mlx-worker-python/worker/model_load_trust.py`.
- Direct local probe: `elapsed_ms_mean=6.6728511259758045`, `elapsed_ms_min=5.569737986661494`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`.
- Local registered base/head comparison: base `elapsed_ms_mean=6.093018871199872`, head `elapsed_ms_mean=5.932514555752277`, delta `-0.160504315447595 ms`, speedup `1.027055029037632x`; peak bytes unchanged at `3187.4285714285716`; rejections unchanged at `300.0`.

## Known Gaps
- Local validation is Linux-only. The registered PR-scoped performance workflow is still required as the authoritative CI report before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
