### PR TITLE
perf: fast path hub size hint markers

### DIFF
--- a/docs/plans/2026-07-03-hub-size-hint-marker-fastpath.md
+++ b/docs/plans/2026-07-03-hub-size-hint-marker-fastpath.md
@@ -1,0 +1,39 @@
+# Hub Catalog Size Hint Marker Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to Hub catalog size-hint parsing in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py`. The behavior stays
+unchanged for supported `MODEL SIZE | ...`, `Model size: ...`, and generic
+`model size` metadata lines.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+The registry entry already defines focused `test_command`, `coverage_command`,
+and `probe_command` values and watches:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Implementation plan
+
+1. Add a tiny direct line parser helper so common exact Hub readme/card marker
+   forms can jump directly to value parsing without replaying the generic marker
+   whitespace/separator scan.
+2. Keep the generic marker path as the fallback for uncommon but currently
+   supported forms.
+3. Reuse the focused Hub catalog tests, changed-scope coverage command, and the
+   registered probe locally on Linux before opening the PR.
+4. Use GitHub Actions PR-scoped performance as the final registered-probe merge
+   gate.
+
+## Metrics target
+
+Primary metric: `elapsed_ms_mean` from `scripts/hub_catalog_size_hint_probe.py`.
+Accept only if the local registered probe shows a clear improvement over the
+same-worktree `origin/main` baseline without increasing parser fallbacks or
+changing checksum/matched-count outputs.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -918,7 +918,27 @@ def _direct_card_size_hint_from_text(text: str) -> int:
     return _direct_size_hint_from_text(text)
 
 
+def _direct_size_hint_from_line(text: str, value_start: int) -> int:
+    newline_index = text.find("\n", value_start)
+    if newline_index >= 0:
+        return _direct_size_hint_from_text(text[value_start:newline_index])
+    value_end = value_start
+    text_length = len(text)
+    while (
+        value_end < text_length
+        and text[value_end] not in "\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
+    ):
+        value_end += 1
+    return _direct_size_hint_from_text(text[value_start:value_end])
+
+
 def _direct_explicit_size_hint_from_text(text: str) -> int:
+    marker_index = text.find("MODEL SIZE | ")
+    if marker_index >= 0:
+        return _direct_size_hint_from_line(text, marker_index + 13)
+    marker_index = text.find("Model size: ")
+    if marker_index >= 0:
+        return _direct_size_hint_from_line(text, marker_index + 12)
     marker_index = text.find("MODEL SIZE")
     if marker_index < 0:
         marker_index = text.find("Model size")
@@ -936,17 +956,7 @@ def _direct_explicit_size_hint_from_text(text: str) -> int:
     while value_start < text_length and text[value_start].isspace():
         value_start += 1
 
-    newline_index = text.find("\n", value_start)
-    if newline_index >= 0:
-        return _direct_size_hint_from_text(text[value_start:newline_index])
-
-    value_end = value_start
-    while (
-        value_end < text_length
-        and text[value_end] not in "\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
-    ):
-        value_end += 1
-    return _direct_size_hint_from_text(text[value_start:value_end])
+    return _direct_size_hint_from_line(text, value_start)
 
 
 def _strip_model_size_label(text: str) -> str:


### PR DESCRIPTION
## Summary
- Fast-path common Hub `MODEL SIZE | ...` and `Model size: ...` marker lines directly to the size value parser.
- Reuse the shared direct line parser for both fast-path and fallback explicit marker parsing.
- Add the governing performance slice plan for this registered probe.

## Plan or Spec
- `docs/plans/2026-07-03-hub-size-hint-marker-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_direct_explicit_size_hint_handles_common_readme_lines services/mlx-worker-python/tests/test_hub_catalog.py::test_size_hint_scans_multiple_text_fields_before_joining
# 2 passed in 0.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 90 passed in 1.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 90 passed in 0.51s; TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'if [ -f "${PWD}/../head/scripts/hub_catalog_size_hint_probe.py" ]; then python3 "${PWD}/../head/scripts/hub_catalog_size_hint_probe.py"; else python3 "${PWD}/scripts/hub_catalog_size_hint_probe.py"; fi'
# {"elapsed_ms_mean": 1723.372544767335, "payload_compatibility_elapsed_ms_mean": 195.20066557452083, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub_size_hint_pr_perf.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile`.
- Local PR-scoped probe comparison on Linux:
  - `elapsed_ms_mean`: base `1761.834549997002`, head `1712.7111899899319` (`-49.12336000707005 ms`, about `2.79%` faster)
  - `payload_compatibility_elapsed_ms_mean`: base `200.56633641943336`, head `195.49891559872776` (`-5.0674208207056 ms`, about `2.53%` faster)
  - `checksum`: unchanged at `1545732096.0`
  - `matched_hint_count`: unchanged at `120000.0`
  - `size_hint_calls_mean`: unchanged at `0.0`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local validation covers the Python Hub catalog path only; GitHub Actions remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
