### PR TITLE
Add network fetch privacy receipts

### DIFF
--- a/docs/plans/2026-07-04-issue-2188-network-fetch-policy-receipts.md
+++ b/docs/plans/2026-07-04-issue-2188-network-fetch-policy-receipts.md
@@ -1,0 +1,115 @@
+# Issue 2188 Network Fetch Policy Receipts
+
+## Goal
+
+Land the next executable privacy-policy slice for local proxy and workspace
+ingest safety evidence by defining stable network-fetch and aggregate privacy
+audit receipt shapes, then wiring those shapes into existing diagnostics
+surfaces without adding network I/O.
+
+## Scope
+
+- Add `NetworkFetchPolicyReceipt` and `PrivacyAuditCounter` helpers for Python
+  workspace and diagnostics code.
+- Classify URL candidates as public, loopback, link-local, private, local, or
+  invalid without performing DNS or HTTP fetches.
+- Accept an already-resolved IP from the caller so DNS-rebinding-style host
+  changes can be recorded as blocked private-network targets.
+- Add a local workspace-ingest preflight network-fetch receipt that proves the
+  current ingest path is local-only and does not dereference remote URLs.
+- Add namespaced diagnostics metadata support so proxy or worker surfaces can
+  emit network-fetch and privacy-audit receipts into
+  `effective-config.json`.
+- Extend the Swift local proxy external-media URL admission path to expose the
+  same receipt and audit-counter schema for blocked unsafe URLs and to forward
+  accepted remote-media decisions through worker request metadata.
+- Keep raw URLs, query strings, fragments, userinfo, and private-network
+  targets out of exported diagnostics and client-visible error bodies.
+
+## Non-Goals
+
+- No new protobuf schema.
+- No DNS resolver, HTTP client, redirect follower, or remote URL fetch.
+- No change to local proxy Host/Origin security policy behavior.
+- No change to remote provider base-URL storage or provider health probes.
+- No model-backed privacy detector or NER.
+
+## Receipt Shapes
+
+`NetworkFetchPolicyReceipt` uses schema version
+`melix.network_fetch_policy_receipt.v1` and records:
+
+- `surface`
+- `route_scope`
+- `action` (`passed` or `blocked`)
+- `url_class`
+- `url_scheme`
+- `host_class`
+- `resolved_ip`
+- `resolved_ip_class`
+- `redirect_hops_checked`
+- `blocked_reason`
+- `redacted_url`
+- `raw_url_included`
+- `fetch_attempted`
+
+`PrivacyAuditCounter` uses schema version `melix.privacy_audit_counter.v1` and
+records:
+
+- `surface`
+- `route_scope`
+- `blocked_count`
+- `redacted_count`
+- `passed_count`
+- `raw_sensitive_span_count`
+
+## Architecture
+
+The Python helper owns the canonical JSON shape used by workspace preflight and
+serving diagnostics bundle writing. The helper performs deterministic parsing
+and IP classification only; any caller that performs DNS resolution must pass the
+resolved address into the helper. Private, loopback, link-local, and invalid
+targets are blocked before fetch, and their receipts carry only classified or
+redacted target evidence.
+
+Workspace preflight emits a local-only `network_fetch_policy` receipt and a
+`privacy_audit_counters` list because dataset ingest embeds the preflight receipt
+before reading sources. This gives the workspace-ingest path a machine-readable
+privacy receipt without changing ingest execution.
+
+Serving diagnostics preserves explicit receipt payloads and can synthesize them
+from complete namespaced metadata. Incomplete metadata remains nested in the
+original effective config so bundle writing does not fabricate partial privacy
+evidence.
+
+The Swift local proxy external-media URL admission path keeps its existing
+admission behavior. It adds the shared network-fetch receipt shape to blocked
+image-edit URL errors and forwards accepted URL-admission metadata into worker
+request `ext`, making downstream diagnostics able to surface the proxy decision.
+
+## Performance Probes And Metrics
+
+- Measurement points:
+  - workspace preflight receipt construction;
+  - serving diagnostics effective-config enrichment;
+  - local proxy external-media URL admission.
+- Target metrics:
+  - no network I/O during receipt construction;
+  - no raw sensitive spans in exported receipts;
+  - changed-scope coverage at least 95 percent.
+- Probe overhead:
+  - workspace and diagnostics overhead is small JSON construction on existing
+    receipt paths;
+  - local proxy overhead is only on external-media URL admission or 4xx refusal
+    paths.
+- PR-scoped performance:
+  - use the repository pre-commit scoped performance report. If no registered
+    probe matches all touched files, report the no-probe result explicitly.
+
+## Verification
+
+- Focused Python tests for network-fetch classification, redaction, privacy
+  counters, workspace preflight receipt shape, dataset ingest embedding, and
+  serving diagnostics metadata derivation.
+- Focused Swift tests for external-media local proxy receipts and metadata.
+- Full repository pre-commit gate before PR update.

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -166,6 +166,83 @@ If any required readiness metadata key is missing, the writer leaves the
 original metadata in place and does not synthesize a partial top-level
 `serving_readiness` receipt.
 
+When a proxy, workspace-ingest, or worker path has already evaluated network
+fetch safety, `effective-config.json` may include a `network_fetch_policy`
+receipt and `privacy_audit_counters`. These receipts are diagnostics-only:
+bundle writing must not resolve hostnames, follow redirects, open sockets,
+probe URLs, inspect source content, or rerun privacy detectors.
+
+`network_fetch_policy` uses schema version
+`melix.network_fetch_policy_receipt.v1` and records:
+
+- `surface` - emitting surface, such as `local_proxy_external_media` or
+  `workspace_ingest`.
+- `route_scope` - route or operation scope for the decision.
+- `action` - `passed` or `blocked`.
+- `url_class` - classified target, such as `public`, `loopback`,
+  `link_local`, `private`, `local`, or `invalid`.
+- `url_scheme` - normalized URL scheme or `path` for local path inputs.
+- `host_class` - classified host before any caller-provided resolved IP.
+- `resolved_ip` - public resolved IP when safe to expose, or a redaction marker
+  for private-network targets.
+- `resolved_ip_class` - classified caller-provided resolved IP.
+- `redirect_hops_checked` - number of redirect hops already evaluated by the
+  caller.
+- `blocked_reason` - typed refusal reason, or an empty string for passed
+  decisions.
+- `redacted_url` - URL summary with userinfo, path detail, query, and fragment
+  removed.
+- `raw_url_included` - always false for exported Melix diagnostics.
+- `fetch_attempted` - whether the emitting path attempted a network fetch.
+
+Diagnostics writers may derive `network_fetch_policy` from namespaced metadata
+when all of these keys are present:
+
+- `melix.network_fetch.policy.surface`
+- `melix.network_fetch.policy.route_scope`
+- `melix.network_fetch.policy.action`
+- `melix.network_fetch.policy.url_class`
+- `melix.network_fetch.policy.url_scheme`
+- `melix.network_fetch.policy.host_class`
+- `melix.network_fetch.policy.redirect_hops_checked`
+- `melix.network_fetch.policy.blocked_reason`
+- `melix.network_fetch.policy.redacted_url`
+- `melix.network_fetch.policy.raw_url_included`
+- `melix.network_fetch.policy.fetch_attempted`
+
+Optional metadata keys:
+
+- `melix.network_fetch.policy.schema_version`
+- `melix.network_fetch.policy.resolved_ip`
+- `melix.network_fetch.policy.resolved_ip_class`
+
+If any required network-fetch metadata key is missing, the writer leaves the
+original metadata in place and does not synthesize a partial top-level receipt.
+
+`privacy_audit_counters` is a list of `melix.privacy_audit_counter.v1`
+objects. Each counter records:
+
+- `surface`
+- `route_scope`
+- `blocked_count`
+- `redacted_count`
+- `passed_count`
+- `raw_sensitive_span_count`
+
+Diagnostics writers may derive one counter from namespaced metadata when all of
+these keys are present:
+
+- `melix.privacy.audit.surface`
+- `melix.privacy.audit.route_scope`
+- `melix.privacy.audit.blocked_count`
+- `melix.privacy.audit.redacted_count`
+- `melix.privacy.audit.passed_count`
+- `melix.privacy.audit.raw_sensitive_span_count`
+
+Optional metadata key:
+
+- `melix.privacy.audit.schema_version`
+
 `request-summary.json` records stable request-level fields:
 
 - request id

--- a/docs/workspace-manifest-contract.md
+++ b/docs/workspace-manifest-contract.md
@@ -110,8 +110,23 @@ Preflight returns stable JSON with:
 - `workspace_manifest_schema_version`
 - `project_id`
 - `manifest_path`
+- `network_fetch_policy`
+- `privacy_audit_counters`
 - `checks`
 - `metrics`
