### PR TITLE
perf: fast path exact MLX hub atoms

### DIFF
--- a/docs/plans/2026-07-04-hub-catalog-mlx-atom-exact-fastpath.md
+++ b/docs/plans/2026-07-04-hub-catalog-mlx-atom-exact-fastpath.md
@@ -1,0 +1,48 @@
+# Hub Catalog MLX Atom Exact Fast Path
+
+## Goal
+
+Reduce repeated compatibility-check overhead in the Hub catalog path when the common MLX marker is exactly `mlx` or `MLX`.
+
+## Scope
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+- `infra/perf/pr_scoped_probes.json` (existing registered probe only)
+
+## Linux Constraint
+
+This slice is Python-only and is locally verifiable on Linux with focused pytest, changed-scope coverage, and the registered PR-scoped probe.
+
+## Optimization Hypothesis
+
+`_is_mlx_atom()` is called from hot Hub compatibility paths for library names, repo/card tags, and card metadata. The most common exact atoms are `mlx` and `MLX`; returning immediately for those exact values avoids the ordinal character checks while preserving the existing mixed-case fallback for less common variants such as `Mlx`.
+
+## Registered Probe
+
+- Probe ID: `hub-catalog-size-hint-regex-precompile`
+- Workload: repeatedly exercises Hub size-hint extraction and MLX compatibility classification through `scripts/hub_catalog_size_hint_probe.py`.
+- Metrics:
+  - `elapsed_ms_mean` lower is better
+  - `payload_compatibility_elapsed_ms_mean` lower is better
+  - `size_hint_calls_mean`, compatibility call counts, checksum, and matched counts preserve behavior.
+
+## Success Metrics
+
+- Focused Hub catalog tests preserve exact and mixed-case MLX marker behavior.
+- Changed-scope coverage for touched lines remains at or above 95%.
+- Local registered probe improves compatibility elapsed time versus the pre-change baseline.
+- PR-scoped performance CI selects and completes the registered probe for this path.
+
+## Verification Commands
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
+git diff --check
+```

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -477,6 +477,8 @@ def _lowered_tag_set(tags: list[str]) -> set[str]:
 
 
 def _is_mlx_atom(value: str) -> bool:
+    if value == "mlx" or value == "MLX":
+        return True
     if len(value) != 3:
         return False
     first = ord(value[0])

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -477,10 +477,10 @@ def _lowered_tag_set(tags: list[str]) -> set[str]:
 
 
 def _is_mlx_atom(value: str) -> bool:
-    if value == "mlx" or value == "MLX":
-        return True
     if len(value) != 3:
         return False
+    if value == "mlx" or value == "MLX":
+        return True
     first = ord(value[0])
     second = ord(value[1])
     third = ord(value[2])


### PR DESCRIPTION
## Summary
- Add an exact-atom fast path for MLX hub catalog trust/runtime-name matching after the existing length guard and before the ordinal fallback.
- Keep regex/wildcard fallback semantics unchanged while avoiding extra ordinal work for common exact MLX entries.
- Follow up on the PR performance regression by preserving the length short-circuit for non-3-character catalog values.

## Plan or Spec
- Plan: `docs/plans/2026-07-04-hub-catalog-mlx-atom-exact-fastpath.md`
- Registered probes selected by the PR-scoped performance workflow: `hub-catalog-tag-normalization-single-pass`, `hub-catalog-next-cursor-fast-parse`, and `hub-catalog-size-hint-regex-precompile`.

## Commands Run
```text
- git status --short && git branch --show-current
- git fetch origin && git reset --hard origin/main
- git merge --no-edit origin/main
- PYTHONPATH=services/mlx-worker-python:. uv run pytest services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_hub_catalog.py -q
  -> 121 passed in 0.76s after merging origin/main
- PYTHONPATH=services/mlx-worker-python:. uv run coverage run -m pytest -q services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_hub_catalog.py && PYTHONPATH=services/mlx-worker-python:. uv run coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_hub_catalog.py
  -> 121 passed; changed-line coverage 100%
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py
  -> elapsed_ms_mean=194.754670, tag_normalization_calls_mean=5000 after merging origin/main
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
  -> elapsed_ms_mean=484.649353, cursor_parse_calls_mean=50000, peak_bytes_mean=832
- PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
  -> elapsed_ms_mean=1687.934609, payload_compatibility_elapsed_ms_mean=196.801751
```

## Coverage and Metrics
- Focused tests: 121 passed locally on Linux after merging `origin/main`.
- Changed-scope coverage: 100% for the touched `hub_catalog.py` lines before the merge-base moved to the updated mainline.
- CI PR-scoped performance report: `ok`, 3 selected probes, 0 regressions, 0 verification failures.
- Latest CI probe metrics:
  - `hub-catalog-tag-normalization-single-pass`: base `202.540 ms`, head `200.800 ms`, delta `-1.740 ms` (`-0.86%`, neutral).
  - `hub-catalog-next-cursor-fast-parse`: base `539.355 ms`, head `543.309 ms`, delta `+3.954 ms` (`+0.73%`, neutral).
  - `hub-catalog-size-hint-regex-precompile`: base `1944.438 ms`, head `1915.706 ms`, delta `-28.732 ms` (`-1.48%`, neutral); payload compatibility base `220.047 ms`, head `216.071 ms`, delta `-3.976 ms` (`-1.81%`, neutral).

## Known Gaps
- This is a Python-only slice verified locally on Linux.
- The optimization targets exact 3-character MLX atoms only; wildcard/regex catalog behavior intentionally remains on the existing fallback path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
