### PR TITLE
Add serving readiness diagnostics receipts

### DIFF
--- a/docs/plans/2026-07-04-issue-350-serving-readiness-diagnostics-receipts.md
+++ b/docs/plans/2026-07-04-issue-350-serving-readiness-diagnostics-receipts.md
@@ -1,0 +1,95 @@
+# Issue 350 Serving Readiness Diagnostics Receipts
+
+## Goal
+
+Add a narrow diagnostics-only serving readiness receipt so `effective-config.json`
+can preserve model identity, budget, readiness, progress, and dependency-policy
+facts without starting or probing a real serving backend.
+
+## Scope
+
+- Preserve an explicit `serving_readiness` receipt when a caller already supplies
+  one in diagnostics `effective_config`.
+- Derive a stable `serving_readiness` receipt from namespaced execution metadata
+  when all required readiness fields are present.
+- Keep partial metadata out of the derived receipt so diagnostics do not imply a
+  complete readiness decision when upstream code has not emitted one yet.
+- Document the receipt fields and interpretation in the serving diagnostics
+  evidence runbook.
+
+## Out Of Scope
+
+- Changing serving admission, model loading, health polling, or dependency
+  resolution behavior.
+- Detecting package versions or known-incompatible dependency ranges in this
+  slice.
+- Adding Swift control-plane metadata emission. This diagnostics slice only
+  establishes the artifact contract for later producers.
+- Claiming acceleration or readiness improvements.
+
+## Receipt Contract
+
+`effective-config.json` may contain:
+
+```json
+{
+  "serving_readiness": {
+    "requested_model_id": "operator requested identity",
+    "effective_model_id": "backend/runtime identity selected for serving",
+    "identity_source": "explicit_request | cached_catalog | backend_health | fallback",
+    "budget_source": "explicit_request | profile_default | runtime_default",
+    "health_ready_at": "ISO-8601 timestamp or empty string when not ready",
+    "progress_source": "backend_health | cached_status | not_ready",
+    "dependency_policy_status": "allowed | blocked | unknown"
+  }
+}
+```
+
+When deriving from metadata, the diagnostics writer reads the following keys
+from the same metadata sources already used for serving profile receipts:
+
+- `melix.serving.readiness.requested_model_id`
+- `melix.serving.readiness.effective_model_id`
+- `melix.serving.readiness.identity_source`
+- `melix.serving.readiness.budget_source`
+- `melix.serving.readiness.health_ready_at`
+- `melix.serving.readiness.progress_source`
+- `melix.serving.readiness.dependency_policy_status`
+
+All seven fields are required for a derived receipt. This keeps partial upstream
+state observable in its original metadata location while preventing the
+top-level `serving_readiness` object from looking complete before it is.
+
+## Implementation Plan
+
+1. Add focused Python diagnostics tests:
+   - explicit `serving_readiness` survives stable JSON serialization;
+   - complete readiness audit metadata derives `serving_readiness`;
+   - incomplete readiness audit metadata is left in-place without a derived
+     receipt.
+2. Implement readiness field mapping and required-field validation beside the
+   existing serving profile receipt derivation.
+3. Update `docs/runbooks/serving-diagnostics-evidence.md` with the readiness
+   receipt fields, metadata keys, and diagnostics-only scope.
+4. Keep bundle serialization within the existing serving diagnostics queue
+   performance gate by using compact stable JSON writes for structured bundle
+   files and avoiding unnecessary nested directory creation work.
+5. Verify focused tests, changed-scope coverage, PR-scoped performance, and
+   whitespace.
+
+## Verification
+
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json`
+- `UV_PYTHON=3.12 uv run python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_serving_diagnostics.py`
+- `git diff --check`
+
+## Metrics
+
+This slice adds only small dictionary scans over existing diagnostics metadata
+sources during bundle writing. It does not add runtime probes, model loading,
+network calls, dependency imports, or token-path instrumentation. Success is a
+stable receipt contract in generated diagnostics artifacts with 95% or higher
+changed-line coverage for the touched Python scope and a PR-scoped performance
+report with no serving diagnostics regressions.

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -130,6 +130,42 @@ serving-diagnostics/<bundle_id>/
 `effective-config.json` records the effective runtime and request config after
 defaults, admission, and runtime-specific resolution.
 
+When upstream serving code has evaluated readiness or dependency policy,
+`effective-config.json` should also include a `serving_readiness` receipt. This
+receipt is diagnostics-only: it records facts already known to the serving path
+and must not trigger model discovery, health polling, package imports, or
+dependency checks during bundle writing.
+
+`serving_readiness` fields:
+
+- `requested_model_id` — operator-requested model identity, alias, or handle.
+- `effective_model_id` — backend/runtime identity selected for serving.
+- `identity_source` — where the effective identity came from, such as
+  `explicit_request`, `cached_catalog`, `backend_health`, or `fallback`.
+- `budget_source` — where the serving token or profile budget came from, such
+  as `explicit_request`, `profile_default`, or `runtime_default`.
+- `health_ready_at` — ISO-8601 timestamp for the first ready health state, or an
+  empty string when the session was not ready when the bundle was written.
+- `progress_source` — source of readiness/progress truth, such as
+  `backend_health`, `cached_status`, or `not_ready`.
+- `dependency_policy_status` — dependency policy classification, such as
+  `allowed`, `blocked`, or `unknown`.
+
+Diagnostics writers may derive `serving_readiness` from namespaced metadata
+when all of these keys are present:
+
+- `melix.serving.readiness.requested_model_id`
+- `melix.serving.readiness.effective_model_id`
+- `melix.serving.readiness.identity_source`
+- `melix.serving.readiness.budget_source`
+- `melix.serving.readiness.health_ready_at`
+- `melix.serving.readiness.progress_source`
+- `melix.serving.readiness.dependency_policy_status`
+
+If any required readiness metadata key is missing, the writer leaves the
+original metadata in place and does not synthesize a partial top-level
+`serving_readiness` receipt.
+
 `request-summary.json` records stable request-level fields:
 
 - request id

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -359,6 +359,97 @@ def test_serving_diagnostics_effective_config_keeps_explicit_serving_profile(
     }
 
 
+def test_serving_diagnostics_effective_config_preserves_serving_readiness_receipt(
+    tmp_path: Path,
+) -> None:
+    readiness_receipt = {
+        "requested_model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+        "effective_model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+        "identity_source": "explicit_request",
+        "budget_source": "explicit_request",
+        "health_ready_at": "2026-07-04T11:00:00Z",
+        "progress_source": "backend_health",
+        "dependency_policy_status": "allowed",
+    }
+
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-readiness-explicit",
+        invocation={},
+        effective_config={
+            "serving_readiness": readiness_receipt,
+            "runtime": {"mode": "baseline"},
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert effective_config["serving_readiness"] == readiness_receipt
+
+
+def test_serving_diagnostics_effective_config_derives_readiness_receipt_from_metadata(
+    tmp_path: Path,
+) -> None:
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-readiness-derived",
+        invocation={},
+        effective_config={
+            "request_metadata": {
+                "melix.serving.readiness.requested_model_id": "configured-alias",
+                "melix.serving.readiness.effective_model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+                "melix.serving.readiness.identity_source": "cached_catalog",
+                "melix.serving.readiness.budget_source": "profile_default",
+                "melix.serving.readiness.health_ready_at": "2026-07-04T11:01:00Z",
+                "melix.serving.readiness.progress_source": "backend_health",
+                "melix.serving.readiness.dependency_policy_status": "allowed",
+            }
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert effective_config["serving_readiness"] == {
+        "requested_model_id": "configured-alias",
+        "effective_model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+        "identity_source": "cached_catalog",
+        "budget_source": "profile_default",
+        "health_ready_at": "2026-07-04T11:01:00Z",
+        "progress_source": "backend_health",
+        "dependency_policy_status": "allowed",
+    }
+
+
+def test_serving_diagnostics_effective_config_skips_incomplete_readiness_metadata(
+    tmp_path: Path,
+) -> None:
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-readiness-incomplete",
+        invocation={},
+        effective_config={
+            "execution_ext": {
+                "melix.serving.readiness.requested_model_id": "configured-alias",
+                "melix.serving.readiness.effective_model_id": "mlx-community/Qwen3.5-9B-MLX-4bit",
+                "melix.serving.readiness.dependency_policy_status": "allowed",
+            }
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert "serving_readiness" not in effective_config
+
+
 def test_serving_diagnostics_empty_effective_config_skips_profile_receipt_scan(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -516,6 +607,34 @@ def test_serving_diagnostics_event_instances_use_slots_for_debug_queue() -> None
     assert event.to_dict()["attributes"] == {"token": "***"}
     with pytest.raises(AttributeError):
         event.status = "mutated"  # type: ignore[misc]
+
+
+def test_serving_diagnostics_event_preserves_dataclass_style_equality() -> None:
+    first = ServingDiagnosticsEvent(
+        request_id="req-eq",
+        phase="decode",
+        event_index=1,
+        status="completed",
+        duration_ms=0.25,
+    )
+    matching = ServingDiagnosticsEvent(
+        request_id="req-eq",
+        phase="decode",
+        event_index=1,
+        status="completed",
+        duration_ms=0.25,
+    )
+    different = ServingDiagnosticsEvent(
+        request_id="req-eq",
+        phase="decode",
+        event_index=2,
+        status="completed",
+        duration_ms=0.25,
+    )
+
+    assert first == matching
+    assert first != different
+    assert first != object()
 
 
 def test_serving_diagnostics_queue_snapshot_uses_slots_for_debug_queue() -> None:

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -594,7 +594,10 @@ def _effective_config_with_profile_receipt(
                 break
     if enriched_config == stable_config:
         return stable_config
-    return _stable_json_object(enriched_config)
+    return {
+        str(key): value
+        for key, value in sorted(enriched_config.items(), key=lambda item: str(item[0]))
+    }
 
 
 def _effective_config_metadata_sources(

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -30,12 +30,23 @@ _PROFILE_AUDIT_TO_RECEIPT_FIELDS = {
 _PROFILE_RECEIPT_REQUIRED_FIELDS = frozenset(
     ("requested_profile", "effective_profile", "profile_admission_status")
 )
+_READINESS_AUDIT_TO_RECEIPT_FIELDS = {
+    "melix.serving.readiness.requested_model_id": "requested_model_id",
+    "melix.serving.readiness.effective_model_id": "effective_model_id",
+    "melix.serving.readiness.identity_source": "identity_source",
+    "melix.serving.readiness.budget_source": "budget_source",
+    "melix.serving.readiness.health_ready_at": "health_ready_at",
+    "melix.serving.readiness.progress_source": "progress_source",
+    "melix.serving.readiness.dependency_policy_status": "dependency_policy_status",
+}
+_READINESS_RECEIPT_REQUIRED_FIELDS = frozenset(
+    _READINESS_AUDIT_TO_RECEIPT_FIELDS.values()
+)
 _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
 _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
 _JSON_STRING_ENCODER = json.encoder.encode_basestring_ascii
 _IS_FINITE = math.isfinite
-_SET_FROZEN_ATTR = object.__setattr__
 _EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX = b'{"attributes":{},"duration_ms":'
 _EMPTY_EVENT_JSON_DECODE_COMPLETED_MID = b',"event_index":'
 _EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX = (
@@ -195,14 +206,15 @@ class ServingDiagnosticsRequestSummary:
         }
 
 
-@dataclass(frozen=True, slots=True, init=False)
 class ServingDiagnosticsEvent:
-    request_id: str
-    phase: str
-    event_index: int
-    status: str
-    duration_ms: float = 0.0
-    attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES
+    __slots__ = (
+        "_attributes",
+        "_duration_ms",
+        "_event_index",
+        "_phase",
+        "_request_id",
+        "_status",
+    )
 
     def __init__(
         self,
@@ -212,27 +224,71 @@ class ServingDiagnosticsEvent:
         status: str,
         duration_ms: float = 0.0,
         attributes: Mapping[str, object] = _EMPTY_EVENT_ATTRIBUTES,
-        _set_attr: Any = _SET_FROZEN_ATTR,
     ) -> None:
-        _set_attr(self, "request_id", request_id)
-        _set_attr(self, "phase", phase)
-        _set_attr(self, "event_index", event_index)
-        _set_attr(self, "status", status)
-        _set_attr(self, "duration_ms", duration_ms)
-        _set_attr(self, "attributes", attributes)
+        self._request_id = request_id
+        self._phase = phase
+        self._event_index = event_index
+        self._status = status
+        self._duration_ms = duration_ms
+        self._attributes = attributes
+
+    @property
+    def request_id(self) -> str:
+        return self._request_id
+
+    @property
+    def phase(self) -> str:
+        return self._phase
+
+    @property
+    def event_index(self) -> int:
+        return self._event_index
+
+    @property
+    def status(self) -> str:
+        return self._status
+
+    @property
+    def duration_ms(self) -> float:
+        return self._duration_ms
+
+    @property
+    def attributes(self) -> Mapping[str, object]:
+        return self._attributes
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ServingDiagnosticsEvent):
+            return NotImplemented
+        return (
+            self._request_id,
+            self._phase,
+            self._event_index,
+            self._status,
+            self._duration_ms,
+            self._attributes,
+        ) == (
+            other._request_id,
+            other._phase,
+            other._event_index,
+            other._status,
+            other._duration_ms,
+            other._attributes,
+        )
+
+    __hash__ = None  # type: ignore[assignment]
 
     def to_dict(self) -> dict[str, object]:
-        attributes = self.attributes
-        event_index = self.event_index
-        duration_ms = self.duration_ms
+        attributes = self._attributes
+        event_index = self._event_index
+        duration_ms = self._duration_ms
         return {
             "schema_version": SERVING_DIAGNOSTICS_EVENT_SCHEMA_VERSION,
-            "request_id": self.request_id,
-            "phase": self.phase,
+            "request_id": self._request_id,
+            "phase": self._phase,
             "event_index": event_index
             if type(event_index) is int
             else int(event_index),
-            "status": self.status,
+            "status": self._status,
             "duration_ms": duration_ms
             if type(duration_ms) is float
             else float(duration_ms),
@@ -323,8 +379,10 @@ def write_serving_diagnostics_bundle(
     if diagnostics_mode not in {"debug", "claim_evidence"}:
         raise ValueError("diagnostics_mode must be debug or claim_evidence")
 
-    bundle_root = output_root / "serving-diagnostics" / _safe_artifact_id(bundle_id)
-    bundle_root.mkdir(parents=True, exist_ok=True)
+    diagnostics_root = output_root / "serving-diagnostics"
+    diagnostics_root.mkdir(parents=True, exist_ok=True)
+    bundle_root = diagnostics_root / _safe_artifact_id(bundle_id)
+    bundle_root.mkdir(exist_ok=True)
     manifest_path = bundle_root / "manifest.json"
     effective_config_path = bundle_root / "effective-config.json"
     request_summary_path = bundle_root / "request-summary.json"
@@ -520,15 +578,23 @@ def _effective_config_with_profile_receipt(
     if not effective_config:
         return {}
     stable_config = _stable_json_object(effective_config)
-    if "serving_profile" in stable_config:
+    enriched_config = dict(stable_config)
+    metadata_sources = _effective_config_metadata_sources(stable_config)
+    if "serving_profile" not in enriched_config:
+        for metadata in metadata_sources:
+            receipt = _serving_profile_receipt_from_audit_metadata(metadata)
+            if receipt:
+                enriched_config["serving_profile"] = receipt
+                break
+    if "serving_readiness" not in enriched_config:
+        for metadata in metadata_sources:
+            receipt = _serving_readiness_receipt_from_audit_metadata(metadata)
+            if receipt:
+                enriched_config["serving_readiness"] = receipt
+                break
+    if enriched_config == stable_config:
         return stable_config
-    for metadata in _effective_config_metadata_sources(stable_config):
-        receipt = _serving_profile_receipt_from_audit_metadata(metadata)
-        if receipt:
-            enriched_config = dict(stable_config)
-            enriched_config["serving_profile"] = receipt
-            return _stable_json_object(enriched_config)
-    return stable_config
+    return _stable_json_object(enriched_config)
 
 
 def _effective_config_metadata_sources(
@@ -569,6 +635,19 @@ def _serving_profile_receipt_from_audit_metadata(
     return {}
 
 
+def _serving_readiness_receipt_from_audit_metadata(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    receipt = {
+        receipt_key: str(value)
+        for audit_key, receipt_key in _READINESS_AUDIT_TO_RECEIPT_FIELDS.items()
+        if (value := metadata.get(audit_key)) is not None
+    }
+    if _READINESS_RECEIPT_REQUIRED_FIELDS.issubset(receipt):
+        return receipt
+    return {}
+
+
 def _stable_json_value(value: object) -> object:
     if isinstance(value, dict):
         return _stable_json_object(value)  # type: ignore[arg-type]
@@ -589,10 +668,10 @@ def _stable_json_sort_key(value: object) -> str:
 
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    if not payload:
+        path.write_bytes(b"{}\n")
+        return
+    path.write_bytes((_JSONL_ENCODER.encode(payload) + "\n").encode("utf-8"))
 
 
 def _write_jsonl(path: Path, rows: Any) -> None:
@@ -630,17 +709,17 @@ def _extend_empty_attribute_event_json_line_bytes(
     event: ServingDiagnosticsEvent,
     request_id_literals: dict[str, bytes],
 ) -> bool:
-    if event.attributes is not _EMPTY_EVENT_ATTRIBUTES:
+    if event._attributes is not _EMPTY_EVENT_ATTRIBUTES:
         return False
-    event_index = event.event_index
-    duration_ms = event.duration_ms
+    event_index = event._event_index
+    duration_ms = event._duration_ms
     if type(event_index) is not int or type(duration_ms) is not float:
         return False
     if not _IS_FINITE(duration_ms):
         return False
-    phase = event.phase
-    request_id = event.request_id
-    status = event.status
+    phase = event._phase
+    request_id = event._request_id
+    status = event._status
     encoded_request_id = request_id_literals.get(request_id)
     if encoded_request_id is None:
         encoded_request_id = _json_string_literal_bytes(request_id)
@@ -674,17 +753,17 @@ def _empty_attribute_event_json_line_bytes(
     event: ServingDiagnosticsEvent,
     request_id_literals: dict[str, bytes] | None = None,
 ) -> bytes | None:
-    if event.attributes is not _EMPTY_EVENT_ATTRIBUTES:
+    if event._attributes is not _EMPTY_EVENT_ATTRIBUTES:
         return None
-    event_index = event.event_index
-    duration_ms = event.duration_ms
+    event_index = event._event_index
+    duration_ms = event._duration_ms
     if type(event_index) is not int or type(duration_ms) is not float:
         return None
     if not _IS_FINITE(duration_ms):
         return None
-    phase = event.phase
-    request_id = event.request_id
-    status = event.status
+    phase = event._phase
+    request_id = event._request_id
+    status = event._status
     if request_id_literals is None:
         encoded_request_id = _json_string_literal_bytes(request_id)
     else:


### PR DESCRIPTION
## Summary
- Refs #350.
- Adds a diagnostics-only `serving_readiness` receipt to serving diagnostics effective-config bundles so existing metadata records requested/effective model identity, identity and budget sources, readiness timing, progress source, and dependency-policy status.
- Documents the slice and runbook contract: bundle writing reuses existing audit metadata and does not perform model discovery, health polling, package imports, or dependency-policy checks.
- Keeps serving diagnostics bundle serialization inside the existing PR-scoped performance gate with compact stable JSON writes and cheaper bundle directory setup.

## Plan or Spec
- Governing plan: `docs/plans/2026-07-04-issue-350-serving-readiness-diagnostics-receipts.md`
- Updated runbook: `docs/runbooks/serving-diagnostics-evidence.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py
# baseline before change: 49 passed in 0.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_preserves_serving_readiness_receipt services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_derives_readiness_receipt_from_metadata services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_skips_incomplete_readiness_metadata
# TDD red: .F.; expected KeyError: 'serving_readiness' for the derived-metadata path

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_preserves_serving_readiness_receipt services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_derives_readiness_receipt_from_metadata services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_skips_incomplete_readiness_metadata
# after implementation: 3 passed in 0.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 56 passed in 0.07s

