### PR TITLE
perf: reuse dev-up dist-info name bounds

### DIFF
--- a/docs/plans/2026-05-02-dev-up-mlx-metal-dist-info-scandir.md
+++ b/docs/plans/2026-05-02-dev-up-mlx-metal-dist-info-scandir.md
@@ -35,6 +35,10 @@ This slice is Python-only and is locally verifiable on Linux with focused pytest
 - Local registered probe improves versus the pre-change baseline.
 - PR-scoped performance CI selects and completes the registered probe for this path.
 
+## Incremental Slice: Name-bound Reuse
+
+This follow-up keeps the same registered `dev-up-mlx-metal-dist-info-scandir` probe and narrows the change to `read_mlx_metal_dist_info_version()`. The scan loop binds the `mlx_metal-` prefix, `.dist-info` suffix, their lengths, and each `entry.name` once before the match/fallback checks. This reduces repeated attribute lookups and literal-length work while preserving metadata-first version resolution and directory-name fallback behavior.
+
 ## Verification Commands
 
 ```text

--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -491,19 +491,24 @@ def _read_dist_info_metadata_version(metadata_path: Path) -> str | None:
 
 
 def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
+    dist_info_prefix = "mlx_metal-"
+    dist_info_suffix = ".dist-info"
+    dist_info_prefix_length = len(dist_info_prefix)
+    dist_info_suffix_length = len(dist_info_suffix)
     for ancestor in metallib_path.resolve().parents:
         fallback_version: str | None = None
         try:
             with os.scandir(ancestor) as entries:
                 for entry in entries:
+                    entry_name = entry.name
                     if not (
-                        entry.name.startswith("mlx_metal-")
-                        and entry.name.endswith(".dist-info")
+                        entry_name.startswith(dist_info_prefix)
+                        and entry_name.endswith(dist_info_suffix)
                         and entry.is_dir(follow_symlinks=False)
                     ):
                         continue
 
-                    metadata_path = ancestor / entry.name / "METADATA"
+                    metadata_path = ancestor / entry_name / "METADATA"
                     try:
                         version = _read_dist_info_metadata_version(metadata_path)
                     except OSError:
@@ -512,7 +517,9 @@ def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
                         return version
 
                     if fallback_version is None:
-                        fallback_candidate = entry.name[len("mlx_metal-") : -len(".dist-info")]
+                        fallback_candidate = entry_name[
+                            dist_info_prefix_length:-dist_info_suffix_length
+                        ]
                         if fallback_candidate:
                             fallback_version = fallback_candidate
         except OSError:


### PR DESCRIPTION
## Summary
- Reuse the `mlx_metal-` / `.dist-info` match bounds inside `read_mlx_metal_dist_info_version()`.
- Bind each `DirEntry.name` once before prefix/suffix checks and fallback slicing.
- Document this incremental Python-only dev-up performance slice under the existing dist-info scandir plan.

## Plan or Spec
- Updated `docs/plans/2026-05-02-dev-up-mlx-metal-dist-info-scandir.md` with the name-bound reuse follow-up.
- Registered probe coverage: `dev-up-mlx-metal-dist-info-scandir` in `infra/perf/pr_scoped_probes.json` already covers `scripts/dev_up.py`, focused tests, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_ignores_empty_dist_info_version services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_when_metadata_read_fails services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dev-up-mlx-metal-dist-info-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dev-up-dist-info-name-bounds-20260704 --head-repo "$PWD" --output /tmp/dev_up_dist_info_name_bounds_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed.
- Changed-scope coverage: 100.00% (`scripts/dev_up.py`: 7/7 changed measurable lines covered).
- Registered local probe (`dev-up-mlx-metal-dist-info-scandir`):
  - `elapsed_ms_mean`: base `0.999299` ms, head `0.977791` ms, delta `-0.021508` ms (`~2.15%` faster).
  - `elapsed_ms_min`: base `0.970981` ms, head `0.916279` ms, delta `-0.054702` ms (`~5.63%` faster).

## Known Gaps
- This is a Python-only Linux-local slice. It does not validate Swift runtime effects locally.
- GitHub Actions / PR-scoped performance CI must still run and validate the registered probe on the PR.

## Evidence Checklist
- [x] Synced from `origin/main` before branch creation.
- [x] Affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is >= 95%.
- [x] Registered local probe shows a positive metric direction.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance workflow completed successfully.
