### PR TITLE
Add multimodal speculative comparison artifacts

### DIFF
--- a/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
+++ b/docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md
@@ -624,6 +624,23 @@ Executable unit issues:
   and benchmark artifacts without emitting an optimistic success state before
   receipt gates pass. Plan 4.3 continues promotion evidence, comparison
   artifacts, Apple Silicon smoke probes, and default-on release gates.
+- Unit 4.3.1 adds matched baseline-vs-accelerated benchmark evidence for the
+  multimodal speculative decode route. VLM benchmarks run a baseline leg with
+  `melix.vlm.speculative_probe.enabled=false` and an accelerated leg with the
+  probe enabled plus the requested speculative acceleration policy. The
+  comparison artifact reuses the serving-diagnostics
+  `baseline-vs-accelerated.json` contract, including prefill and decode phase
+  rows for both legs, greedy sampler status, admission/fallback reason, and the
+  native acceleration receipt payload. The shared verifier blocks claim-eligible
+  artifacts when prompt protocol, prompt digest, prompt template digest, model
+  id, task kind, generation config, greedy sampler, or route stability differ.
+  Benchmark metrics expose speculative comparison validity, claim-blocked,
+  identity-match, route-stability, reason-code, baseline/accelerated TTFT and
+  decode throughput, and artifact-present status. A public speculative speed
+  claim remains blocked unless the accelerated receipt proves
+  `native_acceleration_runtime_active=true`; media-bearing verification-only
+  fallbacks therefore stay visible as blocked evidence until later Plan 4.3
+  smoke and release gates admit them.
 
 ## Verification Policy
 

