### PR TITLE
perf: bound report evidence slowest phase heap

### DIFF
--- a/docs/plans/2026-07-03-report-evidence-slowest-phase-bounded-heap.md
+++ b/docs/plans/2026-07-03-report-evidence-slowest-phase-bounded-heap.md
@@ -1,0 +1,34 @@
+# Report Evidence Slowest Phase Bounded Heap
+
+## Scope
+
+This Python-only performance slice is limited to the report evidence gate slowest
+probe phase extraction in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+The behavior remains unchanged: the gate still reports at most five slowest
+probe phase rows across baseline and candidate summaries, preserving duration
+ordering and existing tie order semantics.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for the report
+evidence gate tests, changed-scope coverage, and command-json probe metrics.
+
+## Optimization Plan
+
+1. Keep the existing row validation and typed duration coercion semantics.
+2. Replace the generator plus `heapq.nlargest(5, ...)` slowest-phase selection
+   with an explicit bounded min-heap of size five.
+3. Sort only the five retained rows before returning the public result payload.
+4. Run the registered focused test command, changed-scope coverage command, and
+   registered command-json probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate after push.
+
+## Validation Notes
+
+The local Linux validation source is the registered Python probe. The expected
+metric direction is a lower `slowest_probe_phase_elapsed_ms_mean` and a neutral
+or improved aggregate `elapsed_ms_mean` without changing report-evidence gate
+semantics.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -4,7 +4,7 @@ import heapq
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import AbstractSet, Any, Iterator, cast
+from typing import AbstractSet, Any, cast
 
 from worker.productization.benchmark_evaluation_report import validate_report_payload
 
@@ -564,35 +564,40 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
     probe_summary = report.get("probe_summary")
     if not isinstance(probe_summary, dict):
         return []
-
-    def iter_rows() -> Iterator[tuple[float, int, str, dict[str, object]]]:
-        row_index = 0
-        for side in ("baseline", "candidate"):
-            side_summary = probe_summary.get(side)
-            if not isinstance(side_summary, dict):
+    rows: list[tuple[float, int, str, dict[str, object]]] = []
+    row_index = 0
+    row_count = 0
+    rows_push = heapq.heappush
+    rows_replace = heapq.heapreplace
+    for side in ("baseline", "candidate"):
+        side_summary = probe_summary.get(side)
+        if not isinstance(side_summary, dict):
+            continue
+        slowest_phases = side_summary.get("slowest_phases")
+        if not isinstance(slowest_phases, list):
+            continue
+        for row in slowest_phases:
+            if not isinstance(row, dict):
                 continue
-            slowest_phases = side_summary.get("slowest_phases")
-            if not isinstance(slowest_phases, list):
-                continue
-            for row in slowest_phases:
-                if not isinstance(row, dict):
-                    continue
-                duration = row.get("duration_ms")
-                if type(duration) is float:
-                    duration_ms = duration
-                elif type(duration) is int:
-                    duration_ms = float(duration)
-                elif type(duration) is str:
-                    duration_ms = float(duration or 0.0)
-                else:
-                    duration_ms = 0.0
-                yield (duration_ms, -row_index, side, row)
-                row_index += 1
-
-    return [
-        {"side": side, **row}
-        for _duration_ms, _row_order, side, row in heapq.nlargest(5, iter_rows())
-    ]
+            duration = row.get("duration_ms")
+            if type(duration) is float:
+                duration_ms = duration
+            elif type(duration) is int:
+                duration_ms = float(duration)
+            elif type(duration) is str:
+                duration_ms = float(duration or 0.0)
+            else:
+                duration_ms = 0.0
+            if row_count < 5:
+                rows_push(rows, (duration_ms, -row_index, side, row))
+                row_count += 1
+            elif duration_ms >= rows[0][0]:
+                item = (duration_ms, -row_index, side, row)
+                if item > rows[0]:
+                    rows_replace(rows, item)
+            row_index += 1
+    rows.sort(reverse=True)
+    return [{"side": side, **row} for _duration_ms, _row_order, side, row in rows]
 
 
 def _probe_phases(report: dict[str, object]) -> set[str]:


### PR DESCRIPTION
## Summary
- Optimize report evidence slowest probe phase selection with a bounded size-5 heap.
- Preserve existing duration coercion, row filtering, side annotation, and tie-order semantics.
- Add a focused plan for the Python performance slice.

## Plan or Spec
- `docs/plans/2026-07-03-report-evidence-slowest-phase-bounded-heap.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...registered report-evidence-gate-run-kind-set-membership tests...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused slowest-phase tests: `2 passed`.
- Registered focused tests: `29 passed`.
- Changed-scope coverage: `TOTAL 33 0 100%`.
- Local registered probe (head): `elapsed_ms_mean=944.6655309991911`, `slowest_probe_phase_elapsed_ms_mean=22.710592998191714`.
- Baseline comparison sampled on `origin/main`: mean `slowest_probe_phase_elapsed_ms_mean=39.068 ms` over 3 runs before the slice; head registered run reported `22.711 ms` for the optimized target metric.
- GitHub Actions PR-scoped performance must validate the registered probe before merge.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime behavior is changed or claimed.
- Aggregate probe metrics include unrelated report-evidence subprobes and can vary with runner noise; the scoped target metric is `slowest_probe_phase_elapsed_ms_mean`.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and reports target metric improvement.
- [ ] GitHub Actions PR-scoped performance completed successfully.
