### PR TITLE
perf: index metrics snapshot latest tracking

### DIFF
--- a/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
+++ b/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
@@ -80,3 +80,16 @@ single-scan runtime discovery behavior.
 The behavior contract remains unchanged: exact, prefix/suffix, empty-prefix, and
 multi-wildcard runtime pattern matches still select the newest regular file per
 source, and configured sources still bypass runtime scanning.
+
+## 2026-07-03 follow-up slice: index-backed latest tracking
+
+This Python-only follow-up keeps the same registered
+`melix-metrics-snapshot-runtime-scandir` probe and remains scoped to
+`discover_latest_metrics_paths(...)`. The scan precomputes source indexes for
+exact, prefix/suffix, and wildcard matchers, then tracks latest paths and mtimes
+in fixed-size lists instead of per-source dictionaries on the hot update path.
+
+The behavior contract remains unchanged: the returned mapping is still keyed by
+source name, overlapping source matches still receive the newest matching file,
+configured sources still bypass runtime scanning, and missing runtime directories
+still return unresolved source paths without raising.

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -84,81 +84,79 @@ def discover_latest_metrics_paths(runtime_dir: Path | None, source_names: tuple[
     discovered: dict[str, Path | None] = {name: None for name in source_names}
     if runtime_dir is None or not source_names:
         return discovered
-    exact_matchers: dict[str, str] = {}
-    prefix_matchers_by_initial: dict[str, list[tuple[str, str, str]]] = {}
-    wildcard_matchers: list[tuple[str, str]] = []
-    for source_name in source_names:
+    exact_matchers: dict[str, int] = {}
+    prefix_matchers_by_initial: dict[str, list[tuple[int, str, str]]] = {}
+    wildcard_matchers: list[tuple[int, str]] = []
+    for source_index, source_name in enumerate(source_names):
         pattern = SOURCE_DEFINITIONS[source_name]["runtime_pattern"]
         wildcard_index = pattern.find("*")
         if wildcard_index == -1:
-            exact_matchers[pattern] = source_name
+            exact_matchers[pattern] = source_index
         elif pattern.find("*", wildcard_index + 1) == -1:
             prefix = pattern[:wildcard_index]
             suffix = pattern[wildcard_index + 1 :]
             initial = prefix[:1]
             prefix_matchers_by_initial.setdefault(initial, []).append(
-                (source_name, prefix, suffix)
+                (source_index, prefix, suffix)
             )
         else:
-            wildcard_matchers.append((source_name, pattern))
+            wildcard_matchers.append((source_index, pattern))
     try:
-        latest_paths: dict[str, str | None] = {name: None for name in source_names}
-        latest_mtimes: dict[str, float | None] = {name: None for name in source_names}
-        latest_paths_set = latest_paths.__setitem__
-        latest_mtimes_get = latest_mtimes.get
-        latest_mtimes_set = latest_mtimes.__setitem__
+        source_count = len(source_names)
+        latest_paths: list[str | None] = [None] * source_count
+        latest_mtimes: list[float | None] = [None] * source_count
         empty_prefix_matchers = prefix_matchers_by_initial.get("", ())
         with os.scandir(os.fspath(runtime_dir.expanduser())) as entries:
             for entry in entries:
                 entry_name = entry.name
-                matched_source_name = exact_matchers.get(entry_name)
-                matched_source_names: list[str] | None = None
-                for source_name, prefix, suffix in prefix_matchers_by_initial.get(
+                matched_source_index = exact_matchers.get(entry_name)
+                matched_source_indexes: list[int] | None = None
+                for source_index, prefix, suffix in prefix_matchers_by_initial.get(
                     entry_name[:1], ()
                 ):
                     if entry_name.startswith(prefix) and entry_name.endswith(suffix):
-                        if matched_source_name is None:
-                            matched_source_name = source_name
-                        elif matched_source_names is None:
-                            matched_source_names = [matched_source_name, source_name]
+                        if matched_source_index is None:
+                            matched_source_index = source_index
+                        elif matched_source_indexes is None:
+                            matched_source_indexes = [matched_source_index, source_index]
                         else:
-                            matched_source_names.append(source_name)
+                            matched_source_indexes.append(source_index)
                 if empty_prefix_matchers:
-                    for source_name, prefix, suffix in empty_prefix_matchers:
+                    for source_index, prefix, suffix in empty_prefix_matchers:
                         if entry_name.endswith(suffix):
-                            if matched_source_name is None:
-                                matched_source_name = source_name
-                            elif matched_source_names is None:
-                                matched_source_names = [matched_source_name, source_name]
+                            if matched_source_index is None:
+                                matched_source_index = source_index
+                            elif matched_source_indexes is None:
+                                matched_source_indexes = [matched_source_index, source_index]
                             else:
-                                matched_source_names.append(source_name)
-                for source_name, pattern in wildcard_matchers:
+                                matched_source_indexes.append(source_index)
+                for source_index, pattern in wildcard_matchers:
                     if _matches_runtime_pattern(entry_name, pattern):
-                        if matched_source_name is None:
-                            matched_source_name = source_name
-                        elif matched_source_names is None:
-                            matched_source_names = [matched_source_name, source_name]
+                        if matched_source_index is None:
+                            matched_source_index = source_index
+                        elif matched_source_indexes is None:
+                            matched_source_indexes = [matched_source_index, source_index]
                         else:
-                            matched_source_names.append(source_name)
-                if matched_source_name is None:
+                            matched_source_indexes.append(source_index)
+                if matched_source_index is None:
                     continue
                 if not entry.is_file():
                     continue
                 mtime = entry.stat().st_mtime
-                if matched_source_names is None:
-                    latest_mtime = latest_mtimes_get(matched_source_name)
+                if matched_source_indexes is None:
+                    latest_mtime = latest_mtimes[matched_source_index]
                     if latest_mtime is None or mtime > latest_mtime:
-                        latest_paths_set(matched_source_name, entry.path)
-                        latest_mtimes_set(matched_source_name, mtime)
+                        latest_paths[matched_source_index] = entry.path
+                        latest_mtimes[matched_source_index] = mtime
                     continue
-                for source_name in matched_source_names:
-                    latest_mtime = latest_mtimes_get(source_name)
+                for source_index in matched_source_indexes:
+                    latest_mtime = latest_mtimes[source_index]
                     if latest_mtime is None or mtime > latest_mtime:
-                        latest_paths_set(source_name, entry.path)
-                        latest_mtimes_set(source_name, mtime)
-        for source_name, latest_path in latest_paths.items():
+                        latest_paths[source_index] = entry.path
+                        latest_mtimes[source_index] = mtime
+        for source_index, latest_path in enumerate(latest_paths):
             if latest_path is not None:
-                discovered[source_name] = Path(latest_path)
+                discovered[source_names[source_index]] = Path(latest_path)
         return discovered
     except OSError:
         return discovered


### PR DESCRIPTION
## Summary
- Optimize `scripts/melix_metrics_snapshot.py` runtime metrics discovery by precomputing source indexes for matcher buckets.
- Track latest paths and mtimes in fixed-size lists during the scan instead of per-source dictionaries on the hot update path.
- Update the governing metrics snapshot performance plan with the 2026-07-03 follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md`
- Registered probe: `melix-metrics-snapshot-runtime-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_skips_runtime_scan_when_all_sources_are_configured tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics
# 11 passed in 0.56s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/melix_metrics_snapshot.py tests/test_melix_metrics_snapshot.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 40 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id melix-metrics-snapshot-runtime-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-metrics-snapshot-index-latest-20260703 --head-repo "$PWD" --output /tmp/melix_metrics_snapshot_index_probe.json
# head verification passed; registered probe passed

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 40 0 100%`.
- Registered local Linux probe (`melix-metrics-snapshot-runtime-scandir`) repeated comparison:
  - Run 1: `elapsed_ms_mean` 11.531452 -> 11.146419 ms (`-3.34%`), `elapsed_ms_min` 9.990455 -> 10.193917 ms (`+2.04%`).
  - Run 2: `elapsed_ms_mean` 12.361291 -> 11.280881 ms (`-8.74%`), `elapsed_ms_min` 11.383416 -> 10.139364 ms (`-10.93%`).
  - Run 3: `elapsed_ms_mean` 11.745569 -> 11.173792 ms (`-4.87%`), `elapsed_ms_min` 10.744557 -> 10.369014 ms (`-3.50%`).
- CI PR-scoped performance is required as the final registered-probe validation before merge.

## Known Gaps
- Local verification is Linux/Python-only; no Swift runtime effects are claimed.
- One single-run probe comparison was noisy (`elapsed_ms_mean` +0.66%) before the repeated three-run comparison showed stable mean improvement.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