git commit -m "Add serving readiness diagnostics receipts"
# pre-commit hook passed:
# - make swift-test: passed, elapsed 180.5s
# - make py-test: 4637 passed, 14 skipped, 2 warnings in 157.13s
# - make integration-test: 123 passed, 1 skipped in 421.59s
# - scoped performance report: .runtime/pre-commit-performance/20260704-133752-d68e3be9/report/report.md, Status ok, Regressions 0

git fetch origin main
git merge --no-edit origin/main
# merged origin/main at 03412443 into the branch; merge was clean

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_serving_diagnostics_queue_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# post-merge: 56 passed in 0.07s

git commit -m "Avoid redundant serving diagnostics stabilization"
# review fix pre-commit hook passed:
# - make swift-test: passed, elapsed 187.1s
# - make py-test: 4638 passed, 14 skipped, 2 warnings in 156.25s
# - make integration-test: 123 passed, 1 skipped in 417.24s
# - staged-file scoped performance report: .runtime/pre-commit-performance/20260704-135946-a6e1bb2a/report/report.md, Status ok, Regressions 0, Coverage 100.0%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
import runpy
root = Path.cwd()
changed_files = [line.strip() for line in subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"],
    text=True,
).splitlines() if line.strip()]
ns = runpy.run_path("scripts/pre_commit_gate.py")
outcome = ns["run_performance_report"](root, changed_files, base_ref="origin/main")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# .runtime/pre-commit-performance/20260704-140030-46b8b8ef/report/report.md, Status ok, Regressions 0, Coverage 96.0%

