### PR TITLE
Add research fetch byte budget receipts

### DIFF
--- a/docs/plans/2026-07-05-issue-1758-research-fetch-byte-budget.md
+++ b/docs/plans/2026-07-05-issue-1758-research-fetch-byte-budget.md
@@ -1,0 +1,172 @@
+# Issue 1758 Research Fetch Byte Budget Receipts
+
+## Goal
+
+Add a narrow research/source fetch budget contract for deep-research presets so
+URL fetches can be capped, receipted, and cached by effective byte budget before
+model-visible truncation happens.
+
+## Context
+
+Issue #1758 tracks operator-facing deep-research presets with scoped tools,
+citations, and evidence bundles. The 2026-06-16 watch note identifies a smaller
+executable slice: every URL fetch used by future research/web tools must expose
+byte-budget receipts, soft truncation, hard pre-buffer refusal, per-call override
+clamping, and cache-key separation between truncated and full fetches.
+
+This slice intentionally creates the productization helper and deterministic
+mock streaming fixture first. It does not add a full research agent, external
+browser integration, or UI.
+
+## Scope
+
+In scope:
+
+- Define a stable research fetch budget receipt schema.
+- Resolve requested, default, and hard maximum byte budgets deterministically.
+- Soft-truncate text responses at the effective byte budget and attach a
+  model-visible partial-content notice.
+- Refuse declared bodies above the hard maximum before buffering.
+- Treat truncated binary/PDF responses as budget errors rather than parseable
+  evidence.
+- Include the effective byte budget and truncation state in cache keys so
+  partial and full fetches cannot collide.
+- Add deterministic tests with a mock streaming source.
+- Document the receipt fields and interpretation rules.
+
+Out of scope:
+
+- Real network I/O, DNS, redirects, or SSRF policy; #2188 owns fetch safety
+  receipts.
+- Full deep-research preset execution, source citation maps, or UI flows.
+- Parsing PDF or binary payloads.
+- Persisted cache storage.
+
+## Receipt Contract
+
+Research fetch budget receipts use schema version
+`melix.research_fetch_budget_receipt.v1` and include:
+
+| Field | Meaning |
+| --- | --- |
+| `source_id` | Stable caller-provided source identifier. |
+| `source_url_hash` | SHA-256 hash of the normalized URL. |
+| `requested_max_bytes` | Optional per-call byte budget requested by the caller. |
+| `default_max_bytes` | Preset default byte budget used when no override exists. |
+| `effective_max_bytes` | Budget after clamping to the hard maximum. |
+| `hard_max_bytes` | Absolute maximum allowed before buffering. |
+| `fetched_bytes` | Bytes consumed from the stream before completion/refusal. |
+| `declared_total_bytes` | Response-declared total bytes when available. |
+| `truncated` | Whether the returned content was truncated. |
+| `status` | `ok`, `truncated`, or `blocked`. |
+| `blocked_reason` | Typed reason when no model-visible content is returned. |
+| `content_type` | Normalized content type such as `text/html` or `application/pdf`. |
+| `partial_content_notice` | Model-visible notice prepended to truncated text content. |
+| `refetch_hint` | Operator-facing hint for retrieving the full source. |
+| `cache_key` | Stable key that includes URL, content type, effective budget, and truncation state. |
+| `raw_url_included` | Always false; receipts must not contain raw URLs. |
+
+## Implementation Plan
+
+### Task 1: Red Tests
+
+Files:
+
+- Create: `services/mlx-worker-python/tests/test_research_fetch_budget.py`
+
+Steps:
+
+1. Add a mock streaming source helper that yields byte chunks and optional
+   declared total bytes.
+2. Add failing tests for soft text truncation:
+   - effective budget is applied before model-visible output.
+   - receipt records requested/default/effective bytes, fetched bytes,
+     declared total bytes, `truncated=true`, and a non-empty
+     `partial_content_notice`.
+   - raw URLs and query parameters do not appear in the serialized receipt.
+3. Add failing tests for hard pre-buffer refusal:
+   - declared total bytes above `hard_max_bytes` return blocked status before
+     consuming stream chunks.
+   - `blocked_reason` is `declared_total_exceeds_hard_max`.
+4. Add failing tests for per-call override clamping:
+   - requested values above the hard max resolve to the hard max.
+   - requested values below the hard max are honored.
+5. Add failing tests for cache-key separation:
+   - a truncated fetch and a full fetch of the same URL produce different keys.
+   - two full fetches with the same effective budget produce the same key.
+6. Add failing tests for binary/PDF truncation refusal:
+   - truncated `application/pdf` or `application/octet-stream` content returns
+     blocked status with `blocked_reason=binary_truncation_not_parseable`.
+
+Verification command:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 \
+  uv run --project services/mlx-worker-python --extra mlx \
+  pytest services/mlx-worker-python/tests/test_research_fetch_budget.py -q
+```
+
+Expected red result: import failure for
+`worker.productization.research_fetch_budget`.
+
+### Task 2: Research Fetch Budget Helper
+
+Files:
+
+- Create: `services/mlx-worker-python/worker/productization/research_fetch_budget.py`
+
+Steps:
+
+1. Add dataclasses:
+   - `ResearchFetchBudgetPolicy`
+   - `ResearchFetchBudgetReceipt`
+   - `ResearchFetchResult`
+2. Add `fetch_stream_with_budget(...)` that consumes an iterable of byte chunks
+   and returns a `ResearchFetchResult`.
+3. Resolve byte budgets with these rules:
+   - default policy values are positive integers.
+   - absent or invalid requested values use the default.
+   - requested values above the hard max clamp to the hard max.
+4. Refuse declared totals above the hard max before reading chunks.
+5. Soft-truncate text content at the effective byte budget, decode with UTF-8
+   replacement, and prepend a concise partial-content notice.
+6. Block truncated binary/PDF content instead of returning parseable evidence.
+7. Generate a stable cache key from normalized URL hash, content type,
+   effective max bytes, declared total bytes, and truncation state.
+8. Ensure `to_dict()` never includes raw URLs or raw content.
+
+### Task 3: Documentation
+
+Files:
+
+- Modify: `docs/runbooks/serving-diagnostics-evidence.md`
+
+Steps:
+
+1. Add a short "Research Fetch Budget Receipts" section.
+2. Define when `ok`, `truncated`, and `blocked` receipts are expected.
+3. Document that this helper performs no network safety checks and must be
+   paired with #2188 fetch policy admission before real URL dereferencing.
+4. Document that debug/evidence bundles may include receipts but not raw URLs,
+   credentials, or raw truncated query strings.
+
+### Task 4: Verification And PR Evidence
+
+Steps:
+
+1. Run focused tests for the new helper.
+2. Run changed-scope coverage for the new module and tests.
+3. Run `git diff --check`.
+4. Run the repo pre-commit hook through `git commit`.
+5. Prepare PR evidence with the exact template headings.
+6. Open a PR for #1758 and wait for CI plus PR-scoped performance report.
+7. Merge only after all checks pass, the performance report has zero
+   regressions, the branch is current with `origin/main`, and review threads are
+   resolved.
+
+## Metrics
+
+The changed path is a pure byte-budget helper over caller-provided chunks. It
+does not perform network I/O, model inference, PDF parsing, or cache persistence.
+Success metrics are deterministic receipt construction, bounded bytes consumed,
+and stable cache-key separation in focused tests.

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -312,6 +312,47 @@ metadata into execution ext fields:
 - `melix.acceleration.profile.fallback_reason`
 - `melix.acceleration.profile.recovery_hint`
 
+## Research Fetch Budget Receipts
+
+Deep-research and web-enabled source tools should emit
+`melix.research_fetch_budget_receipt.v1` receipts before any fetched source
+content becomes model-visible. These receipts are a byte-budget and cache-key
+contract only; they do not perform DNS, redirect, SSRF, or private-network
+admission. Real URL dereferencing must still pass through the network fetch
+policy layer described by #2188 before bytes are streamed into a research
+fetch-budget helper.
+
+Receipts use these status values:
+
+| Status | Meaning |
+| --- | --- |
+| `ok` | The source fit inside the effective byte budget and can be used as complete fetched evidence. |
+| `truncated` | Text content was soft-truncated at the effective byte budget and includes a model-visible partial-content notice. |
+| `blocked` | The helper returned no model-visible source content because the declared body exceeded the hard ceiling or a binary/PDF source would have been truncated. |
+
+Expected receipt fields include:
+
+- `source_id`
+- `source_url_hash`
+- `requested_max_bytes`
+- `default_max_bytes`
+- `effective_max_bytes`
+- `hard_max_bytes`
+- `fetched_bytes`
+- `declared_total_bytes`
+- `truncated`
+- `status`
+- `blocked_reason`
+- `content_type`
+- `partial_content_notice`
+- `refetch_hint`
+- `cache_key`
+- `raw_url_included`
+
+`cache_key` must include the effective byte budget and truncation state so a
+partial source cannot masquerade as a complete source. Receipts and diagnostics
+must not include raw URLs, query strings, credentials, or raw fetched content.
+
 ## Lightweight Status Diagnostics
 
 `ListLoadedModels` exposes per-loaded-model throughput counters with the same

--- a/services/mlx-worker-python/tests/test_research_fetch_budget.py
+++ b/services/mlx-worker-python/tests/test_research_fetch_budget.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from worker.productization.research_fetch_budget import (
+    ResearchFetchBudgetPolicy,
+    fetch_stream_with_budget,
+)
+
+
+def chunked(payload: bytes, size: int) -> tuple[bytes, ...]:
+    return tuple(payload[index : index + size] for index in range(0, len(payload), size))
+
+
+def test_text_fetch_soft_truncates_with_model_visible_notice_and_redacted_receipt() -> None:
+    payload = b"alpha beta gamma delta epsilon"
+    result = fetch_stream_with_budget(
+        source_id="source-1",
+        url="https://research.example.test/report.html?api_key=sk-secret",
+        content_type="text/html; charset=utf-8",
+        chunks=chunked(payload, 5),
+        declared_total_bytes=len(payload),
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=16, hard_max_bytes=64),
+    )
+
+    assert result.content.startswith("[Melix partial content:")
+    assert "alpha beta" in result.content
+    assert "epsilon" not in result.content
+    assert result.receipt["schema_version"] == "melix.research_fetch_budget_receipt.v1"
+    assert result.receipt["source_id"] == "source-1"
+    assert result.receipt["requested_max_bytes"] == 0
+    assert result.receipt["default_max_bytes"] == 16
+    assert result.receipt["effective_max_bytes"] == 16
+    assert result.receipt["hard_max_bytes"] == 64
+    assert result.receipt["fetched_bytes"] == 16
+    assert result.receipt["declared_total_bytes"] == len(payload)
+    assert result.receipt["truncated"] is True
+    assert result.receipt["status"] == "truncated"
+    assert result.receipt["blocked_reason"] == ""
+    assert result.receipt["content_type"] == "text/html"
+    assert result.receipt["partial_content_notice"] == "[Melix partial content: fetched 16 of 30 bytes.]"
+    assert result.receipt["refetch_hint"] == "Increase max_bytes to fetch the complete source."
+    assert result.receipt["raw_url_included"] is False
+    receipt_payload = json.dumps(result.receipt, sort_keys=True)
+    assert "research.example.test/report.html" not in receipt_payload
+    assert "api_key" not in receipt_payload
+    assert "sk-secret" not in receipt_payload
+
+
+def test_declared_total_above_hard_max_refuses_before_stream_consumption() -> None:
+    consumed = False
+
+    def chunks():
+        nonlocal consumed
+        consumed = True
+        yield b"this should never be read"
+
+    result = fetch_stream_with_budget(
+        source_id="source-large",
+        url="https://research.example.test/large",
+        content_type="text/plain",
+        chunks=chunks(),
+        declared_total_bytes=1_000,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=100, hard_max_bytes=256),
+    )
+
+    assert consumed is False
+    assert result.content == ""
+    assert result.receipt["status"] == "blocked"
+    assert result.receipt["blocked_reason"] == "declared_total_exceeds_hard_max"
+    assert result.receipt["fetched_bytes"] == 0
+    assert result.receipt["declared_total_bytes"] == 1_000
+    assert result.receipt["truncated"] is False
+
+
+def test_requested_max_bytes_clamps_to_hard_max_and_honors_smaller_overrides() -> None:
+    clamped = fetch_stream_with_budget(
+        source_id="source-clamped",
+        url="https://research.example.test/source",
+        content_type="text/plain",
+        chunks=(b"abcdef",),
+        declared_total_bytes=6,
+        requested_max_bytes=1_000,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=4, hard_max_bytes=8),
+    )
+    smaller = fetch_stream_with_budget(
+        source_id="source-smaller",
+        url="https://research.example.test/source",
+        content_type="text/plain",
+        chunks=(b"abcdef",),
+        declared_total_bytes=6,
+        requested_max_bytes=3,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=4, hard_max_bytes=8),
+    )
+
+    assert clamped.receipt["requested_max_bytes"] == 1_000
+    assert clamped.receipt["effective_max_bytes"] == 8
+    assert clamped.content == "abcdef"
+    assert smaller.receipt["requested_max_bytes"] == 3
+    assert smaller.receipt["effective_max_bytes"] == 3
+    assert smaller.receipt["status"] == "truncated"
+    assert "abc" in smaller.content
+    assert "def" not in smaller.content
+
+
+def test_cache_key_separates_truncated_and_full_fetches() -> None:
+    truncated = fetch_stream_with_budget(
+        source_id="source-cache",
+        url="https://research.example.test/source",
+        content_type="text/plain",
+        chunks=(b"abcdef",),
+        declared_total_bytes=6,
+        requested_max_bytes=3,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=6, hard_max_bytes=10),
+    )
+    full = fetch_stream_with_budget(
+        source_id="source-cache",
+        url="https://research.example.test/source",
+        content_type="text/plain",
+        chunks=(b"abcdef",),
+        declared_total_bytes=6,
+        requested_max_bytes=6,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=6, hard_max_bytes=10),
+    )
+    full_again = fetch_stream_with_budget(
+        source_id="source-cache",
+        url=" https://research.example.test/source ",
+        content_type="text/plain; charset=utf-8",
+        chunks=(b"abcdef",),
+        declared_total_bytes=6,
+        requested_max_bytes=6,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=6, hard_max_bytes=10),
+    )
+
+    assert truncated.receipt["cache_key"] != full.receipt["cache_key"]
+    assert full.receipt["cache_key"] == full_again.receipt["cache_key"]
+
+
+def test_truncated_binary_and_pdf_sources_are_blocked_as_unparseable_evidence() -> None:
+    for content_type in ("application/pdf", "application/octet-stream"):
+        result = fetch_stream_with_budget(
+            source_id="source-binary",
+            url="https://research.example.test/file",
+            content_type=content_type,
+            chunks=(b"0123456789",),
+            declared_total_bytes=10,
+            requested_max_bytes=4,
+            policy=ResearchFetchBudgetPolicy(default_max_bytes=4, hard_max_bytes=16),
+        )
+
+        assert result.content == ""
+        assert result.receipt["status"] == "blocked"
+        assert result.receipt["blocked_reason"] == "binary_truncation_not_parseable"
+        assert result.receipt["truncated"] is True
+        assert result.receipt["fetched_bytes"] == 4
+
+
+def test_policy_limits_must_be_positive_and_ordered() -> None:
+    with pytest.raises(ValueError, match="default_max_bytes must be positive"):
+        ResearchFetchBudgetPolicy(default_max_bytes=0, hard_max_bytes=10)
+    with pytest.raises(ValueError, match="hard_max_bytes must be positive"):
+        ResearchFetchBudgetPolicy(default_max_bytes=1, hard_max_bytes=0)
+    with pytest.raises(ValueError, match="default_max_bytes must not exceed hard_max_bytes"):
+        ResearchFetchBudgetPolicy(default_max_bytes=20, hard_max_bytes=10)
+
+
+def test_unknown_total_truncation_handles_empty_chunks_without_overreading() -> None:
+    result = fetch_stream_with_budget(
+        source_id="source-unknown-total",
+        url="/local/research/source.txt",
+        content_type="text/plain",
+        chunks=(b"", b"ab", b"cdef"),
+        requested_max_bytes=2,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=4, hard_max_bytes=8),
+    )
+
+    assert result.content == "[Melix partial content: fetched 2 of an unknown total bytes.]\nab"
+    assert result.receipt["content_type"] == "text/plain"
+    assert result.receipt["declared_total_bytes"] == 0
+    assert result.receipt["fetched_bytes"] == 2
+    assert result.receipt["status"] == "truncated"
+    assert result.receipt["truncated"] is True
+
+
+def test_declared_large_total_does_not_mark_short_stream_as_budget_truncated() -> None:
+    result = fetch_stream_with_budget(
+        source_id="source-short-stream",
+        url="https://research.example.test/short",
+        content_type="text/plain",
+        chunks=(b"short",),
+        declared_total_bytes=100,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=16, hard_max_bytes=128),
+    )
+
+    assert result.content == "short"
+    assert result.receipt["fetched_bytes"] == 5
+    assert result.receipt["declared_total_bytes"] == 100
+    assert result.receipt["status"] == "ok"
+    assert result.receipt["truncated"] is False
+    assert result.receipt["partial_content_notice"] == ""
+
+
+def test_invalid_budget_inputs_fall_back_without_leaking_normalized_url_details() -> None:
+    bad_inputs = fetch_stream_with_budget(
+        source_id="source-bad-inputs",
+        url="HTTPS://Research.Example.Test:8443/path?q=secret",
+        content_type="",
+        chunks=(b"abc",),
+        declared_total_bytes="unknown",  # type: ignore[arg-type]
+        requested_max_bytes="NaN",  # type: ignore[arg-type]
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=5, hard_max_bytes=10),
+    )
+    non_positive = fetch_stream_with_budget(
+        source_id="source-negative",
+        url="HTTPS://Research.Example.Test:8443/path?q=secret",
+        content_type="",
+        chunks=(b"abc",),
+        declared_total_bytes=-20,
+        requested_max_bytes=-1,
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=5, hard_max_bytes=10),
+    )
+
+    assert bad_inputs.content == "abc"
+    assert bad_inputs.receipt["requested_max_bytes"] == 0
+    assert bad_inputs.receipt["declared_total_bytes"] == 0
+    assert bad_inputs.receipt["effective_max_bytes"] == 5
+    assert bad_inputs.receipt["content_type"] == "application/octet-stream"
+    assert non_positive.receipt["requested_max_bytes"] == 0
+    assert non_positive.receipt["declared_total_bytes"] == 0
+    assert bad_inputs.receipt["cache_key"] == non_positive.receipt["cache_key"]
+    receipt_payload = json.dumps(bad_inputs.receipt, sort_keys=True)
+    assert "Research.Example.Test" not in receipt_payload
+    assert "q=secret" not in receipt_payload
+
+
+def test_malformed_urls_are_hashed_without_raising_or_leaking_receipt_details() -> None:
+    result = fetch_stream_with_budget(
+        source_id="source-malformed-url",
+        url="https://Research.Example.Test:bad-port/path?q=secret",
+        content_type="text/plain",
+        chunks=(b"abc",),
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=5, hard_max_bytes=10),
+    )
+
+    assert result.content == "abc"
+    assert result.receipt["status"] == "ok"
+    assert result.receipt["raw_url_included"] is False
+    receipt_payload = json.dumps(result.receipt, sort_keys=True)
+    assert "Research.Example.Test" not in receipt_payload
+    assert "bad-port" not in receipt_payload
+    assert "q=secret" not in receipt_payload
+
+    invalid_ipv6 = fetch_stream_with_budget(
+        source_id="source-invalid-ipv6",
+        url="https://[::1/path?q=secret",
+        content_type="text/plain",
+        chunks=(b"abc",),
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=5, hard_max_bytes=10),
+    )
+
+    assert invalid_ipv6.content == "abc"
+    invalid_payload = json.dumps(invalid_ipv6.receipt, sort_keys=True)
+    assert "[::1" not in invalid_payload
+    assert "q=secret" not in invalid_payload
+
+
+def test_non_string_url_and_content_type_inputs_are_defensive() -> None:
+    result = fetch_stream_with_budget(
+        source_id="source-defensive-inputs",
+        url=None,  # type: ignore[arg-type]
+        content_type=None,  # type: ignore[arg-type]
+        chunks=(b"abc",),
+        policy=ResearchFetchBudgetPolicy(default_max_bytes=5, hard_max_bytes=10),
+    )
+
+    assert result.content == "abc"
+    assert result.receipt["content_type"] == "application/octet-stream"
+    assert result.receipt["status"] == "ok"
+    assert result.receipt["source_url_hash"]

--- a/services/mlx-worker-python/worker/productization/research_fetch_budget.py
+++ b/services/mlx-worker-python/worker/productization/research_fetch_budget.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from urllib.parse import urlsplit, urlunsplit
+
+
+RESEARCH_FETCH_BUDGET_RECEIPT_SCHEMA_VERSION = "melix.research_fetch_budget_receipt.v1"
+
+_BINARY_CONTENT_TYPES = frozenset(
+    (
+        "application/octet-stream",
+        "application/pdf",
+    )
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchFetchBudgetPolicy:
+    default_max_bytes: int
+    hard_max_bytes: int
+
+    def __post_init__(self) -> None:
+        if self.default_max_bytes <= 0:
+            raise ValueError("default_max_bytes must be positive")
+        if self.hard_max_bytes <= 0:
+            raise ValueError("hard_max_bytes must be positive")
+        if self.default_max_bytes > self.hard_max_bytes:
+            raise ValueError("default_max_bytes must not exceed hard_max_bytes")
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchFetchBudgetReceipt:
+    source_id: str
+    source_url_hash: str
+    requested_max_bytes: int
+    default_max_bytes: int
+    effective_max_bytes: int
+    hard_max_bytes: int
+    fetched_bytes: int
+    declared_total_bytes: int
+    truncated: bool
+    status: str
+    blocked_reason: str
+    content_type: str
+    partial_content_notice: str
+    refetch_hint: str
+    cache_key: str
+    raw_url_included: bool = False
+    schema_version: str = RESEARCH_FETCH_BUDGET_RECEIPT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "source_id": self.source_id,
+            "source_url_hash": self.source_url_hash,
+            "requested_max_bytes": int(self.requested_max_bytes),
+            "default_max_bytes": int(self.default_max_bytes),
+            "effective_max_bytes": int(self.effective_max_bytes),
+            "hard_max_bytes": int(self.hard_max_bytes),
+            "fetched_bytes": int(self.fetched_bytes),
+            "declared_total_bytes": int(self.declared_total_bytes),
+            "truncated": bool(self.truncated),
+            "status": self.status,
+            "blocked_reason": self.blocked_reason,
+            "content_type": self.content_type,
+            "partial_content_notice": self.partial_content_notice,
+            "refetch_hint": self.refetch_hint,
+            "cache_key": self.cache_key,
+            "raw_url_included": bool(self.raw_url_included),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ResearchFetchResult:
+    content: str
+    receipt: dict[str, object]
+
+
+def fetch_stream_with_budget(
+    *,
+    source_id: str,
+    url: str,
+    content_type: str,
+    chunks: Iterable[bytes],
+    policy: ResearchFetchBudgetPolicy,
+    declared_total_bytes: int | None = None,
+    requested_max_bytes: int | None = None,
+) -> ResearchFetchResult:
+    normalized_content_type = _normalized_content_type(content_type)
+    normalized_url = _normalized_url(url)
+    source_url_hash = _sha256_hex(normalized_url)
+    requested = _requested_budget_value(requested_max_bytes)
+    effective_max_bytes = _effective_max_bytes(requested, policy)
+    declared_total = _declared_total_value(declared_total_bytes)
+
+    if declared_total > policy.hard_max_bytes:
+        receipt = _receipt(
+            source_id=source_id,
+            source_url_hash=source_url_hash,
+            requested_max_bytes=requested,
+            policy=policy,
+            effective_max_bytes=effective_max_bytes,
+            fetched_bytes=0,
+            declared_total_bytes=declared_total,
+            truncated=False,
+            status="blocked",
+            blocked_reason="declared_total_exceeds_hard_max",
+            content_type=normalized_content_type,
+            partial_content_notice="",
+            refetch_hint="Lower the source size or configure a higher hard fetch ceiling.",
+        )
+        return ResearchFetchResult(content="", receipt=receipt.to_dict())
+
+    collected = bytearray()
+    truncated = False
+    for chunk in chunks:
+        if not chunk:
+            continue
+        remaining = effective_max_bytes - len(collected)
+        if remaining <= 0:
+            truncated = True
+            break
+        if len(chunk) > remaining:
+            collected.extend(chunk[:remaining])
+            truncated = True
+            break
+        collected.extend(chunk)
+
+    fetched_bytes = len(collected)
+    if (
+        declared_total
+        and fetched_bytes >= effective_max_bytes
+        and declared_total > fetched_bytes
+    ):
+        truncated = True
+
+    if truncated and normalized_content_type in _BINARY_CONTENT_TYPES:
+        receipt = _receipt(
+            source_id=source_id,
+            source_url_hash=source_url_hash,
+            requested_max_bytes=requested,
+            policy=policy,
+            effective_max_bytes=effective_max_bytes,
+            fetched_bytes=fetched_bytes,
+            declared_total_bytes=declared_total,
+            truncated=True,
+            status="blocked",
+            blocked_reason="binary_truncation_not_parseable",
+            content_type=normalized_content_type,
+            partial_content_notice="",
+            refetch_hint="Fetch the complete binary source before parsing it as evidence.",
+        )
+        return ResearchFetchResult(content="", receipt=receipt.to_dict())
+
+    notice = ""
+    status = "ok"
+    if truncated:
+        total_description = str(declared_total) if declared_total else "an unknown total"
+        notice = (
+            f"[Melix partial content: fetched {fetched_bytes} of "
+            f"{total_description} bytes.]"
+        )
+        status = "truncated"
+
+    body = collected.decode("utf-8", errors="replace")
+    content = f"{notice}\n{body}" if notice else body
+    receipt = _receipt(
+        source_id=source_id,
+        source_url_hash=source_url_hash,
+        requested_max_bytes=requested,
+        policy=policy,
+        effective_max_bytes=effective_max_bytes,
+        fetched_bytes=fetched_bytes,
+        declared_total_bytes=declared_total,
+        truncated=truncated,
+        status=status,
+        blocked_reason="",
+        content_type=normalized_content_type,
+        partial_content_notice=notice,
+        refetch_hint="Increase max_bytes to fetch the complete source." if truncated else "",
+    )
+    return ResearchFetchResult(content=content, receipt=receipt.to_dict())
+
+
+def _receipt(
+    *,
+    source_id: str,
+    source_url_hash: str,
+    requested_max_bytes: int,
+    policy: ResearchFetchBudgetPolicy,
+    effective_max_bytes: int,
+    fetched_bytes: int,
+    declared_total_bytes: int,
+    truncated: bool,
+    status: str,
+    blocked_reason: str,
+    content_type: str,
+    partial_content_notice: str,
+    refetch_hint: str,
+) -> ResearchFetchBudgetReceipt:
+    cache_key = _cache_key(
+        source_url_hash=source_url_hash,
+        content_type=content_type,
+        effective_max_bytes=effective_max_bytes,
+        declared_total_bytes=declared_total_bytes,
+        truncated=truncated,
+    )
+    return ResearchFetchBudgetReceipt(
+        source_id=source_id,
+        source_url_hash=source_url_hash,
+        requested_max_bytes=requested_max_bytes,
+        default_max_bytes=policy.default_max_bytes,
+        effective_max_bytes=effective_max_bytes,
+        hard_max_bytes=policy.hard_max_bytes,
+        fetched_bytes=fetched_bytes,
+        declared_total_bytes=declared_total_bytes,
+        truncated=truncated,
+        status=status,
+        blocked_reason=blocked_reason,
+        content_type=content_type,
+        partial_content_notice=partial_content_notice,
+        refetch_hint=refetch_hint,
+        cache_key=cache_key,
+    )
+
+
+def _effective_max_bytes(requested: int, policy: ResearchFetchBudgetPolicy) -> int:
+    if requested <= 0:
+        return policy.default_max_bytes
+    return min(requested, policy.hard_max_bytes)
+
+
+def _requested_budget_value(value: int | None) -> int:
+    if value is None:
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if parsed > 0 else 0
+
+
+def _declared_total_value(value: int | None) -> int:
+    if value is None:
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(parsed, 0)
+
+
+def _normalized_content_type(content_type: str) -> str:
+    if not isinstance(content_type, str):
+        return "application/octet-stream"
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    return normalized or "application/octet-stream"
+
+
+def _normalized_url(url: str) -> str:
+    if not isinstance(url, str):
+        return ""
+    raw = url.strip()
+    try:
+        parts = urlsplit(raw)
+    except ValueError:
+        return raw
+    if not parts.scheme or not parts.netloc:
+        return raw
+    host = (parts.hostname or "").lower()
+    netloc = host
+    try:
+        port = parts.port
+    except ValueError:
+        return raw
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunsplit((parts.scheme.lower(), netloc, parts.path or "/", parts.query, ""))
+
+
+def _cache_key(
+    *,
+    source_url_hash: str,
+    content_type: str,
+    effective_max_bytes: int,
+    declared_total_bytes: int,
+    truncated: bool,
+) -> str:
+    payload = "|".join(
+        (
+            source_url_hash,
+            content_type,
+            str(effective_max_bytes),
+            str(declared_total_bytes),
+            "truncated" if truncated else "full",
+        )
+    )
+    return f"research-fetch:{_sha256_hex(payload)}"
+
+
+def _sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
- Add a deterministic research fetch byte-budget helper for future deep-research/web source tools.
- Cover soft text truncation, hard pre-buffer refusal, per-call override clamping, truncated binary refusal, cache-key separation, redacted receipts, short-stream false-positive handling, and defensive URL/content-type normalization.
- Document the receipt contract and its boundary with the #2188 network fetch policy layer.

Refs #1758

## Plan or Spec
- `docs/plans/2026-07-05-issue-1758-research-fetch-byte-budget.md`
- `docs/runbooks/serving-diagnostics-evidence.md` research fetch budget receipt section

## Commands Run
```text
# Red TDD check before implementation:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_research_fetch_budget.py -q
Outcome: failed as expected with ModuleNotFoundError for worker.productization.research_fetch_budget.

