### PR TITLE
perf: fast path quantized high precision prefixes

### DIFF
--- a/docs/plans/2026-06-30-quantized-metadata-high-precision-prefilter.md
+++ b/docs/plans/2026-06-30-quantized-metadata-high-precision-prefilter.md
@@ -27,11 +27,14 @@ with the rest of the registered quantized metadata metrics as regression guards.
    `test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries`.
 2. Add a cheap substring prefilter before the segment scanner so common language
    model prefixes without any high-precision marker can return immediately.
-3. Keep the segment scanner as the source of truth for positive and near-miss
-   strings so boundary behavior does not drift.
-4. Run the registered focused test command, changed-scope coverage command, and
+3. Add direct exact/prefix shortcuts for common top-level and one-level container
+   high-precision module names while preserving the segment scanner fallback for
+   deeper or malformed positive strings.
+4. Keep the segment scanner as the source of truth for near-miss strings so
+   boundary behavior does not drift.
+5. Run the registered focused test command, changed-scope coverage command, and
    registered probe locally on Linux before opening the PR.
-5. Use GitHub Actions PR-scoped performance as the merge gate.
+6. Use GitHub Actions PR-scoped performance as the merge gate.
 
 ## Success criteria
 

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -85,7 +85,22 @@ _NATIVE_MULTIMODAL_HIGH_PRECISION_SEGMENTS = frozenset(_NATIVE_MULTIMODAL_HIGH_P
 _NATIVE_MULTIMODAL_HIGH_PRECISION_OUTPUT_SEGMENTS = frozenset(
     suffix[1:] for suffix in _NATIVE_MULTIMODAL_HIGH_PRECISION_SUFFIXES
 )
+_NATIVE_MULTIMODAL_HIGH_PRECISION_DIRECT_SEGMENTS = (
+    _NATIVE_MULTIMODAL_HIGH_PRECISION_SEGMENTS
+    | _NATIVE_MULTIMODAL_HIGH_PRECISION_OUTPUT_SEGMENTS
+)
+_NATIVE_MULTIMODAL_HIGH_PRECISION_DIRECT_PREFIXES = tuple(
+    f"{segment}." for segment in _NATIVE_MULTIMODAL_HIGH_PRECISION_DIRECT_SEGMENTS
+)
 _NATIVE_MULTIMODAL_CONTAINER_SEGMENTS = frozenset(("model", "language_model"))
+_NATIVE_MULTIMODAL_CONTAINER_HIGH_PRECISION_EXACT_PREFIXES = frozenset(
+    f"{container}.{segment}"
+    for container in _NATIVE_MULTIMODAL_CONTAINER_SEGMENTS
+    for segment in _NATIVE_MULTIMODAL_HIGH_PRECISION_DIRECT_SEGMENTS
+)
+_NATIVE_MULTIMODAL_CONTAINER_HIGH_PRECISION_DIRECT_PREFIXES = tuple(
+    f"{prefix}." for prefix in _NATIVE_MULTIMODAL_CONTAINER_HIGH_PRECISION_EXACT_PREFIXES
+)
 
 
 def _load_json_payload(path: Path) -> dict[str, Any]:
@@ -220,6 +235,16 @@ def _native_multimodal_high_precision_module(prefix: str) -> bool:
         and "score" not in prefix
     ):
         return False
+    direct_segments = _NATIVE_MULTIMODAL_HIGH_PRECISION_DIRECT_SEGMENTS
+    if prefix in direct_segments or prefix.startswith(
+        _NATIVE_MULTIMODAL_HIGH_PRECISION_DIRECT_PREFIXES
+    ):
+        return True
+    container_prefixes = _NATIVE_MULTIMODAL_CONTAINER_HIGH_PRECISION_EXACT_PREFIXES
+    if prefix in container_prefixes or prefix.startswith(
+        _NATIVE_MULTIMODAL_CONTAINER_HIGH_PRECISION_DIRECT_PREFIXES
+    ):
+        return True
     start = 0
     prefix_length = len(prefix)
     previous_segment = ""


### PR DESCRIPTION
## Summary
- Adds direct exact/prefix shortcuts for common quantized multimodal high-precision module prefixes before falling back to the existing segment scanner.
- Keeps near-miss boundary handling unchanged for names such as `prevision_tower`, `visualizer`, and `output_projection`.

## Plan or Spec
- `docs/plans/2026-06-30-quantized-metadata-high-precision-prefilter.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries
1 passed in 1.09s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...registered quantized-tensor-metadata-prepass test_command...
29 passed in 1.32s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,...' -m pytest -q ...registered quantized-tensor-metadata-prepass coverage_command... && ... coverage json ... && python3 scripts/changed_scope_coverage.py ...
29 passed in 0.70s
TOTAL 10 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/quantized_tensor_metadata_prepass_probe.py"; ...'
registered probe completed successfully; JSON metrics recorded below.

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`aggregate_measurable_changed_lines=10`, `aggregate_covered_changed_lines=10`, `aggregate_missed_changed_lines=0`).
- Registered probe: `quantized-tensor-metadata-prepass`.
- Baseline local Linux probe before change: `high_precision_decision_elapsed_ms_mean=89.788704412058`, `high_precision_decision_count=20000.0`.
- Head local Linux registered probe after change: `high_precision_decision_elapsed_ms_mean=74.03501637745649`, `high_precision_decision_count=20000.0`.
- Delta: `-15.753688 ms`, `1.212787x`, `17.55%` improvement for the primary high-precision decision metric.
- Regression guard metrics from the registered probe: `metadata_decision_elapsed_ms_mean=29.344110400415957`, `matched_decision_count=40000.0`, `header_tensor_count=6000.0`, `cross_shard_pair_count=2000.0`.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Known Gaps
- Local validation is Linux-only. No Swift/runtime effect is claimed locally; this Python slice relies on the registered GitHub Actions PR-scoped performance workflow for merge validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing registered probe reused.
- [x] Deferred work and known gaps are stated explicitly.
