### PR TITLE
perf: cache native mtp base shard skips

### DIFF
--- a/docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md
+++ b/docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md
@@ -24,9 +24,13 @@ JSON-emitting performance probe script.
 2. Narrow the implementation to local bindings for repeated string helper calls
    in `_extra_mtp_safetensor_file_paths(...)` so the hot loop avoids repeated
    attribute lookup while scanning large native-MTP index maps.
-3. Reuse the existing native-MTP regression tests and changed-scope coverage
+3. Cache ignored duplicate base `model*.safetensors` file names in the existing
+   sidecar duplicate set. This keeps the sidecar result unchanged, but avoids
+   repeating basename checks when large native-MTP indexes contain repeated
+   MTP-prefixed references to ordinary base shards.
+4. Reuse the existing native-MTP regression tests and changed-scope coverage
    command from the registered probe.
-4. Run the registered probe locally on Linux before opening the PR. GitHub
+5. Run the registered probe locally on Linux before opening the PR. GitHub
    Actions PR-scoped performance remains the merge gate for the registered probe
    report.
 

--- a/scripts/native_mtp_loader_safetensor_scandir_probe.py
+++ b/scripts/native_mtp_loader_safetensor_scandir_probe.py
@@ -48,6 +48,12 @@ def _populate_model_dir(model_dir: Path, *, model_files: int, distractor_files: 
         (model_dir / f"model-{index:05d}.bin").write_bytes(b"0")
         weight_map[f"language_model.mtp.layers.{index}.weight"] = mtp_name
         weight_map[f"language_model.mtp.layers.{index}.duplicate_weight"] = mtp_name
+        weight_map[f"language_model.mtp.layers.{index}.base_weight"] = (
+            f"model-{index % max(1, min(model_files, 32)):05d}-of-{model_files:05d}.safetensors"
+        )
+        weight_map[f"language_model.mtp.layers.{index}.base_weight_duplicate"] = (
+            f"model-{index % max(1, min(model_files, 32)):05d}-of-{model_files:05d}.safetensors"
+        )
         weight_map[f"language_model.mtp.layers.{index}.metadata"] = f"mtp-{index:05d}.json"
         weight_map[f"language_model.mtp.layers.{index}.metadata_duplicate"] = f"mtp-{index:05d}.json"
     (model_dir / "model-nested.safetensors").mkdir()
@@ -323,7 +329,8 @@ def run_probe() -> dict[str, float | int | str]:
         "model_files": model_files,
         "distractor_files": distractor_files,
         "duplicate_mtp_entries": distractor_files,
-        "irrelevant_mtp_entries": distractor_files * 2,
+        "irrelevant_mtp_entries": distractor_files * 4,
+        "duplicate_base_model_entries": distractor_files,
         "samples": samples,
         "key_iterations": key_iterations,
         "weight_load_iterations": weight_load_iterations,

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -640,7 +640,7 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
 
     assert metrics["old_mean_ms"] >= 0.0
     assert metrics["new_mean_ms"] >= 0.0
-    assert metrics["result_count"] == 40
+    assert metrics["result_count"] == 56
     assert metrics["model_listing_old_mean_ms"] >= 0.0
     assert metrics["model_listing_new_mean_ms"] >= 0.0
     assert metrics["model_listing_result_count"] == 10
@@ -648,9 +648,10 @@ def test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics(
     assert metrics["model_files"] == 8
     assert metrics["distractor_files"] == 8
     assert metrics["duplicate_mtp_entries"] == 8
-    assert metrics["irrelevant_mtp_entries"] == 16
-    assert metrics["key_count"] == 42
-    assert metrics["key_true_count"] == 33
+    assert metrics["irrelevant_mtp_entries"] == 32
+    assert metrics["duplicate_base_model_entries"] == 8
+    assert metrics["key_count"] == 58
+    assert metrics["key_true_count"] == 49
     assert metrics["key_iterations"] == 2
     assert metrics["weight_load_iterations"] == 2
     assert metrics["weight_load_result_count"] == 18

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -74,6 +74,7 @@ def _extra_mtp_safetensor_file_paths(model_path: Path) -> list[str]:
     append_extra_file = extra_files.append
     seen: set[str] = set()
     seen_add = seen.add
+    seen_contains = seen.__contains__
     model_path_text = os.fspath(model_path)
     path_join = os.path.join
     path_exists = os.path.exists
@@ -97,11 +98,12 @@ def _extra_mtp_safetensor_file_paths(model_path: Path) -> list[str]:
             file_name_text = to_text(file_name)
         if not str_endswith(file_name_text, safetensors_suffix):
             continue
-        if file_name_text in seen:
+        if seen_contains(file_name_text):
             continue
         separator_index = str_rfind(file_name_text, path_sep)
         file_basename = file_name_text if separator_index < 0 else file_name_text[separator_index + 1 :]
         if str_startswith(file_basename, model_prefix):
+            seen_add(file_name_text)
             continue
         seen_add(file_name_text)
         path_text = path_join(model_path_text, file_name_text)


### PR DESCRIPTION
## Summary
- Cache duplicate native-MTP references to ordinary base `model*.safetensors` shards in the sidecar discovery skip set.
- Bind the duplicate-set membership check in `_extra_mtp_safetensor_file_paths(...)` while preserving sidecar result ordering and missing-shard behavior.
- Extend the registered native-MTP probe fixture to include duplicate MTP-prefixed base-shard references.

## Plan or Spec
- Updated `docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md` with this follow-up slice.
- Registered probe already exists: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...native-MTP focused tests... ...test_pr_scoped_performance native-MTP probe tests...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q ...native-MTP focused tests... && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id native-mtp-loader-safetensor-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-native-mtp-extra-seen-local-bind-20260704 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-native-mtp-extra-seen-local-bind-20260704 --output /tmp/native_mtp_extra_seen_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `13 passed`.
- Changed-scope coverage: `TOTAL 3 0 100%` for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
- Direct local registered probe (Linux): `extra_old_mean_ms=263.712066`, `extra_new_mean_ms=36.901240`, `extra_delta_ms=-226.810827`, `extra_speedup=7.146428`.
- PR-scoped local registered probe head run: `extra_old_mean_ms=274.300905`, `extra_new_mean_ms=37.674331`, `extra_delta_ms=-236.626573`, `extra_speedup=7.280843`; `new_mean_ms=12.237037`, `old_mean_ms=12.732342`, `speedup=1.040476`.

## Known Gaps
- This is Python worker code; no Swift/macOS runtime effect is claimed.
- GitHub Actions PR-scoped performance is still the merge gate for the registered probe report.

## Evidence Checklist
- [x] Synced from `origin/main` before creating the slice worktree.
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally on Linux.
- [x] Changed-scope coverage is at least 95% for changed measured lines.
- [x] Registered probe ran locally with base/head comparison.
- [ ] GitHub Actions PR-scoped performance completed successfully.