+
+`network_fetch_policy` uses schema version
+`melix.network_fetch_policy_receipt.v1`. During workspace preflight the receipt
+records `surface: workspace_ingest`, `route_scope: workspace_preflight`,
+`action: passed`, `url_class: local`, `raw_url_included: false`, and
+`fetch_attempted: false`. This receipt is a local-only policy statement; it does
+not perform DNS resolution, HTTP requests, redirect following, or source-file
+reads.
+
+`privacy_audit_counters` is a list of `melix.privacy_audit_counter.v1`
+objects. Workspace preflight emits a single counter for the
+`workspace_ingest` / `workspace_preflight` surface with one passed decision and
+zero blocked, redacted, or raw-sensitive-span counts.
 
 Each check is designed for CLI, Desktop, and report consumers to explain the
 failure without reading raw logs. A check contains:

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -5282,16 +5282,17 @@ button.primary:active {
             return .accepted(receipt)
         } catch let error as ExternalMediaURLAdmissionError {
             await recordExternalMediaURLRefusal(error)
-            return .rejected(invalidArgumentResponse(message: error.operatorMessage))
+            return .rejected(externalMediaURLAdmissionErrorResponse(error, rawURL: rawURL))
         } catch {
             let admissionError = ExternalMediaURLAdmissionError.malformedURL(mediaKind)
             await recordExternalMediaURLRefusal(admissionError)
-            return .rejected(invalidArgumentResponse(message: admissionError.operatorMessage))
+            return .rejected(externalMediaURLAdmissionErrorResponse(admissionError, rawURL: rawURL))
         }
     }
 
     private func recordExternalMediaURLAdmission(_ receipt: ExternalMediaURLAdmissionReceipt) async {
         await metricsStore.increment("external_media.url_admission_count")
+        await metricsStore.increment("privacy_audit.passed_count")
         if receipt.sourceKind == "remote" {
             await metricsStore.increment("external_media.remote_url_admission_count")
         } else {
@@ -5302,6 +5303,36 @@ button.primary:active {
     private func recordExternalMediaURLRefusal(_ error: ExternalMediaURLAdmissionError) async {
         await metricsStore.increment("external_media.url_refusal_count")
         await metricsStore.increment("external_media.refusal.\(error.refusalReason)")
+        await metricsStore.increment("privacy_audit.blocked_count")
+        await metricsStore.increment("privacy_audit.redacted_count")
+    }
+
+    private func externalMediaURLAdmissionErrorResponse(
+        _ error: ExternalMediaURLAdmissionError,
+        rawURL: String
+    ) -> HTTPResponse {
+        let receipt = error.networkFetchPolicyReceipt(
+            rawURL: rawURL,
+            surface: "local_proxy_external_media",
+            routeScope: "image_edit"
+        )
+        let counter = PrivacyAuditCounter(
+            surface: "local_proxy_external_media",
+            routeScope: "image_edit",
+            blockedCount: 1,
+            redactedCount: 1
+        )
+        return jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "invalid_argument",
+                    "message": error.operatorMessage,
+                    "privacy_receipt": receipt.jsonObject,
+                    "privacy_audit_counters": [counter.jsonObject],
+                ],
+            ]
+        )
     }
 
     private func applyExternalMediaURLReceipt(
@@ -5315,6 +5346,21 @@ button.primary:active {
         request.ext["\(prefix).reason"] = receipt.reason
         if !receipt.host.isEmpty {
             request.ext["\(prefix).host"] = receipt.host
+        }
+        let networkReceipt = receipt.networkFetchPolicyReceipt(
+            surface: "local_proxy_external_media",
+            routeScope: "image_edit"
+        )
+        for (key, value) in networkReceipt.metadataFields(prefix: "melix.network_fetch.policy") {
+            request.ext[key] = value
+        }
+        let counter = PrivacyAuditCounter(
+            surface: "local_proxy_external_media",
+            routeScope: "image_edit",
+            passedCount: 1
+        )
+        for (key, value) in counter.metadataFields(prefix: "melix.privacy.audit") {
+            request.ext[key] = value
         }
     }
 

--- a/services/control-plane-swift/Sources/Requests/ExternalMediaURLAdmission.swift
+++ b/services/control-plane-swift/Sources/Requests/ExternalMediaURLAdmission.swift
@@ -1,5 +1,144 @@
 import Foundation
 
+public struct NetworkFetchPolicyReceipt: Equatable, Sendable {
+    public let schemaVersion: String
+    public let surface: String
+    public let routeScope: String
+    public let action: String
+    public let urlClass: String
+    public let urlScheme: String
+    public let hostClass: String
+    public let resolvedIP: String
+    public let resolvedIPClass: String
+    public let redirectHopsChecked: Int
+    public let blockedReason: String
+    public let redactedURL: String
+    public let rawURLIncluded: Bool
+    public let fetchAttempted: Bool
+
+    public init(
+        schemaVersion: String = "melix.network_fetch_policy_receipt.v1",
+        surface: String,
+        routeScope: String,
+        action: String,
+        urlClass: String,
+        urlScheme: String,
+        hostClass: String,
+        resolvedIP: String = "",
+        resolvedIPClass: String = "",
+        redirectHopsChecked: Int = 0,
+        blockedReason: String = "",
+        redactedURL: String,
+        rawURLIncluded: Bool = false,
+        fetchAttempted: Bool = false
+    ) {
+        self.schemaVersion = schemaVersion
+        self.surface = surface
+        self.routeScope = routeScope
+        self.action = action
+        self.urlClass = urlClass
+        self.urlScheme = urlScheme
+        self.hostClass = hostClass
+        self.resolvedIP = resolvedIP
+        self.resolvedIPClass = resolvedIPClass
+        self.redirectHopsChecked = redirectHopsChecked
+        self.blockedReason = blockedReason
+        self.redactedURL = redactedURL
+        self.rawURLIncluded = rawURLIncluded
+        self.fetchAttempted = fetchAttempted
+    }
+
+    public var jsonObject: [String: Any] {
+        [
+            "schema_version": schemaVersion,
+            "surface": surface,
+            "route_scope": routeScope,
+            "action": action,
+            "url_class": urlClass,
+            "url_scheme": urlScheme,
+            "host_class": hostClass,
+            "resolved_ip": resolvedIP,
+            "resolved_ip_class": resolvedIPClass,
+            "redirect_hops_checked": redirectHopsChecked,
+            "blocked_reason": blockedReason,
+            "redacted_url": redactedURL,
+            "raw_url_included": rawURLIncluded,
+            "fetch_attempted": fetchAttempted,
+        ]
+    }
+
+    public func metadataFields(prefix: String) -> [String: String] {
+        [
+            "\(prefix).schema_version": schemaVersion,
+            "\(prefix).surface": surface,
+            "\(prefix).route_scope": routeScope,
+            "\(prefix).action": action,
+            "\(prefix).url_class": urlClass,
+            "\(prefix).url_scheme": urlScheme,
+            "\(prefix).host_class": hostClass,
+            "\(prefix).resolved_ip": resolvedIP,
+            "\(prefix).resolved_ip_class": resolvedIPClass,
+            "\(prefix).redirect_hops_checked": String(redirectHopsChecked),
+            "\(prefix).blocked_reason": blockedReason,
+            "\(prefix).redacted_url": redactedURL,
+            "\(prefix).raw_url_included": String(rawURLIncluded),
+            "\(prefix).fetch_attempted": String(fetchAttempted),
+        ]
+    }
+}
+
+public struct PrivacyAuditCounter: Equatable, Sendable {
+    public let schemaVersion: String
+    public let surface: String
+    public let routeScope: String
+    public let blockedCount: Int
+    public let redactedCount: Int
+    public let passedCount: Int
+    public let rawSensitiveSpanCount: Int
+
+    public init(
+        schemaVersion: String = "melix.privacy_audit_counter.v1",
+        surface: String,
+        routeScope: String,
+        blockedCount: Int = 0,
+        redactedCount: Int = 0,
+        passedCount: Int = 0,
+        rawSensitiveSpanCount: Int = 0
+    ) {
+        self.schemaVersion = schemaVersion
+        self.surface = surface
+        self.routeScope = routeScope
+        self.blockedCount = blockedCount
+        self.redactedCount = redactedCount
+        self.passedCount = passedCount
+        self.rawSensitiveSpanCount = rawSensitiveSpanCount
+    }
+
+    public var jsonObject: [String: Any] {
+        [
+            "schema_version": schemaVersion,
+            "surface": surface,
+            "route_scope": routeScope,
+            "blocked_count": blockedCount,
+            "redacted_count": redactedCount,
+            "passed_count": passedCount,
+            "raw_sensitive_span_count": rawSensitiveSpanCount,
+        ]
+    }
+
+    public func metadataFields(prefix: String) -> [String: String] {
+        [
+            "\(prefix).schema_version": schemaVersion,
+            "\(prefix).surface": surface,
+            "\(prefix).route_scope": routeScope,
+            "\(prefix).blocked_count": String(blockedCount),
+            "\(prefix).redacted_count": String(redactedCount),
+            "\(prefix).passed_count": String(passedCount),
+            "\(prefix).raw_sensitive_span_count": String(rawSensitiveSpanCount),
+        ]
+    }
+}
+
 public struct ExternalMediaURLAdmissionReceipt: Equatable, Sendable {
     public let policy: String
     public let sourceKind: String
@@ -14,6 +153,33 @@ public struct ExternalMediaURLAdmissionReceipt: Equatable, Sendable {
             scheme: scheme,
             host: "",
             reason: "local paths and file URLs stay inside local runtime handling"
+        )
+    }
+
+    public func networkFetchPolicyReceipt(
+        surface: String,
+        routeScope: String
+    ) -> NetworkFetchPolicyReceipt {
+        if sourceKind == "local" {
+            return NetworkFetchPolicyReceipt(
+                surface: surface,
+                routeScope: routeScope,
+                action: "passed",
+                urlClass: "local",
+                urlScheme: scheme,
+                hostClass: "local",
+                redactedURL: "[LOCAL_PATH]"
+            )
+        }
+        let hostClass = ExternalMediaURLAdmission.hostClass(for: host)
+        return NetworkFetchPolicyReceipt(
+            surface: surface,
+            routeScope: routeScope,
+            action: "passed",
+            urlClass: hostClass == "public" ? "public" : hostClass,
+            urlScheme: scheme,
+            hostClass: hostClass,
+            redactedURL: "\(scheme)://\(host)/[redacted]"
         )
     }
 }
