### PR TITLE
perf: assemble tool selection receipts once

### DIFF
--- a/docs/plans/2026-07-03-tool-registry-selected-tool-receipts.md
+++ b/docs/plans/2026-07-03-tool-registry-selected-tool-receipts.md
@@ -1,0 +1,54 @@
+# Tool registry selected-tool receipt single-pass assembly
+
+## Summary
+
+This Python-only performance slice keeps agentic tool selection behavior unchanged
+while reducing per-call work in `select_agentic_tools_for_turn(...)`. Selection
+already admits tools through `_append_selected_tool(...)`; this slice assembles the
+receipt `selected_tools` entries during that admission pass so
+`_build_tool_selection_result(...)` no longer rebuilds the same tool/source list
+from `selected_names` plus the source lookup map.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/tool_registry.py`
+- `services/mlx-worker-python/tests/test_tool_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/tool_registry_select_probe.py`
+
+No probe registry change is required for this slice. The registered probe
+measures selector planning through `selector_planning_elapsed_ms_mean` and the
+broader select path through `elapsed_ms_mean`.
+
+## Optimization slice
+
+Scope is limited to the selected-tool receipt assembly inside
+`worker.runtime.tool_registry.select_agentic_tools_for_turn(...)`:
+
+- pass a `selected_tools` receipt list through `_append_selected_tool(...)`;
+- append the accepted `{"tool_id": ..., "source": ...}` receipt entry exactly
+  when the tool is admitted;
+- reuse that list in `_build_tool_selection_result(...)` instead of rebuilding it
+  from `selected_names` and `selected_sources`.
+
+The slice preserves keyword matching, vector selection, duplicate suppression,
+receipt ordering, always-available tool admission, fallback semantics, and schema
+byte metrics.
+
+## Verification plan
+
+Run the registered focused test command, changed-scope coverage command, and the
+registered probe locally on Linux. The PR-scoped performance workflow remains the
+merge gate for base-vs-head validation.
+
+## Success criteria
+
+- Focused Python tests pass.
+- Changed-scope coverage for touched files remains at or above 95%.
+- Registered probe shows non-regressing or improved selector planning metrics.
+- GitHub Actions and the PR-scoped performance workflow are green before merge.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -338,11 +338,13 @@ def test_append_selected_tool_skips_strip_for_canonical_names() -> None:
 
     selected_names: list[str] = []
     selected_sources: dict[str, str] = {}
+    selected_tools: list[dict[str, str]] = []
     canonical_name = StripCountingName("text_search")
 
     assert tool_registry_module._append_selected_tool(
         selected_names,
         selected_sources,
+        selected_tools,
         canonical_name,
         "keyword",
         4,
@@ -351,11 +353,13 @@ def test_append_selected_tool_skips_strip_for_canonical_names() -> None:
     assert StripCountingName.strip_calls == 0
     assert selected_names == ["text_search"]
     assert selected_sources == {"text_search": "keyword"}
+    assert selected_tools == [{"tool_id": "text_search", "source": "keyword"}]
 
     whitespace_name = StripCountingName("  visit  ")
     assert tool_registry_module._append_selected_tool(
         selected_names,
         selected_sources,
+        selected_tools,
         whitespace_name,
         "keyword",
         4,
@@ -363,15 +367,24 @@ def test_append_selected_tool_skips_strip_for_canonical_names() -> None:
     assert StripCountingName.strip_calls == 1
     assert selected_names == ["text_search", "visit"]
     assert selected_sources["visit"] == "keyword"
+    assert selected_tools == [
+        {"tool_id": "text_search", "source": "keyword"},
+        {"tool_id": "visit", "source": "keyword"},
+    ]
 
     assert not tool_registry_module._append_selected_tool(
         selected_names,
         selected_sources,
+        selected_tools,
         StripCountingName("   "),
         "keyword",
         4,
     )
     assert StripCountingName.strip_calls == 2
+    assert selected_tools == [
+        {"tool_id": "text_search", "source": "keyword"},
+        {"tool_id": "visit", "source": "keyword"},
+    ]
 
 
 def test_tool_registry_select_reuses_cached_name_index() -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -511,6 +511,7 @@ def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> co
 def _append_selected_tool(
     selected_names: list[str],
     selected_sources: dict[str, str],
+    selected_tools: list[dict[str, str]],
     tool_name: str,
     source: str,
     max_selected_tools: int,
@@ -529,6 +530,7 @@ def _append_selected_tool(
         return False
     selected_sources[normalized_name] = source
     selected_names.append(normalized_name)
+    selected_tools.append({"tool_id": normalized_name, "source": source})
     return True
 
 
@@ -546,12 +548,20 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         return _build_always_only_tool_selection_result(registry, selection_input)
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
+    selected_tools: list[dict[str, str]] = []
     append_selected_tool = _append_selected_tool
     has_vector_selection = False
     has_keyword_selection = False
 
     for tool_name in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES:
-        append_selected_tool(selected_names, selected_sources, tool_name, "always", max_selected_tools)
+        append_selected_tool(
+            selected_names,
+            selected_sources,
+            selected_tools,
+            tool_name,
+            "always",
+            max_selected_tools,
+        )
 
     selection_mode = "fallback"
     fallback_reason = "no_keyword_match"
@@ -559,7 +569,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         return _build_tool_selection_result(
             registry,
             selected_names,
-            selected_sources,
+            selected_tools,
             selection_input,
             selection_mode,
             fallback_reason,
@@ -570,6 +580,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             if append_selected_tool(
                 selected_names,
                 selected_sources,
+                selected_tools,
                 tool_name,
                 "vector",
                 max_selected_tools,
@@ -579,7 +590,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             return _build_tool_selection_result(
                 registry,
                 selected_names,
-                selected_sources,
+                selected_tools,
                 selection_input,
                 "vector",
                 "",
@@ -591,6 +602,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             if append_selected_tool(
                 selected_names,
                 selected_sources,
+                selected_tools,
                 tool_name,
                 "keyword",
                 max_selected_tools,
@@ -604,6 +616,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
                 if append_selected_tool(
                     selected_names,
                     selected_sources,
+                    selected_tools,
                     tool_name,
                     "keyword_context",
                     max_selected_tools,
@@ -616,7 +629,7 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     return _build_tool_selection_result(
         registry,
         selected_names,
-        selected_sources,
+        selected_tools,
         selection_input,
         selection_mode,
         fallback_reason,
@@ -656,7 +669,7 @@ def _build_always_only_tool_selection_result(
 def _build_tool_selection_result(
     registry: ToolRegistry,
     selected_names: list[str],
-    selected_sources: dict[str, str],
+    selected_tools: list[dict[str, str]],
     selection_input: ToolSelectionInput,
     selection_mode: str,
     fallback_reason: str,
@@ -664,13 +677,8 @@ def _build_tool_selection_result(
     if len(selected_names) == 1:
         selected_name = selected_names[0]
         selected_registry = registry.select((selected_name,))
-        selected_tools = [{"tool_id": selected_name, "source": selected_sources[selected_name]}]
     else:
         selected_registry = registry.select(tuple(selected_names))
-        selected_tools = [
-            {"tool_id": tool_name, "source": selected_sources[tool_name]}
-            for tool_name in selected_names
-        ]
     registry_metrics = registry.metrics()
     selected_metrics = selected_registry.metrics()
     selected_tool_count = selected_metrics.tool_count


### PR DESCRIPTION
## Summary
- Assemble `selected_tools` receipt entries during `_append_selected_tool(...)` admission instead of rebuilding the tool/source list in `_build_tool_selection_result(...)`.
- Update the focused tool-registry performance plan for this receipt assembly slice.
- Extend the `_append_selected_tool(...)` regression test to verify the eagerly assembled receipt entries and unchanged blank/duplicate behavior.

## Plan or Spec
- `docs/plans/2026-07-03-tool-registry-selected-tool-receipts.md`
- Registered PR-scoped performance probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# Baseline on origin/main before editing: exit 0; selector_planning_elapsed_ms_mean=32.42263561114669; elapsed_ms_mean=22.43731003254652

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 97 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; 97 passed; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; selector_planning_elapsed_ms_mean=31.43841060809791; elapsed_ms_mean=22.820300003513694

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local Linux registered probe (baseline -> head):
  - `selector_planning_elapsed_ms_mean`: 32.42263561114669 -> 31.43841060809791 ms (delta -0.9842250030487776 ms, ~3.04% faster).
  - `elapsed_ms_mean`: 22.43731003254652 -> 22.820300003513694 ms (delta +0.3829899709671736 ms, ~1.71% slower/noisy and below the 5% warn threshold).
- CI PR-scoped performance remains the authoritative base-vs-head validation gate.

## Known Gaps
- Local validation was Linux-only; no Swift runtime path is touched.
- The broad `elapsed_ms_mean` probe bucket is dominated by registry `select(...)` cases outside this receipt assembly path, so the slice uses `selector_planning_elapsed_ms_mean` as the direct local signal while CI provides registered probe validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