--- a/docs/plans/2026-07-04-issue-1471-multimodal-speculative-comparison.md
+++ b/docs/plans/2026-07-04-issue-1471-multimodal-speculative-comparison.md
@@ -1,0 +1,483 @@
+# Issue 1471 Multimodal Speculative Comparison Artifact Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add claim-safe baseline-vs-accelerated comparison artifacts for multimodal speculative decode.
+
+**Architecture:** Reuse the existing serving-diagnostics `baseline-vs-accelerated.json` contract instead of introducing a second artifact schema. Extend the VLM benchmark comparison path so speculative-decode comparisons run the same matched baseline and accelerated sample flow as the existing image batch-1 comparison, while keeping identity, greedy-sampler, route-stability, admission, and fallback checks centralized.
+
+**Tech Stack:** Python worker maintenance benchmark code, existing serving-diagnostics artifact writer, pytest, changed-scope coverage, PR-scoped performance probes.
+
+---
+
+## Scope
+
+This plan implements GitHub issue #1471 and is governed by
+`docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`.
+
+The implementation must satisfy these acceptance criteria:
+
+- Comparison artifacts include baseline and accelerated phase rows for prefill and decode.
+- The verifier fails when prompt protocol, prompt digest, prompt template digest, model id, task kind, or generation config differ.
+- Artifacts record greedy sampler status and acceleration admission/fallback reason.
+
+## File Map
+
+- Modify `services/mlx-worker-python/worker/engine/maintenance_core.py`.
+  - Add speculative comparison execution ext constants.
+  - Refactor the existing VLM comparison writer/status metrics enough to support both image batch-1 and speculative comparison names without duplicating identity validation.
+  - Add `_vlm_speculative_comparison_metrics()` and `_write_vlm_speculative_comparison_artifact()`.
+- Modify `services/mlx-worker-python/tests/test_maintenance_service.py`.
+  - Add RED tests for the speculative artifact writer and metrics path before implementation.
+  - Keep existing image batch-1 comparison tests passing.
+- Modify `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`.
+  - Add a Unit 4.3.1 implementation note after the behavior is implemented.
+- Modify `infra/perf/pr_scoped_probes.json` only if changed files are not already covered by an existing focused probe selection.
+  - If the existing VLM comparison probe is already selected for `maintenance_core.py`, keep the registry unchanged so the PR does not force all probes.
+
+## Performance Probes And Metrics
+
+The changed path is benchmark/evidence generation, not request serving hot-path routing. The PR-scoped performance report must select the existing `vlm-batch1-comparison-artifact` or an updated VLM comparison probe for `maintenance_core.py`.
+
+Success metrics:
+
+- No in-scope performance regression in the PR-scoped performance report.
+- Speculative comparison metrics emit:
+  - `bench.<suite>.vlm_speculative_comparison_valid`
+  - `bench.<suite>.vlm_speculative_comparison_claim_blocked`
+  - `bench.<suite>.vlm_speculative_comparison_identity_match`
+  - `bench.<suite>.vlm_speculative_route_stability`
+  - `bench.<suite>.vlm_speculative_comparison_reason_code`
+  - baseline and accelerated TTFT/decode throughput rows when samples exist
+  - artifact-present metric when the artifact is written
+
+## Task 1: Add RED tests for speculative artifact writing
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/tests/test_maintenance_service.py`
+
+- [ ] **Step 1: Add a speculative sample helper**
+
+Add a helper beside `_vlm_batch1_comparison_sample()`:
+
+```python
+def _vlm_speculative_comparison_sample(
+    *,
+    prompt_digest: str = "sha256:prompt-a",
+    status: str = "admitted",
+    fallback_reason: str = "",
+    runtime_active: bool = True,
+    acceleration_mode: str = "speculative_decode",
+) -> maintenance_core_module.BenchSample:
+    return maintenance_core_module.BenchSample(
+        ttft_ms=11.0 if runtime_active else 20.0,
+        total_latency_ms=32.0 if runtime_active else 60.0,
+        completion_tokens=4,
+        decode_tokens_per_second=190.0 if runtime_active else 100.0,
+        prefill_ms=11.0 if runtime_active else 20.0,
+        decode_ms=21.0 if runtime_active else 40.0,
+        multimodal_decode_mode="single_stream",
+        multimodal_fallback_reason=fallback_reason,
+        model_id="melix-dev-vlm",
+        task_kind="image-text-to-text",
+        prompt_protocol_id="melix.vlm.benchmark.v1",
+        prompt_digest=prompt_digest,
+        prompt_template_digest="sha256:template-a",
+        generation_config_digest="config-a",
+        generation_config_json=json.dumps(
+            {"temperature": 0.0, "top_p": 1.0, "top_k": 1, "max_output_tokens": 8},
+            sort_keys=True,
+        ),
+        route_stability_status="stable",
+        acceleration_mode=acceleration_mode,
+        native_acceleration_status=status,
+        native_acceleration_mode="speculative_decode",
+        native_acceleration_runtime_active=runtime_active,
+        native_acceleration_draft_supported=True,
+        native_acceleration_effective_depth=4,
+        native_acceleration_request_gate="media_draft_eligible",
+        native_acceleration_runtime_scope="vlm_mtp",
+        native_acceleration_fallback_reason=fallback_reason,
+        native_acceleration_rounds=3 if runtime_active else 0,
+        native_acceleration_accepted_tokens=9 if runtime_active else 0,
+        native_acceleration_rejected_tokens=3 if runtime_active else 0,
+        native_acceleration_acceptance_rate=0.75 if runtime_active else 0.0,
+        native_acceleration_rollback_rate=0.25 if runtime_active else 0.0,
+        native_acceleration_draft_propose_ms=12.5 if runtime_active else 0.0,
+        native_acceleration_target_verify_ms=25.0 if runtime_active else 0.0,
+        native_acceleration_autoregressive_fallback=not runtime_active,
+        native_acceleration_sampling_matches_baseline=True,
+    )
+```
+
+- [ ] **Step 2: Add the RED writer test**
+
+Add:
+
+```python
+def test_vlm_speculative_comparison_artifact_records_native_acceleration(tmp_path: Path) -> None:
+    baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    accelerated = _vlm_speculative_comparison_sample()
+
+    paths = MaintenanceCore._write_vlm_speculative_comparison_artifact(
+        output_dir=tmp_path,
+        comparison_id="cmp-speculative",
+        baseline=baseline,
+        accelerated=accelerated,
+    )
+
+    payload = json.loads(paths["comparison"].read_text(encoding="utf-8"))
+    assert payload["comparison_validity"] == "valid"
+    assert payload["methodology"]["sampler_is_greedy"] is True
+    assert payload["runs"]["baseline"]["acceleration_mode"] == "baseline"
+    assert payload["runs"]["baseline"]["fallback_reason"] == "operator_disabled"
+    assert payload["runs"]["accelerated"]["acceleration_mode"] == "speculative_decode"
+    assert payload["runs"]["accelerated"]["acceleration_admitted"] is True
+    assert payload["runs"]["accelerated"]["native_acceleration"]["runtime_active"] is True
+    assert payload["runs"]["accelerated"]["native_acceleration"]["forward_counts"] == {
+        "accepted_tokens": 9,
+        "rejected_tokens": 3,
+        "rounds": 3,
+    }
+    assert {row["phase"] for row in payload["phase_rows"]} == {"prefill", "decode"}
+```
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_artifact_records_native_acceleration
+```
+
+Expected: fail with `AttributeError` because `_write_vlm_speculative_comparison_artifact` does not exist.
+
+## Task 2: Implement speculative artifact writer
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/engine/maintenance_core.py`
+
+- [ ] **Step 1: Add the writer**
+
+Add a static method near `_write_vlm_batch1_comparison_artifact()`:
+
+```python
+@staticmethod
+def _write_vlm_speculative_comparison_artifact(
+    *,
+    output_dir: Path,
+    comparison_id: str,
+    baseline: BenchSample,
+    accelerated: BenchSample,
+) -> dict[str, Path]:
+    return write_baseline_accelerated_evidence(
+        output_root=output_dir,
+        comparison_id=comparison_id,
+        baseline=MaintenanceCore._vlm_sample_evidence_run(
+            sample=baseline,
+            acceleration_mode="baseline",
+        ),
+        accelerated=MaintenanceCore._vlm_sample_evidence_run(
+            sample=accelerated,
+            acceleration_mode=accelerated.acceleration_mode or "speculative_decode",
+        ),
+    )
+```
+
+- [ ] **Step 2: Verify GREEN**
+
+Run the RED test again.
+
+Expected: pass.
+
+## Task 3: Add RED tests for speculative comparison metrics
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/tests/test_maintenance_service.py`
+
+- [ ] **Step 1: Add metrics success test**
+
+Add:
+
+```python
+def test_vlm_speculative_comparison_metrics_writes_matched_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    core = MaintenanceCore.__new__(MaintenanceCore)
+    suite = SimpleNamespace(
+        suite_id="smoke",
+        cases=(SimpleNamespace(prompt="what is this?", image_uris=("image.png",)),),
+    )
+    baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    accelerated = _vlm_speculative_comparison_sample()
+    samples = iter((baseline, accelerated))
+    seen_ext: list[dict[str, str] | None] = []
+
+    def fake_measure(**kwargs):
+        seen_ext.append(kwargs.get("execution_ext"))
+        return next(samples)
+
+    monkeypatch.setattr(core, "_measure_vlm_bench_sample", fake_measure)
+
+    metrics = core._vlm_speculative_comparison_metrics(
+        loaded_model=SimpleNamespace(),
+        suite=suite,
+        parameters={},
+        job_id="job-1",
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        output_dir=tmp_path,
+    )
+
+    metric_by_name = {metric.name: metric for metric in metrics}
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_valid"].value == 1.0
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_claim_blocked"].value == 0.0
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_artifact_present"].value == 1.0
+    assert seen_ext == [
+        {"melix.vlm.speculative_probe.enabled": "false"},
+        {"melix.vlm.speculative_probe.enabled": "true"},
+    ]
+```
+
+- [ ] **Step 2: Add blocked-route test**
+
+Add:
+
+```python
+def test_vlm_speculative_comparison_metrics_blocks_when_speculative_not_runtime_active(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    core = MaintenanceCore.__new__(MaintenanceCore)
+    suite = SimpleNamespace(
+        suite_id="smoke",
+        cases=(SimpleNamespace(prompt="what is this?", image_uris=("image.png",)),),
+    )
+    baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    accelerated = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="unsupported_route",
+        runtime_active=False,
+    )
+    samples = iter((baseline, accelerated))
+
+    monkeypatch.setattr(core, "_measure_vlm_bench_sample", lambda **_kwargs: next(samples))
+
+    metrics = core._vlm_speculative_comparison_metrics(
+        loaded_model=SimpleNamespace(),
+        suite=suite,
+        parameters={},
+        job_id="job-1",
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        output_dir=tmp_path,
+    )
+
+    metric_by_name = {metric.name: metric for metric in metrics}
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_valid"].value == 0.0
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_claim_blocked"].value == 1.0
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_reason_code"].value == 9.0
+```
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_writes_matched_artifact services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_blocks_when_speculative_not_runtime_active
+```
+
+Expected: fail with `AttributeError` because `_vlm_speculative_comparison_metrics` does not exist.
+
+## Task 4: Implement speculative comparison metrics
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/engine/maintenance_core.py`
+
+- [ ] **Step 1: Add constants**
+
+Add near the existing VLM comparison constants:
+
+```python
+_VLM_SPECULATIVE_BASELINE_EXT = {"melix.vlm.speculative_probe.enabled": "false"}
+_VLM_SPECULATIVE_ACCELERATED_EXT = {"melix.vlm.speculative_probe.enabled": "true"}
+```
+
+- [ ] **Step 2: Add metrics method**
+
+Add `_vlm_speculative_comparison_metrics()` near `_vlm_batch1_comparison_metrics()`. It should:
+
+- return `[]` when `vlm_speculative_compare` is explicitly falsey
+- return blocked status metrics when `output_dir`, `job_id`, or `suite.cases` is missing
+- measure the first case twice with baseline and accelerated speculative ext
+- block if the accelerated sample is not `native_acceleration_runtime_active`
+- write the speculative comparison artifact through `_write_vlm_speculative_comparison_artifact()`
+- convert `ServingDiagnosticsComparisonError` into blocked status metrics
+
+- [ ] **Step 3: Add status metrics helper**
+
+Add `_vlm_speculative_comparison_status_metrics()` mirroring the existing batch-1 helper but using `vlm_speculative_*` metric names.
+
+- [ ] **Step 4: Add reason-code helper**
+
+Add `_vlm_speculative_comparison_reason_code()` with the same identity and sampler codes as batch-1, plus:
+
+- `speculative_route_not_runtime_active` -> `9.0`
+- `comparison_artifact_context_missing` -> `99.0`
+
+- [ ] **Step 5: Verify GREEN**
+
+Run the two RED metrics tests again.
+
+Expected: pass.
+
+## Task 5: Wire speculative metrics into VLM benchmark mode
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- Modify: `services/mlx-worker-python/tests/test_maintenance_service.py`
+
+- [ ] **Step 1: Add RED integration assertion**
+
+Extend `test_bench_events_vlm_mode_produces_vlm_metrics()` to assert that VLM benchmark events include:
+
+```python
+assert "bench.smoke.vlm_speculative_comparison_valid" in metric_names
+assert "bench.smoke.vlm_speculative_comparison_claim_blocked" in metric_names
+```
+
+and default blocked values:
+
+```python
+assert metrics_by_name["bench.smoke.vlm_speculative_comparison_valid"] == 0.0
+assert metrics_by_name["bench.smoke.vlm_speculative_comparison_claim_blocked"] == 1.0
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run the single integration test.
+
+Expected: fail because the new metric names are absent.
+
+- [ ] **Step 3: Wire metrics into `_measure_vlm_bench_metrics()`**
+
+Append `_vlm_speculative_comparison_metrics()` to the existing comparison metrics list.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run the single integration test again.
+
+Expected: pass.
+
+## Task 6: Update docs and performance probe coverage
+
+**Files:**
+
+- Modify: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
+- Modify if needed: `infra/perf/pr_scoped_probes.json`
+- Modify if needed: `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+- [ ] **Step 1: Add Unit 4.3.1 implementation note**
+
+Record that the unit reuses the serving-diagnostics comparison artifact, records speculative native acceleration receipts, and blocks claims when identity, greedy sampling, route stability, or speculative runtime-active admission fail.
+
+- [ ] **Step 2: Check PR-scoped probe selection**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_vlm_batch1_comparison_probe
+```
+
+The existing probe is selected by `maintenance_core.py`. Do not edit the probe
+registry solely to add the new test names because registry changes intentionally
+select all probes. Instead, run the explicit focused and coverage commands below
+and let the existing VLM comparison probe provide scoped performance coverage.
+
+## Task 7: Verification, coverage, commit, and PR
+
+**Files:**
+
+- All changed files.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_artifact_records_native_acceleration \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_artifact_requires_matched_identity \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_writes_matched_artifact \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_blocks_when_speculative_not_runtime_active \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_blocks_disabled_missing_context_and_identity_errors \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_policy_and_runtime_signature_edges \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_bench_sample_passes_acceleration_policy_when_runtime_supports_it \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_reason_code_covers_blockers \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_bench_events_vlm_mode_produces_vlm_metrics
+```
+
+- [ ] **Step 2: Run changed-scope coverage**
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_batch1_comparison_artifact_requires_matched_identity \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_batch1_comparison_artifact_records_route_metrics \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_batch1_comparison_metrics_blocks_missing_context_and_identity_errors \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_batch1_comparison_metrics_writes_matched_artifact \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_artifact_records_native_acceleration \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_artifact_requires_matched_identity \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_writes_matched_artifact \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_blocks_when_speculative_not_runtime_active \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_metrics_blocks_disabled_missing_context_and_identity_errors \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_policy_and_runtime_signature_edges \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_bench_sample_passes_acceleration_policy_when_runtime_supports_it \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_speculative_comparison_reason_code_covers_blockers \
+  services/mlx-worker-python/tests/test_maintenance_service.py::test_bench_events_vlm_mode_produces_vlm_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/engine/maintenance_core.py \
+  services/mlx-worker-python/tests/test_maintenance_service.py
+```
+
+Expected: changed-scope coverage at or above 95 percent.
+
+- [ ] **Step 3: Run diff and full local gate through commit**
+
+```bash
+git diff --check
+git add docs/plans/2026-07-04-issue-1471-multimodal-speculative-comparison.md \
+  docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md \
+  services/mlx-worker-python/worker/engine/maintenance_core.py \
+  services/mlx-worker-python/tests/test_maintenance_service.py
+git commit -m "Add multimodal speculative comparison artifacts"
+```
+
+Expected: pre-commit full local gate passes and scoped performance report reports `Status: ok` with no regressions.
+
+- [ ] **Step 4: Create PR**
+
+Use the repository PR template with `Closes #1471`, local command evidence, changed-scope coverage, and scoped performance report.
+
+- [ ] **Step 5: Merge lifecycle**
+
+Wait for CI, PR evidence, review threads, and performance report. Fetch `origin/main` before merge, merge `origin/main` into the branch if it advanced, re-verify if needed, then squash merge only after CI/performance report are green and there are no regressions.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -5738,6 +5738,26 @@ def test_vlm_batch1_comparison_artifact_requires_matched_identity(tmp_path: Path
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_identity_match"].value == 0.0
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_reason_code"].value == 2.0
 
+    speculative_baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    speculative_accelerated = _vlm_speculative_comparison_sample(
+        prompt_digest="sha256:prompt-b"
+    )
+    with pytest.raises(
+        maintenance_core_module.ServingDiagnosticsComparisonError,
+        match="prompt_digest",
+    ):
+        MaintenanceCore._write_vlm_speculative_comparison_artifact(
+            output_dir=tmp_path,
+            comparison_id="cmp-speculative-mismatch",
+            baseline=speculative_baseline,
+            accelerated=speculative_accelerated,
+        )
+
 
 def test_vlm_batch1_comparison_artifact_records_route_metrics(tmp_path: Path) -> None:
     generation_config_json = json.dumps(
@@ -5851,6 +5871,49 @@ def test_vlm_batch1_comparison_artifact_records_route_metrics(tmp_path: Path) ->
     assert metrics_by_name["bench.smoke.vlm_batch1_fast_path_decode_tokens_per_second"].value == 166.7
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_artifact_present"].value == 1.0
 
+    speculative_baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    speculative_accelerated = _vlm_speculative_comparison_sample()
+    speculative_paths = MaintenanceCore._write_vlm_speculative_comparison_artifact(
+        output_dir=tmp_path,
+        comparison_id="cmp-speculative",
+        baseline=speculative_baseline,
+        accelerated=speculative_accelerated,
+    )
+    speculative_payload = json.loads(
+        speculative_paths["comparison"].read_text(encoding="utf-8")
+    )
+    assert speculative_payload["comparison_validity"] == "valid"
+    assert speculative_payload["methodology"]["sampler_is_greedy"] is True
+    assert speculative_payload["runs"]["baseline"]["acceleration_mode"] == "baseline"
+    assert speculative_payload["runs"]["baseline"]["fallback_reason"] == "operator_disabled"
+    assert (
+        speculative_payload["runs"]["accelerated"]["acceleration_mode"]
+        == "speculative_decode"
+    )
+    assert speculative_payload["runs"]["accelerated"]["acceleration_admitted"] is True
+    assert (
+        speculative_payload["runs"]["accelerated"]["native_acceleration"]["runtime_active"]
+        is True
+    )
+    assert speculative_payload["runs"]["accelerated"]["native_acceleration"]["forward_counts"] == {
+        "accepted_tokens": 9,
+        "rejected_tokens": 3,
+        "rounds": 3,
+    }
+    speculative_phase_rows = {
+        row["phase"]: row for row in speculative_payload["phase_rows"]
+    }
+    assert set(speculative_phase_rows) == {"prefill", "decode"}
+    assert speculative_phase_rows["prefill"]["baseline"] == 20.0
+    assert speculative_phase_rows["prefill"]["accelerated"] == 11.0
+    assert speculative_phase_rows["decode"]["baseline"] == 40.0
+    assert speculative_phase_rows["decode"]["accelerated"] == 21.0
+
 
 def _vlm_batch1_comparison_sample(
     *,
@@ -5880,6 +5943,55 @@ def _vlm_batch1_comparison_sample(
         ),
         route_stability_status="stable",
         acceleration_mode=acceleration_mode,
+    )
+
+
+def _vlm_speculative_comparison_sample(
+    *,
+    prompt_digest: str = "sha256:prompt-a",
+    status: str = "admitted",
+    fallback_reason: str = "",
+    runtime_active: bool = True,
+    acceleration_mode: str = "speculative_decode",
+) -> maintenance_core_module.BenchSample:
+    return maintenance_core_module.BenchSample(
+        ttft_ms=11.0 if runtime_active else 20.0,
+        total_latency_ms=32.0 if runtime_active else 60.0,
+        completion_tokens=4,
+        decode_tokens_per_second=190.0 if runtime_active else 100.0,
+        prefill_ms=11.0 if runtime_active else 20.0,
+        decode_ms=21.0 if runtime_active else 40.0,
+        multimodal_decode_mode="single_stream",
+        multimodal_fallback_reason=fallback_reason,
+        model_id="melix-dev-vlm",
+        task_kind="image-text-to-text",
+        prompt_protocol_id="melix.vlm.benchmark.v1",
+        prompt_digest=prompt_digest,
+        prompt_template_digest="sha256:template-a",
+        generation_config_digest="config-a",
+        generation_config_json=json.dumps(
+            {"temperature": 0.0, "top_p": 1.0, "top_k": 1, "max_output_tokens": 8},
+            sort_keys=True,
+        ),
+        route_stability_status="stable",
+        acceleration_mode=acceleration_mode,
+        native_acceleration_status=status,
+        native_acceleration_mode="speculative_decode",
+        native_acceleration_runtime_active=runtime_active,
+        native_acceleration_draft_supported=True,
+        native_acceleration_effective_depth=4,
+        native_acceleration_request_gate="media_draft_eligible",
+        native_acceleration_runtime_scope="vlm_mtp",
+        native_acceleration_fallback_reason=fallback_reason,
+        native_acceleration_rounds=3 if runtime_active else 0,
+        native_acceleration_accepted_tokens=9 if runtime_active else 0,
+        native_acceleration_rejected_tokens=3 if runtime_active else 0,
+        native_acceleration_acceptance_rate=0.75 if runtime_active else 0.0,
+        native_acceleration_rollback_rate=0.25 if runtime_active else 0.0,
+        native_acceleration_draft_propose_ms=12.5 if runtime_active else 0.0,
+        native_acceleration_target_verify_ms=25.0 if runtime_active else 0.0,
+        native_acceleration_autoregressive_fallback=not runtime_active,
+        native_acceleration_sampling_matches_baseline=True,
     )
 
 
@@ -5948,6 +6060,127 @@ def test_vlm_batch1_comparison_metrics_blocks_missing_context_and_identity_error
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_identity_match"].value == 0.0
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_reason_code"].value == 2.0
 
+    assert (
+        core._vlm_speculative_comparison_metrics(
+            loaded_model=SimpleNamespace(),
+            suite=suite,
+            parameters={"vlm_speculative_compare": "false"},
+            job_id="job-1",
+            source_repo="repo",
+            task_kind="image-text-to-text",
+            output_dir=tmp_path,
+        )
+        == []
+    )
+    speculative_missing_context = core._vlm_speculative_comparison_metrics(
+        loaded_model=SimpleNamespace(),
+        suite=suite,
+        parameters={},
+        job_id="",
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        output_dir=None,
+    )
+    speculative_missing_by_name = {
+        metric.name: metric for metric in speculative_missing_context
+    }
+    assert (
+        speculative_missing_by_name[
+            "bench.smoke.vlm_speculative_comparison_claim_blocked"
+        ].value
+        == 1.0
+    )
+    assert (
+        speculative_missing_by_name[
+            "bench.smoke.vlm_speculative_comparison_reason_code"
+        ].value
+        == 99.0
+    )
+
+    speculative_baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    speculative_accelerated = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="unsupported_route",
+        runtime_active=False,
+    )
+    samples = iter((speculative_baseline, speculative_accelerated))
+    monkeypatch.setattr(core, "_measure_vlm_bench_sample", lambda **_kwargs: next(samples))
+    speculative_runtime_block = core._vlm_speculative_comparison_metrics(
+        loaded_model=SimpleNamespace(),
+        suite=suite,
+        parameters={},
+        job_id="job-1",
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        output_dir=tmp_path,
+    )
+    speculative_runtime_by_name = {
+        metric.name: metric for metric in speculative_runtime_block
+    }
+    assert (
+        speculative_runtime_by_name["bench.smoke.vlm_speculative_comparison_valid"].value
+        == 0.0
+    )
+    assert (
+        speculative_runtime_by_name[
+            "bench.smoke.vlm_speculative_comparison_claim_blocked"
+        ].value
+        == 1.0
+    )
+    assert (
+        speculative_runtime_by_name[
+            "bench.smoke.vlm_speculative_comparison_reason_code"
+        ].value
+        == 9.0
+    )
+
+    speculative_baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    speculative_accelerated = _vlm_speculative_comparison_sample(
+        prompt_digest="sha256:prompt-b"
+    )
+    samples = iter((speculative_baseline, speculative_accelerated))
+    monkeypatch.setattr(core, "_measure_vlm_bench_sample", lambda **_kwargs: next(samples))
+    speculative_identity_error = core._vlm_speculative_comparison_metrics(
+        loaded_model=SimpleNamespace(),
+        suite=suite,
+        parameters={},
+        job_id="job-1",
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        output_dir=tmp_path,
+    )
+    speculative_identity_by_name = {
+        metric.name: metric for metric in speculative_identity_error
+    }
+    assert (
+        speculative_identity_by_name[
+            "bench.smoke.vlm_speculative_comparison_claim_blocked"
+        ].value
+        == 1.0
+    )
+    assert (
+        speculative_identity_by_name[
+            "bench.smoke.vlm_speculative_comparison_identity_match"
+        ].value
+        == 0.0
+    )
+    assert (
+        speculative_identity_by_name[
+            "bench.smoke.vlm_speculative_comparison_reason_code"
+        ].value
+        == 2.0
+    )
+
 
 def test_vlm_batch1_comparison_metrics_writes_matched_artifact(
     monkeypatch: pytest.MonkeyPatch,
@@ -5989,6 +6222,47 @@ def test_vlm_batch1_comparison_metrics_writes_matched_artifact(
     artifact_paths = list((tmp_path / "serving-diagnostics").glob("*/baseline-vs-accelerated.json"))
     assert artifact_paths
 
+    speculative_baseline = _vlm_speculative_comparison_sample(
+        status="fallback",
+        fallback_reason="operator_disabled",
+        runtime_active=False,
+        acceleration_mode="baseline",
+    )
+    speculative_accelerated = _vlm_speculative_comparison_sample()
+    samples = iter((speculative_baseline, speculative_accelerated))
+    seen_ext: list[dict[str, str] | None] = []
+
+    def fake_measure(**kwargs):
+        seen_ext.append(kwargs.get("execution_ext"))
+        return next(samples)
+
+    monkeypatch.setattr(core, "_measure_vlm_bench_sample", fake_measure)
+
+    metrics = core._vlm_speculative_comparison_metrics(
+        loaded_model=SimpleNamespace(),
+        suite=suite,
+        parameters={},
+        job_id="job-1",
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        output_dir=tmp_path,
+    )
+
+    metric_by_name = {metric.name: metric for metric in metrics}
+    assert metric_by_name["bench.smoke.vlm_speculative_comparison_valid"].value == 1.0
+    assert (
+        metric_by_name["bench.smoke.vlm_speculative_comparison_claim_blocked"].value
+        == 0.0
+    )
+    assert (
+        metric_by_name["bench.smoke.vlm_speculative_comparison_artifact_present"].value
+        == 1.0
+    )
+    assert seen_ext == [
+        {"melix.vlm.speculative_probe.enabled": "false"},
+        {"melix.vlm.speculative_probe.enabled": "true"},
+    ]
+
 
 @pytest.mark.parametrize(
     ("reason", "code"),
@@ -6009,6 +6283,12 @@ def test_vlm_batch1_comparison_reason_code_covers_blockers(
     code: float,
 ) -> None:
     assert MaintenanceCore._vlm_batch1_comparison_reason_code(reason) == code
+    speculative_reason = (
+        "speculative_route_not_runtime_active"
+        if reason == "fast_path_route_not_selected"
+        else reason
+    )
+    assert MaintenanceCore._vlm_speculative_comparison_reason_code(speculative_reason) == code
 
 
 def test_vlm_sample_evidence_run_treats_invalid_generation_config_as_empty() -> None:
@@ -6057,6 +6337,141 @@ def test_vlm_sample_evidence_run_treats_invalid_generation_config_as_empty() -> 
     assert template_digest == MaintenanceCore._vlm_benchmark_prompt_template_digest(
         loaded_model=SimpleNamespace(handle="melix-dev-vlm::loaded", runtime_model={}),
     )
+
+    invalid_policy = MaintenanceCore._vlm_speculative_comparison_policy(
+        {
+            "vlm_speculative_draft_model_id": " draft-model ",
+            "vlm_speculative_num_draft_tokens": "not-an-int",
+        }
+    )
+    assert invalid_policy.draft_model_id == "draft-model"
+    assert invalid_policy.num_draft_tokens == 6
+
+    negative_policy = MaintenanceCore._vlm_speculative_comparison_policy(
+        {"draft_model_id": "fallback-draft", "num_draft_tokens": "-4"}
+    )
+    assert negative_policy.draft_model_id == "fallback-draft"
+    assert negative_policy.num_draft_tokens == 0
+
+    class ExplicitPolicyRuntime:
+        def generate_tokens(self, *, acceleration_policy=None):
+            return ()
+
+    class KwargsRuntime:
+        def generate_tokens(self, **kwargs):
+            return ()
+
+    class UnsupportedRuntime:
+        generate_tokens = 1
+
+    assert MaintenanceCore._runtime_generate_accepts_acceleration_policy(
+        ExplicitPolicyRuntime()
+    )
+    assert MaintenanceCore._runtime_generate_accepts_acceleration_policy(KwargsRuntime())
+    assert not MaintenanceCore._runtime_generate_accepts_acceleration_policy(
+        UnsupportedRuntime()
+    )
+
+    class PolicyAwareRuntime:
+        def __init__(self) -> None:
+            self.seen_acceleration_policy = None
+            self.seen_generation_ext = None
+
+        def render_prompt(self, messages, *, loaded_model, execution_ext):
+            assert messages
+            assert loaded_model == {"model": "loaded"}
+            assert execution_ext == {"probe": "enabled"}
+            return "prepared"
+
+        def generate_tokens(
+            self,
+            runtime_model,
+            prepared,
+            sampling,
+            cancel_event,
+            *,
+            execution_ext=None,
+            acceleration_policy=None,
+        ):
+            assert runtime_model == {"model": "loaded"}
+            assert prepared == "prepared"
+            assert sampling.temperature == 0.0
+            assert cancel_event is not None
+            self.seen_generation_ext = execution_ext
+            self.seen_acceleration_policy = acceleration_policy
+            yield SimpleNamespace(text="ok", completion_tokens=1)
+
+        def last_probe_snapshot(self):
+            return SimpleNamespace(
+                multimodal_decode_mode="single_stream",
+                multimodal_fallback_reason="",
+                multimodal_decode_sync_mode="baseline",
+                speculative_probe_receipt={
+                    "enabled": True,
+                    "status": "admitted",
+                    "mode": "speculative_decode",
+                    "draft_supported": True,
+                    "output_mutation_allowed": True,
+                    "draft_loaded": True,
+                    "target_decode_started": True,
+                    "effective_depth": 4,
+                    "request_gate": "media_draft_eligible",
+                    "runtime_scope": "vlm_mtp",
+                    "rounds": 1,
+                    "accepted_tokens": 1,
+                    "rejected_tokens": 0,
+                    "acceptance_rate": 1.0,
+                    "rollback_rate": 0.0,
+                    "draft_propose_ms": 1.2,
+                    "target_verify_ms": 2.4,
+                    "sampling_matches_baseline": True,
+                },
+            )
+
+    class PolicyAwareRegistry:
+        def __init__(self, runtime: PolicyAwareRuntime) -> None:
+            self.runtime = runtime
+            self.finished_request_ids: list[str] = []
+
+        def runtime_for_loaded_model(self, loaded_model):
+            return self.runtime
+
+        def start_request(self, *, request_id, runtime_kind):
+            assert runtime_kind == "vlm"
+            return SimpleNamespace(cancel_event=threading.Event())
+
+        def finish_request(self, request_id):
+            self.finished_request_ids.append(request_id)
+
+    runtime = PolicyAwareRuntime()
+    registry = PolicyAwareRegistry(runtime)
+    core = MaintenanceCore.__new__(MaintenanceCore)
+    core._registry = registry
+    policy = MaintenanceCore._vlm_speculative_comparison_policy(
+        {"draft_model_id": "draft-model", "num_draft_tokens": "4"}
+    )
+
+    sample = core._measure_vlm_bench_sample(
+        loaded_model=SimpleNamespace(
+            handle="melix-dev-vlm::loaded",
+            runtime_model={"model": "loaded"},
+            runtime_kind="vlm",
+        ),
+        suite=SimpleNamespace(suite_id="smoke"),
+        case=SimpleNamespace(prompt="what is this?", image_uris=("image.png",)),
+        parameters={},
+        execution_ext={"probe": "enabled"},
+        acceleration_policy=policy,
+        source_repo="repo",
+        task_kind="image-text-to-text",
+        route_label="speculative_decode",
+    )
+
+    assert runtime.seen_acceleration_policy is policy
+    assert runtime.seen_generation_ext == {"probe": "enabled"}
+    assert registry.finished_request_ids
+    assert sample.native_acceleration_runtime_active is True
+    assert sample.acceleration_mode == "speculative_decode"
 
 
 def test_vlm_fast_path_bench_metrics_warns_for_unmapped_decode_mode(caplog) -> None:
@@ -8343,6 +8758,8 @@ def test_bench_events_vlm_mode_produces_vlm_metrics(tmp_path: Path) -> None:
     assert "bench.smoke.quantized_load_fallback_reason" in metric_names
     assert "bench.smoke.vlm_batch1_comparison_valid" in metric_names
     assert "bench.smoke.vlm_batch1_comparison_claim_blocked" in metric_names
+    assert "bench.smoke.vlm_speculative_comparison_valid" in metric_names
+    assert "bench.smoke.vlm_speculative_comparison_claim_blocked" in metric_names
     assert "bench.smoke.ttft_ms" not in metric_names
 
     metrics_by_name = {
@@ -8352,6 +8769,8 @@ def test_bench_events_vlm_mode_produces_vlm_metrics(tmp_path: Path) -> None:
     }
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_valid"] == 0.0
     assert metrics_by_name["bench.smoke.vlm_batch1_comparison_claim_blocked"] == 1.0
+    assert metrics_by_name["bench.smoke.vlm_speculative_comparison_valid"] == 0.0
+    assert metrics_by_name["bench.smoke.vlm_speculative_comparison_claim_blocked"] == 1.0
 
     report_event = next(event for event in events if event.HasField("completed"))
     report_content = Path(report_event.completed.report_path).read_text(encoding="utf-8")

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -6364,6 +6364,9 @@ def test_vlm_sample_evidence_run_treats_invalid_generation_config_as_empty() -> 
     class UnsupportedRuntime:
         generate_tokens = 1
 
+    class MissingGenerateRuntime:
+        pass
+
     assert MaintenanceCore._runtime_generate_accepts_acceleration_policy(
         ExplicitPolicyRuntime()
     )
@@ -6371,6 +6374,10 @@ def test_vlm_sample_evidence_run_treats_invalid_generation_config_as_empty() -> 
     assert not MaintenanceCore._runtime_generate_accepts_acceleration_policy(
         UnsupportedRuntime()
     )
+    assert not MaintenanceCore._runtime_generate_accepts_acceleration_policy(
+        MissingGenerateRuntime()
+    )
+    assert not MaintenanceCore._runtime_generate_accepts_acceleration_policy(None)
 
     class PolicyAwareRuntime:
         def __init__(self) -> None:

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -4445,7 +4445,7 @@ class MaintenanceCore:
     def _runtime_generate_accepts_acceleration_policy(runtime) -> bool:
         try:
             parameters = inspect.signature(runtime.generate_tokens).parameters
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, AttributeError):
             return False
         return "acceleration_policy" in parameters or any(
             parameter.kind is inspect.Parameter.VAR_KEYWORD

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 from dataclasses import dataclass
 from functools import lru_cache
@@ -65,6 +66,8 @@ _CAPABILITY_SUPPORTED_PARSERS_KEY = "melix.capability.supported_parsers"
 _VLM_BATCH1_COMPARISON_PROMPT_PROTOCOL = "melix.vlm.benchmark.v1"
 _VLM_BATCH1_BASELINE_EXT = {"melix.vlm.image_batch1_step.enabled": "false"}
 _VLM_BATCH1_FAST_PATH_EXT = {"melix.vlm.image_batch1_step.enabled": "true"}
+_VLM_SPECULATIVE_BASELINE_EXT = {"melix.vlm.speculative_probe.enabled": "false"}
+_VLM_SPECULATIVE_ACCELERATED_EXT = {"melix.vlm.speculative_probe.enabled": "true"}
 
 logger = logging.getLogger(__name__)
 
@@ -3936,6 +3939,14 @@ class MaintenanceCore:
             source_repo=source_repo,
             task_kind=task_kind,
             output_dir=output_dir,
+        ) + self._vlm_speculative_comparison_metrics(
+            loaded_model=loaded_model,
+            suite=suite,
+            parameters=parameters,
+            job_id=job_id,
+            source_repo=source_repo,
+            task_kind=task_kind,
+            output_dir=output_dir,
         )
         if suite.suite_id == "latency":
             total_latencies = [sample.total_latency_ms for sample in samples]
@@ -3985,6 +3996,7 @@ class MaintenanceCore:
         case,
         parameters: dict[str, str],
         execution_ext: dict[str, str] | None = None,
+        acceleration_policy: common_pb2.AccelerationPolicy | None = None,
         source_repo: str = "",
         task_kind: str = "image-text-to-text",
         route_label: str = "",
@@ -4033,12 +4045,18 @@ class MaintenanceCore:
                 max_output_tokens=self._benchmark_max_output_tokens(parameters),
             )
             generation_config = self._vlm_benchmark_generation_config(sampling)
+            generate_kwargs: dict[str, object] = {"execution_ext": execution_ext or {}}
+            if (
+                acceleration_policy is not None
+                and self._runtime_generate_accepts_acceleration_policy(runtime)
+            ):
+                generate_kwargs["acceleration_policy"] = acceleration_policy
             for runtime_event in runtime.generate_tokens(
                 loaded_model.runtime_model,
                 prepared,
                 sampling,
                 cancel_event,
-                execution_ext=execution_ext or {},
+                **generate_kwargs,
             ):
                 text = getattr(runtime_event, "text", "")
                 if not text:
@@ -4322,6 +4340,118 @@ class MaintenanceCore:
             comparison_path=str(paths["comparison"]),
         )
 
+    def _vlm_speculative_comparison_metrics(
+        self,
+        *,
+        loaded_model,
+        suite: ResolvedBenchmarkSuite,
+        parameters: dict[str, str],
+        job_id: str,
+        source_repo: str,
+        task_kind: str,
+        output_dir: Path | None,
+    ) -> list[BenchMetricSpec]:
+        if self._falsey_parameter(parameters, "vlm_speculative_compare"):
+            return []
+        if output_dir is None or not job_id or not suite.cases:
+            return self._vlm_speculative_comparison_status_metrics(
+                suite_id=suite.suite_id,
+                valid=False,
+                blocked=True,
+                reason="comparison_artifact_context_missing",
+            )
+        case = suite.cases[0]
+        baseline = self._measure_vlm_bench_sample(
+            loaded_model=loaded_model,
+            suite=suite,
+            case=case,
+            parameters=parameters,
+            execution_ext=_VLM_SPECULATIVE_BASELINE_EXT,
+            source_repo=source_repo,
+            task_kind=task_kind,
+            route_label="baseline",
+        )
+        accelerated = self._measure_vlm_bench_sample(
+            loaded_model=loaded_model,
+            suite=suite,
+            case=case,
+            parameters=parameters,
+            execution_ext=_VLM_SPECULATIVE_ACCELERATED_EXT,
+            acceleration_policy=self._vlm_speculative_comparison_policy(parameters),
+            source_repo=source_repo,
+            task_kind=task_kind,
+            route_label="speculative_decode",
+        )
+        if not accelerated.native_acceleration_runtime_active:
+            return self._vlm_speculative_comparison_status_metrics(
+                suite_id=suite.suite_id,
+                valid=False,
+                blocked=True,
+                reason="speculative_route_not_runtime_active",
+                baseline=baseline,
+                accelerated=accelerated,
+            )
+        try:
+            paths = self._write_vlm_speculative_comparison_artifact(
+                output_dir=output_dir,
+                comparison_id=f"{job_id}-{suite.suite_id}-vlm-speculative-decode",
+                baseline=baseline,
+                accelerated=accelerated,
+            )
+        except ServingDiagnosticsComparisonError as exc:
+            return self._vlm_speculative_comparison_status_metrics(
+                suite_id=suite.suite_id,
+                valid=False,
+                blocked=True,
+                reason=str(exc),
+                baseline=baseline,
+                accelerated=accelerated,
+            )
+        return self._vlm_speculative_comparison_status_metrics(
+            suite_id=suite.suite_id,
+            valid=True,
+            blocked=False,
+            reason="",
+            baseline=baseline,
+            accelerated=accelerated,
+            comparison_path=str(paths["comparison"]),
+        )
+
+    @staticmethod
+    def _vlm_speculative_comparison_policy(
+        parameters: Mapping[str, str],
+    ) -> common_pb2.AccelerationPolicy:
+        draft_model_id = str(
+            parameters.get("vlm_speculative_draft_model_id")
+            or parameters.get("draft_model_id")
+            or ""
+        ).strip()
+        try:
+            num_draft_tokens = int(
+                parameters.get("vlm_speculative_num_draft_tokens")
+                or parameters.get("num_draft_tokens")
+                or 6
+            )
+        except (TypeError, ValueError):
+            num_draft_tokens = 6
+        return common_pb2.AccelerationPolicy(
+            mode=common_pb2.ACCELERATION_MODE_SPECULATIVE_DECODE,
+            draft_model_id=draft_model_id,
+            num_draft_tokens=max(num_draft_tokens, 0),
+            allow_baseline_fallback=True,
+        )
+
+    @staticmethod
+    def _runtime_generate_accepts_acceleration_policy(runtime) -> bool:
+        try:
+            parameters = inspect.signature(runtime.generate_tokens).parameters
+        except (TypeError, ValueError):
+            return False
+        return "acceleration_policy" in parameters or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+
     @staticmethod
     def _write_vlm_batch1_comparison_artifact(
         *,
@@ -4340,6 +4470,27 @@ class MaintenanceCore:
             accelerated=MaintenanceCore._vlm_sample_evidence_run(
                 sample=fast_path,
                 acceleration_mode=fast_path.acceleration_mode or "image_batch1_step",
+            ),
+        )
+
+    @staticmethod
+    def _write_vlm_speculative_comparison_artifact(
+        *,
+        output_dir: Path,
+        comparison_id: str,
+        baseline: BenchSample,
+        accelerated: BenchSample,
+    ) -> dict[str, Path]:
+        return write_baseline_accelerated_evidence(
+            output_root=output_dir,
+            comparison_id=comparison_id,
+            baseline=MaintenanceCore._vlm_sample_evidence_run(
+                sample=baseline,
+                acceleration_mode="baseline",
+            ),
+            accelerated=MaintenanceCore._vlm_sample_evidence_run(
+                sample=accelerated,
+                acceleration_mode=accelerated.acceleration_mode or "speculative_decode",
             ),
         )
 
@@ -4582,6 +4733,146 @@ class MaintenanceCore:
         if "tier_stability_status" in reason:
             return 8.0
         if reason == "fast_path_route_not_selected":
+            return 9.0
+        return 99.0
+
+    @staticmethod
+    def _vlm_speculative_comparison_status_metrics(
+        *,
+        suite_id: str,
+        valid: bool,
+        blocked: bool,
+        reason: str,
+        baseline: BenchSample | None = None,
+        accelerated: BenchSample | None = None,
+        comparison_path: str = "",
+    ) -> list[BenchMetricSpec]:
+        metrics = [
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.vlm_speculative_comparison_valid",
+                value=1.0 if valid else 0.0,
+                unit="bool",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.vlm_speculative_comparison_claim_blocked",
+                value=1.0 if blocked else 0.0,
+                unit="bool",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.vlm_speculative_comparison_identity_match",
+                value=1.0
+                if baseline is not None
+                and accelerated is not None
+                and MaintenanceCore._vlm_sample_identity(baseline)
+                == MaintenanceCore._vlm_sample_identity(accelerated)
+                else 0.0,
+                unit="bool",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.vlm_speculative_route_stability",
+                value=1.0
+                if baseline is not None
+                and accelerated is not None
+                and baseline.route_stability_status == accelerated.route_stability_status == "stable"
+                else 0.0,
+                unit="bool",
+            ),
+            BenchMetricSpec(
+                suite=suite_id,
+                name=f"bench.{suite_id}.vlm_speculative_comparison_reason_code",
+                value=MaintenanceCore._vlm_speculative_comparison_reason_code(reason),
+                unit="code",
+            ),
+        ]
+        if baseline is not None:
+            metrics.extend(
+                [
+                    BenchMetricSpec(
+                        suite=suite_id,
+                        name=f"bench.{suite_id}.vlm_speculative_baseline_ttft_ms",
+                        value=baseline.ttft_ms,
+                        unit="ms",
+                    ),
+                    BenchMetricSpec(
+                        suite=suite_id,
+                        name=(
+                            f"bench.{suite_id}."
+                            "vlm_speculative_baseline_decode_tokens_per_second"
+                        ),
+                        value=baseline.decode_tokens_per_second
+                        or round(
+                            baseline.completion_tokens
+                            / max((baseline.total_latency_ms - baseline.ttft_ms) / 1_000.0, 0.001),
+                            4,
+                        ),
+                        unit="tok/s",
+                    ),
+                ]
+            )
+        if accelerated is not None:
+            metrics.extend(
+                [
+                    BenchMetricSpec(
+                        suite=suite_id,
+                        name=f"bench.{suite_id}.vlm_speculative_accelerated_ttft_ms",
+                        value=accelerated.ttft_ms,
+                        unit="ms",
+                    ),
+                    BenchMetricSpec(
+                        suite=suite_id,
+                        name=(
+                            f"bench.{suite_id}."
+                            "vlm_speculative_accelerated_decode_tokens_per_second"
+                        ),
+                        value=accelerated.decode_tokens_per_second
+                        or round(
+                            accelerated.completion_tokens
+                            / max(
+                                (accelerated.total_latency_ms - accelerated.ttft_ms) / 1_000.0,
+                                0.001,
+                            ),
+                            4,
+                        ),
+                        unit="tok/s",
+                    ),
+                ]
+            )
+        if comparison_path:
+            metrics.append(
+                BenchMetricSpec(
+                    suite=suite_id,
+                    name=f"bench.{suite_id}.vlm_speculative_comparison_artifact_present",
+                    value=1.0,
+                    unit="bool",
+                )
+            )
+        return metrics
+
+    @staticmethod
+    def _vlm_speculative_comparison_reason_code(reason: str) -> float:
+        if not reason:
+            return 0.0
+        if "prompt_protocol_id" in reason:
+            return 1.0
+        if "prompt_digest" in reason:
+            return 2.0
+        if "prompt_template_digest" in reason:
+            return 3.0
+        if "model_id" in reason:
+            return 4.0
+        if "task_kind" in reason:
+            return 5.0
+        if "generation_config" in reason:
+            return 6.0
+        if "greedy deterministic sampling" in reason:
+            return 7.0
+        if "tier_stability_status" in reason:
+            return 8.0
+        if reason == "speculative_route_not_runtime_active":
             return 9.0
         return 99.0
 


