### PR TITLE
perf: skip fallback path objects for diagnostic redaction

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -194,6 +194,14 @@ inlines the per-pattern marker/expression loops inside the excerpt scan so the
 hot path avoids repeated global, method, and helper lookups in the registered
 diagnostic parser probe.
 
+A follow-up 2026-07-04 external-path redaction slice keeps target-relative
+labels unchanged while short-circuiting clean external absolute paths after the
+lexical target-root check. Paths that do not contain parent-directory segments
+cannot become target-relative through the slower fallback, so the redactor emits
+the existing `<absolute-path>` label without constructing fallback `Path` objects
+or calling `relative_to()`. Paths with `..` segments continue through the
+normalization fallback to preserve safe target-root labeling.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -410,6 +410,42 @@ def test_export_target_diagnostics_uses_lexical_target_path_fast_path(
     ) is None
 
 
+def test_export_target_diagnostics_external_clean_paths_skip_fallback_path_objects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "ollama/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    def fail_path_construction(*_args: object, **_kwargs: object) -> Path:  # pragma: no cover
+        raise AssertionError("clean external paths should not allocate fallback Path objects")
+
+    monkeypatch.setattr(export_target_diagnostics_module, "Path", fail_path_construction)
+
+    excerpt = _build_redacted_excerpt(
+        layout,
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="runtime load failed at /tmp/melix/private/export/model.gguf.",
+            ),
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="missing blob under /var/folders/melix-cache/blob)",
+            ),
+        ],
+        bounded_bytes=4096,
+        bounded_lines=20,
+    )
+
+    assert "<absolute-path>." in excerpt.text
+    assert "<absolute-path>)" in excerpt.text
+    assert excerpt.summary.redacted_absolute_path_count == 2
+
+
 def test_export_target_diagnostics_ascii_excerpt_fast_path_preserves_byte_budget(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -752,6 +752,10 @@ def _redact_absolute_path(
         summary.redacted_absolute_path_count += 1
         summary.redaction_count += 1
         return f"<target>/{relative_text}" + suffix
+    if "/../" not in trimmed_path and not trimmed_path.endswith("/.."):
+        summary.redacted_absolute_path_count += 1
+        summary.redaction_count += 1
+        return replacement + suffix
     try:
         path = Path(trimmed_path)
         if ".." not in path.parts:


### PR DESCRIPTION
## Summary
- Skip fallback `Path` object construction for clean external absolute paths in runtime export diagnostic redaction.
- Add a regression test proving non-target clean absolute paths use the generic `<absolute-path>` fast path without fallback `Path` allocation.
- Document the 2026-07-04 runtime export diagnostic parser slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_external_clean_paths_skip_fallback_path_objects services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_redacts_paths_secrets_private_text_and_identity services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_uses_lexical_target_path_fast_path
# 3 passed in 0.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 78 passed in 1.66s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 78 passed in 1.40s; TOTAL 12 0 100%

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py; done
# baseline path_redaction_elapsed_ms_mean: [21.0538, 20.1789, 17.8695]
# head path_redaction_elapsed_ms_mean: [18.1073, 18.2434, 20.0785]
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered probe `runtime-export-diagnostic-parser` ran locally on Linux.
- Path redaction probe mean: baseline `19.7007 ms`, head `18.8097 ms`, delta `-0.8910 ms` (`4.52%` faster).
- Overall probe elapsed mean: baseline `2650.3088 ms`, head `2599.9069 ms`, delta `-50.4019 ms` (`1.90%` faster).
- Probe coverage stayed `diagnostic_parser_coverage=1.0`; parsed/unknown failure counts stayed `27.0` / `1.0`.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this is a focused Python runtime diagnostics slice.
- GitHub Actions PR-scoped performance workflow is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