# Review-response red check before defensive/truncation fixes:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_research_fetch_budget.py -q
Outcome: failed as expected with 2 failed, 9 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_research_fetch_budget.py -q
Outcome: 11 passed in 0.03s.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --branch -m pytest -q services/mlx-worker-python/tests/test_research_fetch_budget.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/research_fetch_budget.py services/mlx-worker-python/tests/test_research_fetch_budget.py
Outcome: helper changed-line coverage 100.00%; aggregate changed-line coverage 99%; review delta coverage TOTAL 21 0 100%.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_research_fetch_budget.py services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_run_evidence.py -q
Outcome: 86 passed in 0.17s.

git diff --check
Outcome: passed.

git commit --amend --no-edit
Outcome: pre-commit passed; make swift-test, make py-test, make integration-test, and scoped performance report all succeeded.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 241 2 99%`.
- Review-delta changed-scope coverage: `TOTAL 21 0 100%`.
- Helper changed-line coverage: `100.00%`.
- `make swift-test`: passed during pre-commit in 146.2s.
- `make py-test`: `4656 passed, 14 skipped, 2 warnings in 162.81s` during pre-commit.
- `make integration-test`: `123 passed, 1 skipped in 407.68s` during pre-commit.
- PR-scoped performance report: `Status: ok`; selected probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Local report path: `.runtime/pre-commit-performance/20260704-172237-584d3a53/report/report.md`.
- Performance probes: no registered probes selected because this slice adds a pure Python byte-budget helper over caller-provided byte chunks and documentation; it performs no network I/O, model inference, PDF parsing, or cache persistence.
- Observability mode: evidence receipt contract only.
- Probe overhead: N/A because no runtime probe or production metric collection was added.

## Known Gaps
- No real URL dereferencing, DNS, redirect handling, SSRF checks, or private-network admission; #2188 owns the network fetch policy layer.
- No full deep-research preset execution, citation map, CLI, or UI flow in this slice.
- No PDF parsing or persisted cache storage.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol or schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.