@@ -48,6 +214,48 @@ public enum ExternalMediaURLAdmissionError: Error, Equatable {
         case .privateHost:
             return "private_or_loopback_host"
         }
+    }
+
+    public func networkFetchPolicyReceipt(
+        rawURL: String,
+        surface: String,
+        routeScope: String
+    ) -> NetworkFetchPolicyReceipt {
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let components = URLComponents(string: trimmed)
+        let scheme = components?.scheme?.lowercased() ?? ""
+        let host: String
+        let hostClass: String
+        switch self {
+        case .privateHost(let privateHost):
+            host = privateHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            hostClass = ExternalMediaURLAdmission.hostClass(for: host)
+        case .missingHost:
+            host = ""
+            hostClass = "missing"
+        case .malformedURL:
+            host = ""
+            hostClass = "invalid"
+        case .unsupportedScheme:
+            host = components?.host?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+            hostClass = host.isEmpty ? "missing" : ExternalMediaURLAdmission.hostClass(for: host)
+        }
+        let redactedURL: String
+        if hostClass == "loopback" || hostClass == "link_local" || hostClass == "private" {
+            redactedURL = "\(scheme.isEmpty ? "https" : scheme)://[REDACTED_PRIVATE_HOST]/[redacted]"
+        } else {
+            redactedURL = "[REDACTED_URL]"
+        }
+        return NetworkFetchPolicyReceipt(
+            surface: surface,
+            routeScope: routeScope,
+            action: "blocked",
+            urlClass: hostClass,
+            urlScheme: scheme,
+            hostClass: hostClass,
+            blockedReason: refusalReason,
+            redactedURL: redactedURL
+        )
     }
 }
 
@@ -93,34 +301,43 @@ public enum ExternalMediaURLAdmission {
         )
     }
 
-    private static func isPrivateOrLoopbackHost(_ host: String) -> Bool {
+    static func hostClass(for host: String) -> String {
         let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]")).lowercased()
         if normalized == "localhost" || normalized.hasSuffix(".localhost") {
-            return true
+            return "loopback"
         }
         if normalized.contains(":") {
-            if normalized == "::1" || normalized.hasPrefix("fe80:")
-                || normalized.hasPrefix("fc") || normalized.hasPrefix("fd")
-            {
-                return true
+            if normalized == "::1" {
+                return "loopback"
+            }
+            if normalized.hasPrefix("fe80:") {
+                return "link_local"
+            }
+            if normalized.hasPrefix("fc") || normalized.hasPrefix("fd") {
+                return "private"
             }
         }
         let parts = normalized.split(separator: ".").compactMap { UInt8($0) }
         guard parts.count == 4 else {
-            return false
+            return "public"
         }
         if parts[0] == 10 || parts[0] == 127 {
-            return true
+            return parts[0] == 127 ? "loopback" : "private"
         }
         if parts[0] == 169 && parts[1] == 254 {
-            return true
+            return "link_local"
         }
         if parts[0] == 172 && (16...31).contains(parts[1]) {
-            return true
+            return "private"
         }
         if parts[0] == 192 && parts[1] == 168 {
-            return true
+            return "private"
         }
-        return false
+        return "public"
+    }
+
+    private static func isPrivateOrLoopbackHost(_ host: String) -> Bool {
+        let hostClass = hostClass(for: host)
+        return hostClass == "loopback" || hostClass == "link_local" || hostClass == "private"
     }
 }