### PR DESCRIPTION
## Summary
- Adds the Unit 4.3.1 multimodal speculative comparison artifact path for VLM batch-1 benchmark evidence.
- Records baseline and accelerated phase rows, greedy sampler status, native acceleration admission/fallback details, and comparison status metrics.
- Handles missing VLM `generate_tokens` runtime support as unsupported acceleration policy forwarding.
- Extends the Issue 42 multimodal fast-path plan and adds the issue-specific execution plan for #1471.

Closes #1471

## Plan or Spec
- Governing plan: `docs/plans/2026-04-26-issue-42-multimodal-fast-paths.md`
- Issue execution plan: `docs/plans/2026-07-04-issue-1471-multimodal-speculative-comparison.md`

## Commands Run
```text
git diff --check origin/main...HEAD
# pass

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="maintenance-bench-report-readback 3-sample wall-clock outlier; structural counters unchanged and env-matched 15-sample probe showed median parity; outside issue-1471 VLM path" git commit -m "Add multimodal speculative comparison artifacts"
# pre-merge full hook pass:
# make swift-test: pass, elapsed 183.6s
# make py-test: pass, 4612 passed, 14 skipped, 2 warnings in 156.22s
# make integration-test: pass, 123 passed, 1 skipped in 443.51s
# PR-scoped performance report: regression allowed only for maintenance-bench-report-readback 3-sample wall-clock readback noise; structural counters unchanged.

git fetch origin main
# origin/main advanced to db4e683a

git merge --no-edit origin/main
# pass: merged db4e683a into this branch with no conflicts.

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed = subprocess.check_output([
    "git", "diff", "--name-only", "--diff-filter=ACDMRTUXB", "origin/main...HEAD", "--"
], cwd=root, text=True).splitlines()
changed = [line.strip() for line in changed if line.strip()]
outcome = run_performance_report(root, changed, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# pass: status ok, selected probes 8, regressions 0, context regressions 0, verification failures 0

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_sample_evidence_run_treats_invalid_generation_config_as_empty
# red before review fix: failed with AttributeError: 'MissingGenerateRuntime' object has no attribute 'generate_tokens'

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_vlm_sample_evidence_run_treats_invalid_generation_config_as_empty
# pass after review fix: 1 passed in 0.18s

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_maintenance_service.py -k "vlm_batch1_comparison or vlm_sample_evidence_run_treats_invalid_generation_config_as_empty"
# pass after review fix: 14 passed, 194 deselected in 0.17s

MELIX_PRE_COMMIT_ALLOW_PERF_REGRESSION=1 MELIX_PRE_COMMIT_PERF_REGRESSION_REASON="maintenance-bench-report-readback 3-sample wall-clock outlier on review-fix commit; immediate scoped rerun 20260704-023733 was ok with structural counters unchanged; change only catches AttributeError for missing runtime generate_tokens" git commit -m "Handle missing VLM generation policy runtime"
# review-fix full hook pass:
# make swift-test: pass, elapsed 186.8s
# make py-test: pass, 4613 passed, 14 skipped, 2 warnings in 156.14s
# make integration-test: pass, 123 passed, 1 skipped in 444.05s
# PR-scoped performance report: regression allowed only for maintenance-bench-report-readback 3-sample wall-clock readback noise; structural counters unchanged.

git fetch origin main
# origin/main advanced to 3f1c3ae5

git merge --no-edit origin/main
# pass: merged 3f1c3ae5 into this branch with no conflicts.

git diff --check origin/main...HEAD
# pass

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_maintenance_service.py -k "vlm_batch1_comparison or vlm_sample_evidence_run_treats_invalid_generation_config_as_empty"
# pass after final main merge: 14 passed, 194 deselected in 0.18s

python3 - <<'PY'
from pathlib import Path
report = Path(".runtime/pre-commit-performance/20260704-025800-68ee194d/report/report.md")
text = report.read_text()
assert "- Status: `ok`" in text
assert "- Selected probes: `8`" in text
assert "- Regressions: `0`" in text
assert "- Verification failures: `0`" in text
assert "## VLM batch-1 comparison artifact\n\n- Status: `ok`" in text
PY
# pass: final current-base report artifact is ok with 8 selected probes, 0 regressions, and VLM probe ok.
```

