### PR TITLE
perf: fast path diagnostic target-relative text

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -209,6 +209,15 @@ failed and blocked smoke checks, but avoid constructing the two-item set inside
 each checked failure row while aggregating registered diagnostic parser probe
 fixtures.
 
+A follow-up 2026-07-04 target-path relative-text slice keeps target-relative
+and external path redaction labels unchanged while making the lexical
+`_target_relative_text()` fast path return immediately for clean target-local
+relative paths that contain no parent-directory marker. The slice also defers the
+`<absolute-path>` fallback string setup until after the target-local lexical match
+fails. Paths with empty relative text or `..` segments continue through the same
+safe fallback behavior, but ordinary bounded runtime excerpts skip the unused
+fallback assignment and the extra parent-segment boundary checks.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -36,6 +36,7 @@ from worker.productization.export_target_diagnostics import (
     _has_private_text_line_marker,
     _has_secret_redaction_marker,
     _split_source_lines,
+    _target_relative_text,
 )
 from worker.productization.export_target_layout import (
     build_export_target_layout,
@@ -61,6 +62,10 @@ def test_export_target_diagnostics_source_line_extension_matches_split_helper() 
 
     _extend_source_lines(lines, "logs/empty.log", "")
     assert len(lines) == 2
+
+
+def test_export_target_diagnostics_target_relative_text_handles_root_slash_boundary() -> None:
+    assert _target_relative_text("/tmp/melix-target/", "/tmp/melix-target") is None
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -747,12 +747,12 @@ def _redact_absolute_path(
 ) -> str:
     trimmed_path = raw_path.rstrip(".,)")
     suffix = raw_path[len(trimmed_path):]
-    replacement = "<absolute-path>"
     relative_text = _target_relative_text(trimmed_path, resolved_target_root_text)
     if relative_text is not None:
         summary.redacted_absolute_path_count += 1
         summary.redaction_count += 1
         return f"<target>/{relative_text}" + suffix
+    replacement = "<absolute-path>"
     if "/../" not in trimmed_path and not trimmed_path.endswith("/.."):
         summary.redacted_absolute_path_count += 1
         summary.redaction_count += 1
@@ -780,9 +780,12 @@ def _target_relative_text(raw_path: str, resolved_target_root_text: str) -> str 
     if raw_path[boundary_index] != "/":
         return None
     relative_text = raw_path[boundary_index + 1 :]
+    if not relative_text:
+        return None
+    if ".." not in relative_text:
+        return relative_text
     if (
-        not relative_text
-        or relative_text == ".."
+        relative_text == ".."
         or relative_text.startswith("../")
         or "/../" in relative_text
         or relative_text.endswith("/..")


### PR DESCRIPTION
## Summary
- Fast-path clean target-local runtime export diagnostic paths in `_target_relative_text()` by returning before parent-segment boundary checks.
- Defer the `<absolute-path>` fallback setup until the target-local lexical match fails.
- Add a regression guard for the target-root slash boundary and document the slice in the diagnostic parser plan.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the 2026-07-04 target-path relative-text slice.
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=50 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `79 passed`.
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Local registered probe (Linux, head): `elapsed_ms_mean=4328.438`, `path_redaction_elapsed_ms_mean=30.144`, `diagnostic_parser_coverage=1.0`, `diagnosis_code_count=9.0`.
- Same-run local base/head comparison with `iterations=50`, `samples=5`: base `elapsed_ms_mean=4351.316`, `path_redaction_elapsed_ms_mean=29.767`; head `elapsed_ms_mean=4301.119`, `path_redaction_elapsed_ms_mean=28.782`.
- CI PR-scoped performance report is required as the authoritative registered probe validation.

## Known Gaps
- Linux local probe timings are noisy and scoped to the Python diagnostic parser path only.
- No Swift runtime effect is claimed for this slice.

## Evidence Checklist
- [x] Branch synced from `origin/main` before slicing.
- [x] Affected path has registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
