### PR TITLE
perf: fast path report evidence run-kind roles

### DIFF
--- a/docs/plans/2026-07-01-report-evidence-single-evidence-id-sort-elision.md
+++ b/docs/plans/2026-07-01-report-evidence-single-evidence-id-sort-elision.md
@@ -25,6 +25,15 @@ list directly when a role has exactly one evidence id. This preserves behavior
 for empty, single-id, and multi-id roles while reducing release-matrix row
 materialization overhead on the common single-id path.
 
+## 2026-07-03 follow-up: single run-kind role fast path
+
+This Python-only follow-up keeps the same registered probe and narrows to
+`_report_matrix_roles`. Release-matrix rows commonly use run-kind-only rules with
+a single tuple value, so the role scanner can test that tuple directly against the
+precomputed report run-kind set instead of dispatching through the general
+`_run_kind_rule_matches` helper on every role. Multi-value, non-tuple, and
+non-string run-kind rules continue to use the existing general matching behavior.
+
 ## Verification plan
 
 Run the registered focused test command, changed-scope coverage command, and the

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -297,17 +297,27 @@ def _report_matrix_roles(
     matrix: dict[str, dict[str, object]],
 ) -> list[str]:
     roles: list[str] = []
+    roles_append = roles.append
     runs = _dict_list(report.get("runs"))
     targets = _dict_list(report.get("targets"))
     metrics = _dict_list(report.get("metrics"))
     run_kind_values: frozenset[str] | None = None
     probe_phases: set[str] | None = None
+    run_kind_only_rule = _run_kind_only_rule
+    run_kind_rule_matches = _run_kind_rule_matches
     for role, rule in matrix.items():
-        if _run_kind_only_rule(rule):
+        if run_kind_only_rule(rule):
             if run_kind_values is None:
                 run_kind_values = _report_run_kind_values(runs)
-            if _run_kind_rule_matches(rule.get("run_kinds", ()), run_kind_values):
-                roles.append(role)
+            run_kinds = rule.get("run_kinds", ())
+            if isinstance(run_kinds, tuple) and len(run_kinds) == 1:
+                run_kind = run_kinds[0]
+                if run_kind in run_kind_values or (
+                    type(run_kind) is not str and str(run_kind) in run_kind_values
+                ):
+                    roles_append(role)
+            elif run_kind_rule_matches(run_kinds, run_kind_values):
+                roles_append(role)
             continue
         if rule.get("probe_phases") and probe_phases is None:
             probe_phases = _probe_phases(report)


### PR DESCRIPTION
## Summary
- Fast-path report evidence release-matrix role scanning for run-kind-only rules with a single tuple value.
- Keep the general `_run_kind_rule_matches` path for multi-value, non-tuple, and non-string rule values.
- Update the governing report-evidence performance plan for this follow-up slice.

## Plan or Spec
- `docs/plans/2026-07-01-report-evidence-single-evidence-id-sort-elision.md` (2026-07-03 follow-up: single run-kind role fast path)

## Commands Run
```text
# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_rules_accept_non_tuple_iterables services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_tuple_rules_cache_on_rule services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_fast_reject_preserves_empty_prefix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_preserves_non_string_match services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_metric_prefix_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_tuple_rules_reuse_normalized_tuple services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_sparse_match_scans_row_items services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_target_field_preserves_stringified_presence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_tuple_rules_reuse_normalized_set services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phase_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_matrix_roles_skip_probe_phase_scan_without_phase_rules services/mlx-worker-python/tests/test_report_matrix_roles_scans_probe_phases_once_for_phase_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_probe_phases_scans_buckets_without_dict_list services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_passes_complete_release_matrix services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_dedupes_evidence_ids services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_single_role_keeps_stringified_evidence services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_release_matrix_ignores_invalid_cached_roles services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_covers_invalid_payload_and_edge_summaries services/mlx-worker-python/tests/test_report_evidence_gate.py::test_load_report_payload_reads_json_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_report_evidence_gate_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# Result: 29 passed in 1.24s

# Changed-scope coverage via registered coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# Result: 29 passed; TOTAL 11 0 100%

# Registered local probe, base vs head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id report-evidence-gate-run-kind-set-membership --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/report_evidence_pr_run3.json
# Result: verification ok, base probe ok, head probe ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered probe: `report-evidence-gate-run-kind-set-membership`.
- Local Linux probe metrics from `/tmp/report_evidence_pr_run3.json`:
  - `matrix_roles_elapsed_ms_mean`: base `3.5934569779783487` ms → head `3.40117618907243` ms (`-0.1922807889059186` ms, `-5.35%`).
  - `run_kind_elapsed_ms_mean`: base `203.1761997845024` ms → head `203.0898296041414` ms (`-0.08637018036097288` ms, `-0.04%`).
  - `elapsed_ms_mean`: base `988.838771940209` ms → head `1010.4771576821804` ms (`+21.638385741971433` ms, `+2.19%`, within the 5% warn threshold; final registered CI probe remains the merge gate).
- Observability mode: evidence (PR-scoped synthetic performance probe). Probe overhead: N/A, this changes only probe-measured report-evidence gate CPU path and adds no runtime observability.

## Known Gaps
- Linux local validation only; GitHub Actions PR-scoped performance is required for final registered probe validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