## Coverage and Metrics
- Final current-base PR-scoped performance report: `.runtime/pre-commit-performance/20260704-025800-68ee194d/report/report.md`
- Final report status: `ok`; selected probes: 8; direct/gated probes: 8; regressions: 0; context regressions: 0; verification failures: 0.
- Changed-scope coverage in the final report: 99% for the main maintenance/VLM probes and 98% for upload/model-ops probes selected by the changed test file. All selected coverage gates passed and exceed the 95% changed-scope requirement.
- VLM batch-1 comparison artifact probe: `ok`; targeted tests passed; coverage 99%; valid and blocked status counts stayed matched across base/head; route stability and payload-size metrics were neutral.
- Observability mode: evidence. The new path writes benchmark comparison evidence and status metrics only during VLM benchmark maintenance measurement; it does not add production runtime metrics or always-on debug capture.
- Probe overhead: final VLM comparison artifact probe stayed neutral, with valid elapsed mean base 0.203 ms vs head 0.200 ms and blocked elapsed mean base 0.006 ms vs head 0.006 ms.
- Review-fix hook note: the review-fix commit hook allowed one `maintenance-bench-report-readback` 3-sample wall-clock outlier with structural counters unchanged. The final current-base report above is clean, so no performance waiver is needed for the pushed final head.

## Known Gaps
- No live Apple Silicon VLM model execution was run for this PR; the comparison artifact path is covered with synthetic runtime/test evidence and the registered PR-scoped VLM comparison probe.
- `make bootstrap` and `make proto` were not rerun because this change does not update dependencies or protobuf schemas.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or N/A is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded.
- [x] Deferred work and known gaps are stated explicitly.