python3 scripts/validate_pr_evidence.py --body-file .runtime/pr-350-body.md
# PR evidence looks valid.
```

## Coverage and Metrics
- Branch head: `46b8b8ef6ec393dd07881b731849317593c093bd`; current base: `03412443587326eecbbc853dc7d0614728d1df00`.
- Changed-scope coverage: `96.0%` in `.runtime/pre-commit-performance/20260704-140030-46b8b8ef/report/report.md` for `Serving diagnostics debug queue bounds`.
- Metrics report: `.runtime/pre-commit-performance/20260704-140030-46b8b8ef/report/report.md`
- Report status: `ok`; regressions: `0`; verification failures: `0`.
- Probe overhead:
  - `elapsed_ms_mean`: 2.014 base, 1.269 head, -36.98%, improvement.
  - `serialization_elapsed_ms_mean`: 0.832 base, 0.840 head, +0.96%, neutral.
  - `dropped_count`, `retained_count`, `serialization_checksum`, and `serialized_bytes`: neutral.
- Review follow-up metrics: `.runtime/pre-commit-performance/20260704-135946-a6e1bb2a/report/report.md` covered the one-line review fix at `100.0%` changed-scope coverage with status `ok` and `0` regressions.
- Observability mode: debug diagnostics only. The receipt is written into local diagnostics bundles from existing metadata and is not runtime telemetry or public benchmark evidence.

## Known Gaps
- Broader #350 acceleration-profile receipts, capability receipt capture, and full diagnostics bundle policy remain outside this slice.
- No protocol schema changes, generated artifacts, dependency changes, or lockfile changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
