### PR TITLE
perf: reuse export diagnostics failure statuses

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -202,6 +202,13 @@ the existing `<absolute-path>` label without constructing fallback `Path` object
 or calling `relative_to()`. Paths with `..` segments continue through the
 normalization fallback to preserve safe target-root labeling.
 
+A follow-up 2026-07-04 failure-status membership slice keeps failure-check
+semantics unchanged while reusing a module-level `frozenset` for statuses that
+should feed diagnostic source lines. Runtime export diagnostics still admit only
+failed and blocked smoke checks, but avoid constructing the two-item set inside
+each checked failure row while aggregating registered diagnostic parser probe
+fixtures.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -23,6 +23,7 @@ DEFAULT_PARSER_POLICY_ID = "runtime-export-log-v1"
 DEFAULT_BOUNDED_LOG_BYTES = 8192
 DEFAULT_BOUNDED_LOG_LINES = 120
 _SOURCE_READ_MULTIPLIER = 2
+_FAILING_CHECK_STATUSES = frozenset(("failed", "blocked"))
 
 DIAGNOSTIC_STATUS_MATCHED = "matched"
 DIAGNOSTIC_STATUS_UNKNOWN = "unknown"
@@ -492,7 +493,7 @@ def _collect_source_lines(
         status = _check_value(check, "status")
         if not failure_message and not failure_code:
             continue
-        if status and status not in {"failed", "blocked"}:
+        if status and status not in _FAILING_CHECK_STATUSES:
             continue
         check_name = _check_value(check, "check") or _check_value(check, "name") or "smoke_failure"
         evidence_path = _check_value(check, "evidence_path") or manifest.evidence.smoke_receipt_path


### PR DESCRIPTION
## Summary
- Reuse a module-level `frozenset` for runtime export diagnostic failure-check statuses.
- Keep failed/blocked smoke-check admission semantics unchanged while avoiding per-row set literal construction in `_collect_source_lines`.
- Record the micro-slice in the runtime export diagnostic parser plan.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the 2026-07-04 failure-status membership slice.
- Registered PR-scoped probe already covers this path: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main` from `/root/.hermes/profiles/coder/workspace/melix` before branching.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=7 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=60 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 78 passed in 1.65s; coverage replay: 78 passed in 1.36s.
- Changed-scope coverage: 100.00% (2/2 measurable changed lines covered).
- Local registered probe (Linux): `elapsed_ms_mean=5238.2551399724825`, `peak_bytes_mean=220305.2857142857`, `diagnostic_parser_coverage=1.0`, `parsed_failure_count=27.0`, `unknown_failure_count=1.0`, `redaction_count=5.0`, `diagnostic_latency_ms=8.136657997965813`, `path_redaction_elapsed_ms_mean=36.94718830021365`, `diagnosis_matching_elapsed_ms_mean=1.078279855261956`.
- Baseline spot runs on `origin/main` with the same probe settings produced `elapsed_ms_mean=5234.668775977168` and `5309.0372052975`; candidate spot runs produced `5230.020263714583`, `5251.118136569858`, and `5238.2551399724825`. Candidate mean is ~0.61% lower overall (`old_mean≈5271.853`, `new_mean≈5239.798`, `delta≈-32.055ms`).
- CI PR-scoped performance workflow is required for the repository-side registered probe report before merge.

## Known Gaps
- This is a small Python micro-optimization; local Linux probe results are low single-digit/noise-floor scale and must be confirmed by CI registered probe evidence.
- No Swift runtime behavior is changed.

## Evidence Checklist
- [x] Started from clean `origin/main` in an isolated worktree.
- [x] Confirmed registered PR-scoped probe covers the changed path and includes focused test, coverage, and probe commands.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally and removed generated `coverage.json`.
- [x] Ran the registered probe locally on Linux.
- [ ] GitHub Actions and PR-scoped performance probe completed successfully.