--- a/services/control-plane-swift/Sources/Requests/ExternalMediaURLAdmission.swift
+++ b/services/control-plane-swift/Sources/Requests/ExternalMediaURLAdmission.swift
@@ -307,6 +307,9 @@ public enum ExternalMediaURLAdmission {
             return "loopback"
         }
         if normalized.contains(":") {
+            if let ipv4Tail = ipv4TailFromIPv6Literal(normalized) {
+                return hostClass(for: ipv4Tail)
+            }
             if normalized == "::1" {
                 return "loopback"
             }
@@ -334,6 +337,18 @@ public enum ExternalMediaURLAdmission {
             return "private"
         }
         return "public"
+    }
+
+    private static func ipv4TailFromIPv6Literal(_ normalized: String) -> String? {
+        let tail: Substring
+        if normalized.hasPrefix("::ffff:") {
+            tail = normalized.dropFirst("::ffff:".count)
+        } else if normalized.hasPrefix("::") {
+            tail = normalized.dropFirst("::".count)
+        } else {
+            return nil
+        }
+        return tail.contains(".") ? String(tail) : nil
     }
 
     private static func isPrivateOrLoopbackHost(_ host: String) -> Bool {

--- a/services/control-plane-swift/Tests/ControlPlaneTests/MultimodalContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/MultimodalContractTests.swift
@@ -252,6 +252,20 @@ struct MultimodalContractTests {
         #expect(publicURL.scheme == "https")
         #expect(publicURL.host == "example.com")
         #expect(publicURL.reason == "accepted_https_public_host_without_fetch")
+        let networkPolicyReceipt = publicURL.networkFetchPolicyReceipt(
+            surface: "local_proxy_external_media",
+            routeScope: "chat_image"
+        )
+        #expect(networkPolicyReceipt.schemaVersion == "melix.network_fetch_policy_receipt.v1")
+        #expect(networkPolicyReceipt.surface == "local_proxy_external_media")
+        #expect(networkPolicyReceipt.routeScope == "chat_image")
+        #expect(networkPolicyReceipt.action == "passed")
+        #expect(networkPolicyReceipt.urlClass == "public")
+        #expect(networkPolicyReceipt.urlScheme == "https")
+        #expect(networkPolicyReceipt.hostClass == "public")
+        #expect(networkPolicyReceipt.redactedURL == "https://example.com/[redacted]")
+        #expect(networkPolicyReceipt.rawURLIncluded == false)
+        #expect(networkPolicyReceipt.fetchAttempted == false)
 
         let refusals: [(String, ExternalMediaURLAdmissionError)] = [
             ("", .malformedURL("image")),

--- a/services/control-plane-swift/Tests/ControlPlaneTests/MultimodalContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/MultimodalContractTests.swift
@@ -266,6 +266,9 @@ struct MultimodalContractTests {
         #expect(networkPolicyReceipt.redactedURL == "https://example.com/[redacted]")
         #expect(networkPolicyReceipt.rawURLIncluded == false)
         #expect(networkPolicyReceipt.fetchAttempted == false)
+        #expect(ExternalMediaURLAdmission.hostClass(for: "::ffff:127.0.0.1") == "loopback")
+        #expect(ExternalMediaURLAdmission.hostClass(for: "::ffff:10.0.0.1") == "private")
+        #expect(ExternalMediaURLAdmission.hostClass(for: "::127.0.0.1") == "loopback")
 
         let refusals: [(String, ExternalMediaURLAdmissionError)] = [
             ("", .malformedURL("image")),
@@ -283,6 +286,9 @@ struct MultimodalContractTests {
             ("https://[fe80::1]/image.png", .privateHost("[fe80::1]")),
             ("https://[fc00::1]/image.png", .privateHost("[fc00::1]")),
             ("https://[fd00::1]/image.png", .privateHost("[fd00::1]")),
+            ("https://[::ffff:127.0.0.1]/image.png", .privateHost("[::ffff:127.0.0.1]")),
+            ("https://[::ffff:10.0.0.1]/image.png", .privateHost("[::ffff:10.0.0.1]")),
+            ("https://[::127.0.0.1]/image.png", .privateHost("[::127.0.0.1]")),
         ]
 
         for (rawURL, expectedError) in refusals {

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -11859,6 +11859,21 @@ struct OpenAIHandlerTests {
         #expect(urlResponse.statusCode == 200)
         #expect(urlRequest.image.isEmpty)
         #expect(urlRequest.imageUri == "file:///tmp/source.png")
+        #expect(urlRequest.ext["melix.network_fetch.policy.schema_version"] == "melix.network_fetch_policy_receipt.v1")
+        #expect(urlRequest.ext["melix.network_fetch.policy.surface"] == "local_proxy_external_media")
+        #expect(urlRequest.ext["melix.network_fetch.policy.route_scope"] == "image_edit")
+        #expect(urlRequest.ext["melix.network_fetch.policy.action"] == "passed")
+        #expect(urlRequest.ext["melix.network_fetch.policy.url_class"] == "local")
+        #expect(urlRequest.ext["melix.network_fetch.policy.redacted_url"] == "[LOCAL_PATH]")
+        #expect(urlRequest.ext["melix.network_fetch.policy.raw_url_included"] == "false")
+        #expect(urlRequest.ext["melix.network_fetch.policy.fetch_attempted"] == "false")
+        #expect(urlRequest.ext["melix.privacy.audit.schema_version"] == "melix.privacy_audit_counter.v1")
+        #expect(urlRequest.ext["melix.privacy.audit.surface"] == "local_proxy_external_media")
+        #expect(urlRequest.ext["melix.privacy.audit.route_scope"] == "image_edit")
+        #expect(urlRequest.ext["melix.privacy.audit.blocked_count"] == "0")
+        #expect(urlRequest.ext["melix.privacy.audit.redacted_count"] == "0")
+        #expect(urlRequest.ext["melix.privacy.audit.passed_count"] == "1")
+        #expect(urlRequest.ext["melix.privacy.audit.raw_sensitive_span_count"] == "0")
         #expect(urlPayload.contains("\"state\":\"failed\""))
         #expect(urlPayload.contains("\"role\":\"unspecified\""))
         #expect(urlJob.state == .imageJobFailed)
@@ -11925,7 +11940,7 @@ struct OpenAIHandlerTests {
               "id": "image-edit-private-url",
               "model": "melix-dev-image",
               "prompt": "use remote",
-              "image_url": "https://127.0.0.1/source.png"
+              "image_url": "https://user:pass@127.0.0.1/source.png?api_key=sk-local#frag"
             }
             """.data(using: .utf8)
         )
@@ -11939,9 +11954,39 @@ struct OpenAIHandlerTests {
         #expect(response.statusCode == 400)
         #expect(error["code"] as? String == "invalid_argument")
         #expect(error["message"] as? String == "External media URL host is not allowed: 127.0.0.1.")
+        let privacyReceipt = try #require(error["privacy_receipt"] as? [String: Any])
+        #expect(privacyReceipt["schema_version"] as? String == "melix.network_fetch_policy_receipt.v1")
+        #expect(privacyReceipt["surface"] as? String == "local_proxy_external_media")
+        #expect(privacyReceipt["route_scope"] as? String == "image_edit")
+        #expect(privacyReceipt["action"] as? String == "blocked")
+        #expect(privacyReceipt["url_class"] as? String == "loopback")
+        #expect(privacyReceipt["url_scheme"] as? String == "https")
+        #expect(privacyReceipt["host_class"] as? String == "loopback")
+        #expect(privacyReceipt["blocked_reason"] as? String == "private_or_loopback_host")
+        #expect(privacyReceipt["redacted_url"] as? String == "https://[REDACTED_PRIVATE_HOST]/[redacted]")
+        #expect(privacyReceipt["raw_url_included"] as? Bool == false)
+        #expect(privacyReceipt["fetch_attempted"] as? Bool == false)
+        let counters = try #require(error["privacy_audit_counters"] as? [[String: Any]])
+        let counter = try #require(counters.first)
+        #expect(counter["schema_version"] as? String == "melix.privacy_audit_counter.v1")
+        #expect(counter["surface"] as? String == "local_proxy_external_media")
+        #expect(counter["route_scope"] as? String == "image_edit")
+        #expect(counter["blocked_count"] as? Int == 1)
+        #expect(counter["redacted_count"] as? Int == 1)
+        #expect(counter["passed_count"] as? Int == 0)
+        #expect(counter["raw_sensitive_span_count"] as? Int == 0)
+        let encodedPayload = String(
+            decoding: try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+            as: UTF8.self
+        )
+        for leakedFragment in ["user:pass", "api_key", "sk-local", "source.png", "#frag", "?api_key"] {
+            #expect(encodedPayload.contains(leakedFragment) == false)
+        }
         #expect(await imageClient.lastImageEditRequest == nil)
         #expect(await metricsStore.value(forKey: "external_media.url_refusal_count") == 1)
         #expect(await metricsStore.value(forKey: "external_media.refusal.private_or_loopback_host") == 1)
+        #expect(await metricsStore.value(forKey: "privacy_audit.blocked_count") == 1)
+        #expect(await metricsStore.value(forKey: "privacy_audit.redacted_count") == 1)
     }
 
     @Test("image edit responses map failed and completed states into payloads and job summaries")

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -348,6 +348,9 @@ def test_dataset_ingest_receipt_reports_independent_cleaning_controls(
     assert receipt["metrics"]["ingest_throughput_bytes_per_second"] > 0
     assert receipt["metrics"]["segmentation_latency_ms"] >= 0
     assert receipt["metrics"]["workspace_preflight_status"] == "ready"
+    assert receipt["workspace_preflight_receipt"]["network_fetch_policy"]["surface"] == "workspace_ingest"
+    assert receipt["workspace_preflight_receipt"]["network_fetch_policy"]["action"] == "passed"
+    assert receipt["workspace_preflight_receipt"]["privacy_audit_counters"][0]["passed_count"] == 1
 
     segments_path = output_root / "segments.jsonl"
     receipt_path = output_root / "dataset-ingest-receipt.json"

--- a/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
+++ b/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
@@ -4,6 +4,7 @@ import json
 
 from worker.productization.privacy_policy_receipts import (
     PrivacyAuditCounter,
+    network_fetch_policy_receipt_from_metadata,
     network_fetch_policy_receipt_for_url,
     privacy_audit_counter,
 )
@@ -60,6 +61,62 @@ def test_network_fetch_policy_receipt_blocks_private_targets_without_raw_url_lea
     assert "[REDACTED_PRIVATE_IP]" in payload
 
 
+def test_network_fetch_policy_receipt_blocks_ipv4_wrapped_loopback_targets() -> None:
+    host_receipt = network_fetch_policy_receipt_for_url(
+        "https://[::ffff:127.0.0.1]/private/source.png?token=sk-local",
+        surface="local_proxy_external_media",
+        route_scope="image_edit",
+    )
+    resolved_receipt = network_fetch_policy_receipt_for_url(
+        "https://public.example.test/private/source.png?token=sk-rebind",
+        surface="workspace_ingest",
+        route_scope="source_import",
+        resolved_ip="::ffff:127.0.0.1",
+    )
+    compatible_host_receipt = network_fetch_policy_receipt_for_url(
+        "https://[::127.0.0.1]/private/source.png?token=sk-compatible",
+        surface="local_proxy_external_media",
+        route_scope="image_edit",
+    )
+    compatible_resolved_receipt = network_fetch_policy_receipt_for_url(
+        "https://public.example.test/private/source.png?token=sk-compatible-rebind",
+        surface="workspace_ingest",
+        route_scope="source_import",
+        resolved_ip="::127.0.0.1",
+    )
+
+    assert host_receipt["action"] == "blocked"
+    assert host_receipt["url_class"] == "loopback"
+    assert host_receipt["host_class"] == "loopback"
+    assert host_receipt["blocked_reason"] == "private_or_loopback_host"
+    assert host_receipt["redacted_url"] == "https://[REDACTED_PRIVATE_HOST]/[redacted]"
+    assert resolved_receipt["action"] == "blocked"
+    assert resolved_receipt["host_class"] == "public"
+    assert resolved_receipt["resolved_ip"] == "[REDACTED_PRIVATE_IP]"
+    assert resolved_receipt["resolved_ip_class"] == "loopback"
+    assert resolved_receipt["blocked_reason"] == "resolved_private_or_loopback_ip"
+    assert compatible_host_receipt["action"] == "blocked"
+    assert compatible_host_receipt["url_class"] == "loopback"
+    assert compatible_host_receipt["host_class"] == "loopback"
+    assert compatible_resolved_receipt["action"] == "blocked"
+    assert compatible_resolved_receipt["resolved_ip"] == "[REDACTED_PRIVATE_IP]"
+    assert compatible_resolved_receipt["resolved_ip_class"] == "loopback"
+    payload = json.dumps(
+        [
+            host_receipt,
+            resolved_receipt,
+            compatible_host_receipt,
+            compatible_resolved_receipt,
+        ],
+        sort_keys=True,
+    )
+    assert "::ffff:127.0.0.1" not in payload
+    assert "::127.0.0.1" not in payload
+    assert "sk-local" not in payload
+    assert "sk-rebind" not in payload
+    assert "sk-compatible" not in payload
+
+
 def test_network_fetch_policy_receipt_passes_public_https_and_local_workspace_paths() -> None:
     public_receipt = network_fetch_policy_receipt_for_url(
         " HTTPS://Example.com/source.png?api_key=sk-public#frag ",
@@ -95,6 +152,30 @@ def test_network_fetch_policy_receipt_passes_public_https_and_local_workspace_pa
     assert local_receipt["url_scheme"] == "path"
     assert local_receipt["redacted_url"] == "[LOCAL_PATH]"
     assert "/Users/operator/private" not in json.dumps(local_receipt, sort_keys=True)
+
+
+def test_network_fetch_policy_receipt_metadata_accepts_numeric_boolean_values() -> None:
+    receipt = network_fetch_policy_receipt_from_metadata(
+        {
+            "melix.network_fetch.policy.surface": "local_proxy_external_media",
+            "melix.network_fetch.policy.route_scope": "image_edit",
+            "melix.network_fetch.policy.action": "passed",
+            "melix.network_fetch.policy.url_class": "public",
+            "melix.network_fetch.policy.url_scheme": "https",
+            "melix.network_fetch.policy.host_class": "public",
+            "melix.network_fetch.policy.resolved_ip": "93.184.216.34",
+            "melix.network_fetch.policy.resolved_ip_class": "public",
+            "melix.network_fetch.policy.redirect_hops_checked": "0",
+            "melix.network_fetch.policy.blocked_reason": "",
+            "melix.network_fetch.policy.redacted_url": "https://example.com/[redacted]",
+            "melix.network_fetch.policy.raw_url_included": 0,
+            "melix.network_fetch.policy.fetch_attempted": 1,
+        }
+    )
+
+    assert receipt
+    assert receipt["raw_url_included"] is False
+    assert receipt["fetch_attempted"] is True
 
 
 def test_privacy_audit_counter_counts_blocked_redacted_and_passed_decisions() -> None:

--- a/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
+++ b/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+
+from worker.productization.privacy_policy_receipts import (
+    PrivacyAuditCounter,
+    network_fetch_policy_receipt_for_url,
+    privacy_audit_counter,
+)
+
+
+def test_network_fetch_policy_receipt_blocks_private_targets_without_raw_url_leaks() -> None:
+    receipts = [
+        network_fetch_policy_receipt_for_url(
+            "https://user:pass@127.0.0.1/private/source.png?api_key=sk-local#frag",
+            surface="local_proxy_external_media",
+            route_scope="image_edit",
+        ),
+        network_fetch_policy_receipt_for_url(
+            "https://169.254.169.254/latest/meta-data?token=hf_secret_abcdef",
+            surface="local_proxy_external_media",
+            route_scope="image_edit",
+        ),
+        network_fetch_policy_receipt_for_url(
+            "https://10.0.0.5/private/source.png",
+            surface="local_proxy_external_media",
+            route_scope="image_edit",
+        ),
+        network_fetch_policy_receipt_for_url(
+            "https://public.example.test/image.png?token=sk-rebind",
+            surface="workspace_ingest",
+            route_scope="source_import",
+            resolved_ip="10.0.0.7",
+        ),
+    ]
+
+    assert [receipt["action"] for receipt in receipts] == ["blocked"] * 4
+    assert [receipt["url_class"] for receipt in receipts] == [
+        "loopback",
+        "link_local",
+        "private",
+        "private",
+    ]
+    assert receipts[-1]["host_class"] == "public"
+    assert receipts[-1]["resolved_ip_class"] == "private"
+    assert receipts[-1]["blocked_reason"] == "resolved_private_or_loopback_ip"
+    payload = json.dumps(receipts, sort_keys=True)
+    for raw_fragment in (
+        "user",
+        "pass",
+        "api_key",
+        "sk-local",
+        "hf_secret",
+        "latest/meta-data",
+        "private/source",
+        "sk-rebind",
+        "10.0.0.7",
+    ):
+        assert raw_fragment not in payload
+    assert "[REDACTED_PRIVATE_IP]" in payload
+
+
+def test_network_fetch_policy_receipt_passes_public_https_and_local_workspace_paths() -> None:
+    public_receipt = network_fetch_policy_receipt_for_url(
+        " HTTPS://Example.com/source.png?api_key=sk-public#frag ",
+        surface="local_proxy_external_media",
+        route_scope="image_edit",
+        resolved_ip="93.184.216.34",
+        redirect_hops_checked=1,
+    )
+    local_receipt = network_fetch_policy_receipt_for_url(
+        "/Users/operator/private/raw-inputs/source.jsonl",
+        surface="workspace_ingest",
+        route_scope="workspace_preflight",
+    )
+
+    assert public_receipt == {
+        "schema_version": "melix.network_fetch_policy_receipt.v1",
+        "surface": "local_proxy_external_media",
+        "route_scope": "image_edit",
+        "action": "passed",
+        "url_class": "public",
+        "url_scheme": "https",
+        "host_class": "public",
+        "resolved_ip": "93.184.216.34",
+        "resolved_ip_class": "public",
+        "redirect_hops_checked": 1,
+        "blocked_reason": "",
+        "redacted_url": "https://example.com/[redacted]",
+        "raw_url_included": False,
+        "fetch_attempted": False,
+    }
+    assert local_receipt["action"] == "passed"
+    assert local_receipt["url_class"] == "local"
+    assert local_receipt["url_scheme"] == "path"
+    assert local_receipt["redacted_url"] == "[LOCAL_PATH]"
+    assert "/Users/operator/private" not in json.dumps(local_receipt, sort_keys=True)
+
+
+def test_privacy_audit_counter_counts_blocked_redacted_and_passed_decisions() -> None:
+    counter = privacy_audit_counter(
+        surface="local_proxy_external_media",
+        route_scope="image_edit",
+        decisions=("blocked", "redacted", "passed", "redacted"),
+    )
+
+    assert isinstance(counter, PrivacyAuditCounter)
+    assert counter.to_dict() == {
+        "schema_version": "melix.privacy_audit_counter.v1",
+        "surface": "local_proxy_external_media",
+        "route_scope": "image_edit",
+        "blocked_count": 1,
+        "redacted_count": 2,
+        "passed_count": 1,
+        "raw_sensitive_span_count": 0,
+    }

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -450,6 +450,103 @@ def test_serving_diagnostics_effective_config_skips_incomplete_readiness_metadat
     assert "serving_readiness" not in effective_config
 
 
+def test_serving_diagnostics_effective_config_derives_privacy_policy_receipts_from_metadata(
+    tmp_path: Path,
+) -> None:
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-network-fetch-policy",
+        invocation={},
+        effective_config={
+            "execution_ext": {
+                "melix.network_fetch.policy.schema_version": "melix.network_fetch_policy_receipt.v1",
+                "melix.network_fetch.policy.surface": "local_proxy_external_media",
+                "melix.network_fetch.policy.route_scope": "image_edit",
+                "melix.network_fetch.policy.action": "blocked",
+                "melix.network_fetch.policy.url_class": "private",
+                "melix.network_fetch.policy.url_scheme": "https",
+                "melix.network_fetch.policy.host_class": "public",
+                "melix.network_fetch.policy.resolved_ip": "[REDACTED_PRIVATE_IP]",
+                "melix.network_fetch.policy.resolved_ip_class": "private",
+                "melix.network_fetch.policy.redirect_hops_checked": "1",
+                "melix.network_fetch.policy.blocked_reason": "resolved_private_or_loopback_ip",
+                "melix.network_fetch.policy.redacted_url": "https://example.test/[redacted]",
+                "melix.network_fetch.policy.raw_url_included": "false",
+                "melix.network_fetch.policy.fetch_attempted": "false",
+                "melix.privacy.audit.schema_version": "melix.privacy_audit_counter.v1",
+                "melix.privacy.audit.surface": "local_proxy_external_media",
+                "melix.privacy.audit.route_scope": "image_edit",
+                "melix.privacy.audit.blocked_count": "1",
+                "melix.privacy.audit.redacted_count": "1",
+                "melix.privacy.audit.passed_count": "0",
+                "melix.privacy.audit.raw_sensitive_span_count": "0",
+            }
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert effective_config["network_fetch_policy"] == {
+        "schema_version": "melix.network_fetch_policy_receipt.v1",
+        "surface": "local_proxy_external_media",
+        "route_scope": "image_edit",
+        "action": "blocked",
+        "url_class": "private",
+        "url_scheme": "https",
+        "host_class": "public",
+        "resolved_ip": "[REDACTED_PRIVATE_IP]",
+        "resolved_ip_class": "private",
+        "redirect_hops_checked": 1,
+        "blocked_reason": "resolved_private_or_loopback_ip",
+        "redacted_url": "https://example.test/[redacted]",
+        "raw_url_included": False,
+        "fetch_attempted": False,
+    }
+    assert effective_config["privacy_audit_counters"] == [
+        {
+            "schema_version": "melix.privacy_audit_counter.v1",
+            "surface": "local_proxy_external_media",
+            "route_scope": "image_edit",
+            "blocked_count": 1,
+            "redacted_count": 1,
+            "passed_count": 0,
+            "raw_sensitive_span_count": 0,
+        }
+    ]
+    payload = json.dumps(effective_config, sort_keys=True)
+    assert "api_key" not in payload
+    assert "sk-secret" not in payload
+
+
+def test_serving_diagnostics_effective_config_skips_incomplete_privacy_policy_metadata(
+    tmp_path: Path,
+) -> None:
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-network-fetch-policy-incomplete",
+        invocation={},
+        effective_config={
+            "request_metadata": {
+                "melix.network_fetch.policy.surface": "local_proxy_external_media",
+                "melix.network_fetch.policy.action": "blocked",
+                "melix.privacy.audit.surface": "local_proxy_external_media",
+                "melix.privacy.audit.blocked_count": "1",
+            }
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert "network_fetch_policy" not in effective_config
+    assert "privacy_audit_counters" not in effective_config
+
+
 def test_serving_diagnostics_empty_effective_config_skips_profile_receipt_scan(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/services/mlx-worker-python/tests/test_workspace_manifest_contract.py
+++ b/services/mlx-worker-python/tests/test_workspace_manifest_contract.py
@@ -248,6 +248,33 @@ def test_workspace_preflight_ready_receipt_is_machine_readable(tmp_path: Path) -
     assert receipt["metrics"]["unmanaged_artifact_count"] == 0
     assert receipt["metrics"]["preflight_latency_ms"] >= 0
     assert receipt["metrics"]["migration_validation_latency_ms"] >= 0
+    assert receipt["network_fetch_policy"] == {
+        "schema_version": "melix.network_fetch_policy_receipt.v1",
+        "surface": "workspace_ingest",
+        "route_scope": "workspace_preflight",
+        "action": "passed",
+        "url_class": "local",
+        "url_scheme": "path",
+        "host_class": "local",
+        "resolved_ip": "",
+        "resolved_ip_class": "",
+        "redirect_hops_checked": 0,
+        "blocked_reason": "",
+        "redacted_url": "[LOCAL_PATH]",
+        "raw_url_included": False,
+        "fetch_attempted": False,
+    }
+    assert receipt["privacy_audit_counters"] == [
+        {
+            "schema_version": "melix.privacy_audit_counter.v1",
+            "surface": "workspace_ingest",
+            "route_scope": "workspace_preflight",
+            "blocked_count": 0,
+            "redacted_count": 0,
+            "passed_count": 1,
+            "raw_sensitive_span_count": 0,
+        }
+    ]
 
 
 def test_workspace_preflight_receipt_contract_has_stable_json_shape(
@@ -263,6 +290,8 @@ def test_workspace_preflight_receipt_contract_has_stable_json_shape(
         "workspace_manifest_schema_version",
         "project_id",
         "manifest_path",
+        "network_fetch_policy",
+        "privacy_audit_counters",
         "checks",
         "metrics",
     }

--- a/services/mlx-worker-python/worker/productization/privacy_policy_receipts.py
+++ b/services/mlx-worker-python/worker/productization/privacy_policy_receipts.py
@@ -350,6 +350,12 @@ def _classify_host(host: str) -> str:
     normalized = host.strip("[]").lower()
     if normalized == "localhost" or normalized.endswith(".localhost"):
         return "loopback"
+    ipv4_tail = _ipv4_tail_from_ipv6_literal(normalized)
+    if ipv4_tail:
+        try:
+            return _classify_ip(ip_address(ipv4_tail))
+        except ValueError:
+            pass
     try:
         return _classify_ip(ip_address(normalized))
     except ValueError:
@@ -357,9 +363,15 @@ def _classify_host(host: str) -> str:
 
 
 def _classify_ip_literal(value: str) -> str:
-    stripped = str(value).strip().strip("[]")
+    stripped = str(value).strip().strip("[]").lower()
     if not stripped:
         return ""
+    ipv4_tail = _ipv4_tail_from_ipv6_literal(stripped)
+    if ipv4_tail:
+        try:
+            return _classify_ip(ip_address(ipv4_tail))
+        except ValueError:
+            pass
     try:
         return _classify_ip(ip_address(stripped))
     except ValueError:
@@ -367,6 +379,9 @@ def _classify_ip_literal(value: str) -> str:
 
 
 def _classify_ip(address: object) -> str:
+    ipv4_mapped = getattr(address, "ipv4_mapped", None)
+    if ipv4_mapped is not None:
+        address = ipv4_mapped
     if getattr(address, "is_loopback", False):
         return "loopback"
     if getattr(address, "is_link_local", False):
@@ -374,6 +389,18 @@ def _classify_ip(address: object) -> str:
     if getattr(address, "is_private", False):
         return "private"
     return "public"
+
+
+def _ipv4_tail_from_ipv6_literal(value: str) -> str:
+    if value.startswith("::ffff:"):
+        tail = value.removeprefix("::ffff:")
+    elif value.startswith("::"):
+        tail = value.removeprefix("::")
+    else:
+        return ""
+    if "." not in tail:
+        return ""
+    return tail
 
 
 def _effective_url_class(host_class: str, resolved_ip_class: str) -> str:
@@ -421,6 +448,11 @@ def _redacted_url(
 def _bool_value(value: object) -> bool | None:
     if isinstance(value, bool):
         return value
+    if isinstance(value, (int, float)):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
     if isinstance(value, str):
         normalized = value.strip().lower()
         if normalized in {"true", "1", "yes"}:

--- a/services/mlx-worker-python/worker/productization/privacy_policy_receipts.py
+++ b/services/mlx-worker-python/worker/productization/privacy_policy_receipts.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from ipaddress import ip_address
+from urllib.parse import urlsplit
+
+
+NETWORK_FETCH_POLICY_RECEIPT_SCHEMA_VERSION = "melix.network_fetch_policy_receipt.v1"
+PRIVACY_AUDIT_COUNTER_SCHEMA_VERSION = "melix.privacy_audit_counter.v1"
+
+_PRIVATE_IP_REDACTION = "[REDACTED_PRIVATE_IP]"
+_LOCAL_PATH_REDACTION = "[LOCAL_PATH]"
+
+_NETWORK_FETCH_METADATA_FIELDS = {
+    "melix.network_fetch.policy.surface": "surface",
+    "melix.network_fetch.policy.route_scope": "route_scope",
+    "melix.network_fetch.policy.action": "action",
+    "melix.network_fetch.policy.url_class": "url_class",
+    "melix.network_fetch.policy.url_scheme": "url_scheme",
+    "melix.network_fetch.policy.host_class": "host_class",
+    "melix.network_fetch.policy.resolved_ip": "resolved_ip",
+    "melix.network_fetch.policy.resolved_ip_class": "resolved_ip_class",
+    "melix.network_fetch.policy.redirect_hops_checked": "redirect_hops_checked",
+    "melix.network_fetch.policy.blocked_reason": "blocked_reason",
+    "melix.network_fetch.policy.redacted_url": "redacted_url",
+    "melix.network_fetch.policy.raw_url_included": "raw_url_included",
+    "melix.network_fetch.policy.fetch_attempted": "fetch_attempted",
+}
+_NETWORK_FETCH_REQUIRED_FIELDS = frozenset(
+    (
+        "surface",
+        "route_scope",
+        "action",
+        "url_class",
+        "url_scheme",
+        "host_class",
+        "redirect_hops_checked",
+        "blocked_reason",
+        "redacted_url",
+        "raw_url_included",
+        "fetch_attempted",
+    )
+)
+
+_PRIVACY_AUDIT_METADATA_FIELDS = {
+    "melix.privacy.audit.surface": "surface",
+    "melix.privacy.audit.route_scope": "route_scope",
+    "melix.privacy.audit.blocked_count": "blocked_count",
+    "melix.privacy.audit.redacted_count": "redacted_count",
+    "melix.privacy.audit.passed_count": "passed_count",
+    "melix.privacy.audit.raw_sensitive_span_count": "raw_sensitive_span_count",
+}
+_PRIVACY_AUDIT_REQUIRED_FIELDS = frozenset(_PRIVACY_AUDIT_METADATA_FIELDS.values())
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkFetchPolicyReceipt:
+    surface: str
+    route_scope: str
+    action: str
+    url_class: str
+    url_scheme: str
+    host_class: str
+    resolved_ip: str = ""
+    resolved_ip_class: str = ""
+    redirect_hops_checked: int = 0
+    blocked_reason: str = ""
+    redacted_url: str = ""
+    raw_url_included: bool = False
+    fetch_attempted: bool = False
+    schema_version: str = NETWORK_FETCH_POLICY_RECEIPT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "surface": self.surface,
+            "route_scope": self.route_scope,
+            "action": self.action,
+            "url_class": self.url_class,
+            "url_scheme": self.url_scheme,
+            "host_class": self.host_class,
+            "resolved_ip": self.resolved_ip,
+            "resolved_ip_class": self.resolved_ip_class,
+            "redirect_hops_checked": int(self.redirect_hops_checked),
+            "blocked_reason": self.blocked_reason,
+            "redacted_url": self.redacted_url,
+            "raw_url_included": bool(self.raw_url_included),
+            "fetch_attempted": bool(self.fetch_attempted),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PrivacyAuditCounter:
+    surface: str
+    route_scope: str
+    blocked_count: int = 0
+    redacted_count: int = 0
+    passed_count: int = 0
+    raw_sensitive_span_count: int = 0
+    schema_version: str = PRIVACY_AUDIT_COUNTER_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "surface": self.surface,
+            "route_scope": self.route_scope,
+            "blocked_count": int(self.blocked_count),
+            "redacted_count": int(self.redacted_count),
+            "passed_count": int(self.passed_count),
+            "raw_sensitive_span_count": int(self.raw_sensitive_span_count),
+        }
+
+
+def network_fetch_policy_receipt_for_url(
+    raw_url: str,
+    *,
+    surface: str,
+    route_scope: str,
+    resolved_ip: str = "",
+    redirect_hops_checked: int = 0,
+) -> dict[str, object]:
+    """Build a redacted network-fetch policy receipt without dereferencing URLs."""
+
+    receipt = _network_fetch_policy_receipt(
+        raw_url,
+        surface=surface,
+        route_scope=route_scope,
+        resolved_ip=resolved_ip,
+        redirect_hops_checked=redirect_hops_checked,
+    )
+    return receipt.to_dict()
+
+
+def privacy_audit_counter(
+    *,
+    surface: str,
+    route_scope: str,
+    decisions: tuple[str, ...] = (),
+    raw_sensitive_span_count: int = 0,
+) -> PrivacyAuditCounter:
+    return PrivacyAuditCounter(
+        surface=surface,
+        route_scope=route_scope,
+        blocked_count=sum(1 for decision in decisions if decision == "blocked"),
+        redacted_count=sum(1 for decision in decisions if decision == "redacted"),
+        passed_count=sum(1 for decision in decisions if decision == "passed"),
+        raw_sensitive_span_count=raw_sensitive_span_count,
+    )
+
+
+def workspace_ingest_network_fetch_policy_receipt() -> dict[str, object]:
+    return network_fetch_policy_receipt_for_url(
+        ".",
+        surface="workspace_ingest",
+        route_scope="workspace_preflight",
+    )
+
+
+def workspace_ingest_privacy_audit_counters() -> list[dict[str, object]]:
+    return [
+        privacy_audit_counter(
+            surface="workspace_ingest",
+            route_scope="workspace_preflight",
+            decisions=("passed",),
+        ).to_dict()
+    ]
+
+
+def network_fetch_policy_receipt_from_metadata(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    receipt = {
+        receipt_key: metadata.get(audit_key)
+        for audit_key, receipt_key in _NETWORK_FETCH_METADATA_FIELDS.items()
+        if metadata.get(audit_key) is not None
+    }
+    if not _NETWORK_FETCH_REQUIRED_FIELDS.issubset(receipt):
+        return {}
+    schema_version = str(
+        metadata.get(
+            "melix.network_fetch.policy.schema_version",
+            NETWORK_FETCH_POLICY_RECEIPT_SCHEMA_VERSION,
+        )
+    )
+    if schema_version != NETWORK_FETCH_POLICY_RECEIPT_SCHEMA_VERSION:
+        return {}
+    parsed_redirect_hops = _int_value(receipt["redirect_hops_checked"])
+    raw_url_included = _bool_value(receipt["raw_url_included"])
+    fetch_attempted = _bool_value(receipt["fetch_attempted"])
+    if parsed_redirect_hops is None or raw_url_included is None or fetch_attempted is None:
+        return {}
+    return NetworkFetchPolicyReceipt(
+        surface=str(receipt["surface"]),
+        route_scope=str(receipt["route_scope"]),
+        action=str(receipt["action"]),
+        url_class=str(receipt["url_class"]),
+        url_scheme=str(receipt["url_scheme"]),
+        host_class=str(receipt["host_class"]),
+        resolved_ip=str(receipt.get("resolved_ip", "")),
+        resolved_ip_class=str(receipt.get("resolved_ip_class", "")),
+        redirect_hops_checked=parsed_redirect_hops,
+        blocked_reason=str(receipt["blocked_reason"]),
+        redacted_url=str(receipt["redacted_url"]),
+        raw_url_included=raw_url_included,
+        fetch_attempted=fetch_attempted,
+    ).to_dict()
+
+
+def privacy_audit_counter_from_metadata(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    counter = {
+        receipt_key: metadata.get(audit_key)
+        for audit_key, receipt_key in _PRIVACY_AUDIT_METADATA_FIELDS.items()
+        if metadata.get(audit_key) is not None
+    }
+    if not _PRIVACY_AUDIT_REQUIRED_FIELDS.issubset(counter):
+        return {}
+    schema_version = str(
+        metadata.get(
+            "melix.privacy.audit.schema_version",
+            PRIVACY_AUDIT_COUNTER_SCHEMA_VERSION,
+        )
+    )
+    if schema_version != PRIVACY_AUDIT_COUNTER_SCHEMA_VERSION:
+        return {}
+    parsed_counts = {
+        key: _int_value(counter[key])
+        for key in (
+            "blocked_count",
+            "redacted_count",
+            "passed_count",
+            "raw_sensitive_span_count",
+        )
+    }
+    if any(value is None for value in parsed_counts.values()):
+        return {}
+    return PrivacyAuditCounter(
+        surface=str(counter["surface"]),
+        route_scope=str(counter["route_scope"]),
+        blocked_count=parsed_counts["blocked_count"] or 0,
+        redacted_count=parsed_counts["redacted_count"] or 0,
+        passed_count=parsed_counts["passed_count"] or 0,
+        raw_sensitive_span_count=parsed_counts["raw_sensitive_span_count"] or 0,
+    ).to_dict()
+
+
+def _network_fetch_policy_receipt(
+    raw_url: str,
+    *,
+    surface: str,
+    route_scope: str,
+    resolved_ip: str,
+    redirect_hops_checked: int,
+) -> NetworkFetchPolicyReceipt:
+    value = str(raw_url).strip()
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return NetworkFetchPolicyReceipt(
+            surface=surface,
+            route_scope=route_scope,
+            action="blocked",
+            url_class="invalid",
+            url_scheme="",
+            host_class="invalid",
+            redirect_hops_checked=redirect_hops_checked,
+            blocked_reason="malformed_url",
+            redacted_url="[REDACTED_URL]",
+        )
+
+    scheme = parsed.scheme.lower()
+    if not scheme:
+        return NetworkFetchPolicyReceipt(
+            surface=surface,
+            route_scope=route_scope,
+            action="passed",
+            url_class="local",
+            url_scheme="path",
+            host_class="local",
+            redirect_hops_checked=redirect_hops_checked,
+            redacted_url=_LOCAL_PATH_REDACTION,
+        )
+    if scheme == "file":
+        return NetworkFetchPolicyReceipt(
+            surface=surface,
+            route_scope=route_scope,
+            action="passed",
+            url_class="local",
+            url_scheme="file",
+            host_class="local",
+            redirect_hops_checked=redirect_hops_checked,
+            redacted_url=_LOCAL_PATH_REDACTION,
+        )
+    if scheme not in {"http", "https"}:
+        return NetworkFetchPolicyReceipt(
+            surface=surface,
+            route_scope=route_scope,
+            action="blocked",
+            url_class="invalid",
+            url_scheme=scheme,
+            host_class="invalid",
+            redirect_hops_checked=redirect_hops_checked,
+            blocked_reason="unsupported_scheme",
+            redacted_url="[REDACTED_URL]",
+        )
+
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return NetworkFetchPolicyReceipt(
+            surface=surface,
+            route_scope=route_scope,
+            action="blocked",
+            url_class="invalid",
+            url_scheme=scheme,
+            host_class="missing",
+            redirect_hops_checked=redirect_hops_checked,
+            blocked_reason="missing_host",
+            redacted_url="[REDACTED_URL]",
+        )
+
+    host_class = _classify_host(host)
+    resolved_ip_class = _classify_ip_literal(resolved_ip) if resolved_ip else ""
+    url_class = _effective_url_class(host_class, resolved_ip_class)
+    blocked_reason = _blocked_reason(host_class, resolved_ip_class)
+    action = "blocked" if blocked_reason else "passed"
+    return NetworkFetchPolicyReceipt(
+        surface=surface,
+        route_scope=route_scope,
+        action=action,
+        url_class=url_class,
+        url_scheme=scheme,
+        host_class=host_class,
+        resolved_ip=_redacted_resolved_ip(resolved_ip, resolved_ip_class),
+        resolved_ip_class=resolved_ip_class,
+        redirect_hops_checked=redirect_hops_checked,
+        blocked_reason=blocked_reason,
+        redacted_url=_redacted_url(
+            scheme=scheme,
+            host=host,
+            action=action,
+            host_class=host_class,
+            resolved_ip_class=resolved_ip_class,
+        ),
+    )
+
+
+def _classify_host(host: str) -> str:
+    normalized = host.strip("[]").lower()
+    if normalized == "localhost" or normalized.endswith(".localhost"):
+        return "loopback"
+    try:
+        return _classify_ip(ip_address(normalized))
+    except ValueError:
+        return "public"
+
+
+def _classify_ip_literal(value: str) -> str:
+    stripped = str(value).strip().strip("[]")
+    if not stripped:
+        return ""
+    try:
+        return _classify_ip(ip_address(stripped))
+    except ValueError:
+        return "invalid"
+
+
+def _classify_ip(address: object) -> str:
+    if getattr(address, "is_loopback", False):
+        return "loopback"
+    if getattr(address, "is_link_local", False):
+        return "link_local"
+    if getattr(address, "is_private", False):
+        return "private"
+    return "public"
+
+
+def _effective_url_class(host_class: str, resolved_ip_class: str) -> str:
+    if resolved_ip_class in {"loopback", "link_local", "private"}:
+        return resolved_ip_class
+    return host_class
+
+
+def _blocked_reason(host_class: str, resolved_ip_class: str) -> str:
+    if resolved_ip_class in {"loopback", "link_local", "private"} and host_class == "public":
+        return "resolved_private_or_loopback_ip"
+    if host_class in {"loopback", "link_local", "private"}:
+        return "private_or_loopback_host"
+    if resolved_ip_class == "invalid":
+        return "invalid_resolved_ip"
+    return ""
+
+
+def _redacted_resolved_ip(resolved_ip: str, resolved_ip_class: str) -> str:
+    if not resolved_ip:
+        return ""
+    if resolved_ip_class in {"loopback", "link_local", "private"}:
+        return _PRIVATE_IP_REDACTION
+    if resolved_ip_class == "invalid":
+        return "[REDACTED_INVALID_IP]"
+    return str(resolved_ip).strip()
+
+
+def _redacted_url(
+    *,
+    scheme: str,
+    host: str,
+    action: str,
+    host_class: str,
+    resolved_ip_class: str,
+) -> str:
+    if action == "blocked" and (
+        host_class in {"loopback", "link_local", "private"}
+        or resolved_ip_class in {"loopback", "link_local", "private"}
+    ):
+        return f"{scheme}://[REDACTED_PRIVATE_HOST]/[redacted]"
+    return f"{scheme}://{host}/[redacted]"
+
+
+def _bool_value(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+    return None
+
+
+def _int_value(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if parsed < 0:
+        return None
+    return parsed

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -12,6 +12,11 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
+from worker.productization.privacy_policy_receipts import (
+    network_fetch_policy_receipt_from_metadata,
+    privacy_audit_counter_from_metadata,
+)
+
 
 SERVING_DIAGNOSTICS_MANIFEST_SCHEMA_VERSION = "melix.serving_diagnostics.manifest.v1"
 SERVING_DIAGNOSTICS_REQUEST_SCHEMA_VERSION = "melix.serving_diagnostics.request_summary.v1"
@@ -591,6 +596,18 @@ def _effective_config_with_profile_receipt(
             receipt = _serving_readiness_receipt_from_audit_metadata(metadata)
             if receipt:
                 enriched_config["serving_readiness"] = receipt
+                break
+    if "network_fetch_policy" not in enriched_config:
+        for metadata in metadata_sources:
+            receipt = network_fetch_policy_receipt_from_metadata(metadata)
+            if receipt:
+                enriched_config["network_fetch_policy"] = receipt
+                break
+    if "privacy_audit_counters" not in enriched_config:
+        for metadata in metadata_sources:
+            counter = privacy_audit_counter_from_metadata(metadata)
+            if counter:
+                enriched_config["privacy_audit_counters"] = [counter]
                 break
     if enriched_config == stable_config:
         return stable_config

--- a/services/mlx-worker-python/worker/productization/workspace_manifest.py
+++ b/services/mlx-worker-python/worker/productization/workspace_manifest.py
@@ -8,6 +8,10 @@ from typing import Any, overload
 from google.protobuf import json_format
 
 from packages.protocol.python.workspace.v1 import workspace_manifest_pb2
+from worker.productization.privacy_policy_receipts import (
+    workspace_ingest_network_fetch_policy_receipt,
+    workspace_ingest_privacy_audit_counters,
+)
 
 
 WORKSPACE_MANIFEST_SCHEMA_VERSION = "melix.workspace_manifest.v1"
@@ -273,6 +277,8 @@ def preflight_workspace(
         "workspace_manifest_schema_version": manifest.schema_version,
         "project_id": manifest.project.project_id,
         "manifest_path": manifest_path.name,
+        "network_fetch_policy": workspace_ingest_network_fetch_policy_receipt(),
+        "privacy_audit_counters": workspace_ingest_privacy_audit_counters(),
         "checks": checks,
         "metrics": metrics,
     }


### PR DESCRIPTION
## Summary
- Add Melix-owned `NetworkFetchPolicyReceipt` and `PrivacyAuditCounter` shapes for workspace ingest and local proxy external media URL admission.
- Wire workspace preflight, serving diagnostics effective config, and image-edit external media admission to emit redacted receipt/counter metadata.
- Document the new receipt fields and add redaction/loopback/private/link-local/DNS-rebinding-style tests.
- Harden review feedback paths so IPv4-mapped and IPv4-compatible IPv6 literals are classified before admission, and numeric boolean metadata parses as stable receipt booleans.

Refs #2188.

## Plan or Spec
- `docs/plans/2026-07-04-issue-2188-network-fetch-policy-receipts.md`
- `docs/runbooks/serving-diagnostics-evidence.md`
- `docs/workspace-manifest-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py -q
- initial red check failed with ModuleNotFoundError for worker.productization.privacy_policy_receipts

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_workspace_manifest_contract.py::test_workspace_preflight_ready_receipt_is_machine_readable services/mlx-worker-python/tests/test_workspace_manifest_contract.py::test_workspace_preflight_receipt_contract_has_stable_json_shape services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_receipt_reports_independent_cleaning_controls services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_derives_privacy_policy_receipts_from_metadata services/mlx-worker-python/tests/test_serving_diagnostics.py::test_serving_diagnostics_effective_config_skips_incomplete_privacy_policy_metadata -q
- 8 passed in 0.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_workspace_manifest_contract.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_serving_diagnostics.py -q
- 110 passed in 0.19s

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'MultimodalContractTests/externalMediaURLAdmissionCoversLocalPublicAndUnsafeRemoteCases|OpenAIHandlerTests/imageEditEndpointsAcceptImageURLsAndValidateMissingOrMalformedInputs|OpenAIHandlerTests/imageEditEndpointsRejectPrivateExternalMediaURLsBeforeWorkerDispatch'
- first run exposed an over-broad test sentinel; after narrowing the assertion, 3 tests in 2 suites passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'MultimodalContractTests|OpenAIHandlerTests'
- 244 tests in 2 suites passed

git diff --check
- passed

git commit -m "Add network fetch privacy receipts"
- pre-commit full gate passed after rerun with analyzed performance exception:
  - make swift-test: passed
  - make py-test: 4643 passed, 14 skipped, 2 warnings in 157.86s
  - make integration-test: 123 passed, 1 skipped in 450.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py -q
- review-fix RED failed as expected before implementation:
  - compatible IPv6 loopback host receipt action was passed instead of blocked
  - numeric boolean metadata returned an empty receipt

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'MultimodalContractTests/externalMediaURLAdmissionCoversLocalPublicAndUnsafeRemoteCases'
- review-fix RED failed as expected before implementation:
  - ::ffff:127.0.0.1, ::ffff:10.0.0.1, and ::127.0.0.1 hostClass values were public
  - matching IPv6 literal URLs were accepted instead of refused

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py -q
- 5 passed in 0.03s

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'MultimodalContractTests/externalMediaURLAdmissionCoversLocalPublicAndUnsafeRemoteCases'
- 1 test in 1 suite passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_workspace_manifest_contract.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_serving_diagnostics.py -q
- 112 passed in 0.20s

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'MultimodalContractTests|OpenAIHandlerTests'
- 244 tests in 2 suites passed

git diff --check
- passed

git commit -m "Harden network fetch privacy receipts"
- pre-commit full gate passed:
  - make swift-test: passed in 250.5s
  - make py-test: 4645 passed, 14 skipped, 2 warnings in 156.25s
  - make integration-test: 123 passed, 1 skipped in 444.93s
```

## Coverage and Metrics
- First pre-commit performance report: `.runtime/pre-commit-performance/20260704-151028-8cb8ae90/report/report.md`.
- First report status: `regression`, with targeted tests and coverage passing for both selected probes.
- First report analysis/rationale: both findings were timing-only and treated as non-blocking probe noise outside this slice. Serving diagnostics retained/dropped counts, serialized bytes, and checksum were identical. Dataset source-record implementation was not changed; only a receipt assertion was added to an existing test. Additional Python 3.12 base/head reruns showed overlapping ranges for the flagged probes.
- Review-fix pre-commit performance report: `.runtime/pre-commit-performance/20260704-154032-8c50f960/report/report.md`.
- Review-fix report status: `ok`; changed files: 4; selected probes: 0; regressions: 0; verification failures: 0. No registered performance probes were selected for the review-fix change set.
- Changed-scope coverage from the first pre-commit performance report: 100.00% for `serving_diagnostics.py` changed lines, `test_serving_diagnostics.py` changed lines, and `test_dataset_preparation_ingest.py` changed lines.
- Observability mode: minimal runtime counters for local proxy admission (`privacy_audit.*`) plus debug/evidence receipts in workspace preflight and serving diagnostics bundles.
- Probe overhead: no new PR-scoped probe was added.

## Known Gaps
- #2188 remains open for the broader privacy-policy tracker.
- This slice does not add an IP-pinned fetch transport wrapper, model-backed detector backend, operator UI controls, or full chat multimodal structured rejection receipts.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
