### PR TITLE
perf: avoid redundant numeric normalization strip

### DIFF
--- a/docs/plans/2026-07-03-evaluation-normalized-numeric-fullmatch.md
+++ b/docs/plans/2026-07-03-evaluation-normalized-numeric-fullmatch.md
@@ -1,0 +1,49 @@
+# Evaluation Normalized Numeric Fullmatch Slice
+
+## Scope
+
+This slice targets the Python evaluation answer normalization hot path in
+`services/mlx-worker-python/worker/engine/evaluation_core.py`.
+
+The affected behavior is already covered by the registered PR-scoped performance
+probe `evaluation-answer-normalization-fast-path` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries.
+
+## Optimization
+
+`EvaluationCore._normalized_answer(...)` receives an already stripped string from
+`_strip_wrapping(...)`. Its numeric fast path previously delegated to
+`EvaluationCore._looks_like_numeric(stripped)`, which calls `value.strip()` again
+before applying `_NUMERIC_TOKEN_PATTERN.fullmatch(...)`.
+
+This slice keeps the same guard and normalization behavior, but applies the
+compiled numeric token pattern directly to the already stripped value. The change
+avoids the redundant second strip and static-method call for numeric-looking
+answers while leaving `_looks_like_numeric(...)` unchanged for other call sites.
+
+## Behavior Invariants
+
+- Empty values still bypass numeric normalization.
+- Single-letter option normalization still wins before numeric checks.
+- Numeric literals still use the same `_NUMERIC_TOKEN_PATTERN` acceptance rule.
+- Numeric output formatting still goes through `_normalized_numeric_literal(...)`.
+- Non-numeric free text still follows the existing whitespace and case handling.
+
+## Validation Plan
+
+Run the registered probe's focused test command and changed-scope coverage command
+on Linux, then run the registered probe against `origin/main` and this branch with
+`scripts/pr_scoped_performance_run.py`.
+
+## Local Results
+
+- Focused tests: `19 passed`.
+- Changed-scope coverage: `TOTAL 1 0 100%`.
+- Registered probe `evaluation-answer-normalization-fast-path`:
+  - `elapsed_ms_mean`: base `131.749007`, head `124.262952`, delta `-7.486055 ms` (`-5.68%`).
+  - `answer_match_elapsed_ms_mean`: base `78.985713`, head `77.617546`, delta `-1.368167 ms` (`-1.73%`).
+  - `numeric_extract_calls_mean`: base `0.0`, head `0.0`.
+  - `option_extract_calls_mean`: base `0.0`, head `0.0`.
+
+Commands and measured results are also included in the PR body.

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -4126,7 +4126,11 @@ class EvaluationCore:
             option = stripped.upper()
             if option.isalpha():
                 return option
-        if stripped and stripped[0] in "+-0123456789" and EvaluationCore._looks_like_numeric(stripped):
+        if (
+            stripped
+            and stripped[0] in "+-0123456789"
+            and _NUMERIC_TOKEN_PATTERN.fullmatch(stripped) is not None
+        ):
             return EvaluationCore._normalized_numeric_literal(stripped)
         is_ascii = stripped.isascii()
         if (


### PR DESCRIPTION
## Summary
- Avoid the redundant `_looks_like_numeric(...)` static-method call and second `strip()` in `EvaluationCore._normalized_answer(...)` after `_strip_wrapping(...)` has already stripped the candidate.
- Keep the same `_NUMERIC_TOKEN_PATTERN.fullmatch(...)` numeric acceptance rule and `_normalized_numeric_literal(...)` formatting.
- Document the slice and local metrics in `docs/plans/2026-07-03-evaluation-normalized-numeric-fullmatch.md`.

## Plan or Spec
- `docs/plans/2026-07-03-evaluation-normalized-numeric-fullmatch.md`
- Registered probe: `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused test command)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && ... coverage json ... && python3 scripts/changed_scope_coverage.py ...` (registered coverage command)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-answer-normalization-fast-path --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-evaluation-normalized-numeric-fullmatch-20260703b --head-repo "$PWD" --output /tmp/evaluation_answer_normalization_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `19 passed`.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local registered probe result:
  - `elapsed_ms_mean`: base `131.749007`, head `124.262952`, delta `-7.486055 ms` (`-5.68%`).
  - `answer_match_elapsed_ms_mean`: base `78.985713`, head `77.617546`, delta `-1.368167 ms` (`-1.73%`).
  - `numeric_extract_calls_mean`: base `0.0`, head `0.0`.
  - `option_extract_calls_mean`: base `0.0`, head `0.0`.

## Known Gaps
- This is a Python-only slice validated locally on Linux. CI must still run the registered PR-scoped performance workflow for the final PR result.
- The probe entry currently relies on `watch_globs` rather than a `paths` field; it does include focused `test_command`, `coverage_command`, and `probe_command` entries.

## Evidence Checklist
- [x] Synced from `origin/main` before branch creation.
- [x] Registered PR-scoped probe confirmed before implementation.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions completed successfully.
