### PR TITLE
Add pattern privacy detector receipts

### DIFF
--- a/docs/plans/2026-07-05-issue-2188-pattern-privacy-detector.md
+++ b/docs/plans/2026-07-05-issue-2188-pattern-privacy-detector.md
@@ -1,0 +1,91 @@
+# Issue 2188 Pattern Privacy Detector Receipts
+
+## Goal
+
+Land the next executable privacy-policy slice by adding a deterministic pattern
+detector receipt that can redact or block common sensitive spans before local
+proxy, workspace-ingest, and diagnostics surfaces export evidence.
+
+## Scope
+
+- Add a Python `PrivacyDetectorReceipt` shape with schema version
+  `melix.privacy_detector_receipt.v1`.
+- Add a deterministic pattern detector for common contact and secret-like spans.
+- Return redacted text, a detector receipt, and a compatible
+  `PrivacyAuditCounter` from one helper.
+- Support policy modes for `redact` and `block`, with clean text passing
+  through unchanged.
+- Add namespaced diagnostics metadata support so callers that already performed
+  detection can preserve the detector receipt in `effective-config.json`.
+- Keep raw sensitive text, matched substrings, and raw input text out of
+  receipts and exported diagnostics.
+
+## Non-Goals
+
+- No new protobuf schema.
+- No model-backed NER or cloud moderation service.
+- No live route integration for OpenAI-compatible proxy requests, workspace
+  source import, streaming, or document ingest.
+- No scanning of diagnostics bundle content during bundle writing.
+- No mutation of user files or persisted workspace artifacts.
+
+## Receipt Shape
+
+`PrivacyDetectorReceipt` records:
+
+- `schema_version`
+- `surface`
+- `route_scope`
+- `detector_id`
+- `policy_id`
+- `policy_mode`
+- `action` (`passed`, `redacted`, or `blocked`)
+- `categories`
+- `match_count`
+- `redacted_span_count`
+- `blocked_reason`
+- `confidence_source`
+- `raw_sensitive_span_count`
+- `raw_text_included`
+
+The receipt is evidence-only: it reports categories and counts, not raw matched
+values or snippets.
+
+## Architecture
+
+The Python worker keeps the canonical helper beside the existing
+`NetworkFetchPolicyReceipt` and `PrivacyAuditCounter` helpers. The detector is
+pure and deterministic: it receives caller-provided text, applies a fixed set of
+patterns, and returns sanitized output plus machine-readable evidence. Clean
+inputs emit a passed receipt with zero spans. Redaction mode replaces matched
+spans with stable category placeholders. Block mode returns an empty text body
+and records a typed blocked reason.
+
+Serving diagnostics can synthesize a `privacy_detector_receipts` list from
+complete namespaced metadata in the same way it already preserves
+network-fetch receipts. Bundle writing must not inspect prompt, completion,
+document, or artifact content to create detector receipts; callers must attach
+complete metadata after they have already evaluated policy.
+
+## Performance Probes And Metrics
+
+- Measurement points:
+  - detector helper execution on caller-provided text;
+  - diagnostics effective-config enrichment from metadata.
+- Target metrics:
+  - no network I/O, filesystem scans, model inference, or bundle-content scans;
+  - zero raw sensitive spans in exported receipts;
+  - changed-scope coverage at least 95 percent.
+- Probe overhead:
+  - bounded regex scans over already-materialized text;
+  - small JSON construction for receipt and counter payloads.
+- PR-scoped performance:
+  - use the repository pre-commit scoped performance report. If no registered
+    probe matches the changed files, report the no-probe result explicitly.
+
+## Verification
+
+- Focused Python tests for redaction, block mode, clean pass-through, metadata
+  derivation, incomplete metadata rejection, and diagnostics enrichment.
+- Adjacent Python tests for privacy receipts and serving diagnostics.
+- Full repository pre-commit gate before PR update.

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -243,6 +243,54 @@ Optional metadata key:
 
 - `melix.privacy.audit.schema_version`
 
+When a caller has already evaluated local privacy detection policy, diagnostics
+may also include `privacy_detector_receipts`. Bundle writing must not scan
+prompts, completions, documents, artifacts, or trace payloads to create these
+receipts. The caller must attach a complete redacted receipt before diagnostics
+serialization.
+
+`privacy_detector_receipts` is a list of
+`melix.privacy_detector_receipt.v1` objects. Each receipt records:
+
+- `surface`
+- `route_scope`
+- `detector_id`
+- `policy_id`
+- `policy_mode`
+- `action` - `passed`, `redacted`, or `blocked`
+- `categories` - detected category names, not matched values
+- `match_count`
+- `redacted_span_count`
+- `blocked_reason`
+- `confidence_source`
+- `raw_sensitive_span_count`
+- `raw_text_included`
+
+Diagnostics writers may derive one detector receipt from namespaced metadata
+when all of these keys are present:
+
+- `melix.privacy.detector.surface`
+- `melix.privacy.detector.route_scope`
+- `melix.privacy.detector.detector_id`
+- `melix.privacy.detector.policy_id`
+- `melix.privacy.detector.policy_mode`
+- `melix.privacy.detector.action`
+- `melix.privacy.detector.categories`
+- `melix.privacy.detector.match_count`
+- `melix.privacy.detector.redacted_span_count`
+- `melix.privacy.detector.blocked_reason`
+- `melix.privacy.detector.confidence_source`
+- `melix.privacy.detector.raw_sensitive_span_count`
+- `melix.privacy.detector.raw_text_included`
+
+Optional metadata key:
+
+- `melix.privacy.detector.schema_version`
+
+Detector receipt derivation is rejected when `raw_text_included` is true or
+`raw_sensitive_span_count` is greater than zero. Exported receipts must include
+only category/count evidence, never raw sensitive spans or matched snippets.
+
 `request-summary.json` records stable request-level fields:
 
 - request id

--- a/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
+++ b/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
@@ -4,9 +4,12 @@ import json
 
 from worker.productization.privacy_policy_receipts import (
     PrivacyAuditCounter,
+    PrivacyDetectorReceipt,
+    detect_privacy_patterns,
     network_fetch_policy_receipt_from_metadata,
     network_fetch_policy_receipt_for_url,
     privacy_audit_counter,
+    privacy_detector_receipt_from_metadata,
 )
 
 
@@ -195,3 +198,174 @@ def test_privacy_audit_counter_counts_blocked_redacted_and_passed_decisions() ->
         "passed_count": 1,
         "raw_sensitive_span_count": 0,
     }
+
+
+def test_pattern_privacy_detector_redacts_contacts_and_secrets_without_raw_spans() -> None:
+    result = detect_privacy_patterns(
+        (
+            "Contact alice@example.com with "
+            "OPENAI_API_KEY=sk-testsecret and hf_abcdef123456."
+        ),
+        surface="workspace_ingest",
+        route_scope="source_import",
+    )
+
+    assert "[REDACTED_EMAIL]" in result.redacted_text
+    assert result.redacted_text.count("[REDACTED_SECRET]") == 2
+    assert "alice@example.com" not in result.redacted_text
+    assert "sk-testsecret" not in result.redacted_text
+    assert "hf_abcdef123456" not in result.redacted_text
+    assert isinstance(result.receipt_object, PrivacyDetectorReceipt)
+    assert result.receipt == {
+        "schema_version": "melix.privacy_detector_receipt.v1",
+        "surface": "workspace_ingest",
+        "route_scope": "source_import",
+        "detector_id": "melix.pattern_detector.v1",
+        "policy_id": "melix.default_privacy_policy.v1",
+        "policy_mode": "redact",
+        "action": "redacted",
+        "categories": ["email", "secret"],
+        "match_count": 3,
+        "redacted_span_count": 3,
+        "blocked_reason": "",
+        "confidence_source": "deterministic_pattern",
+        "raw_sensitive_span_count": 0,
+        "raw_text_included": False,
+    }
+    assert result.audit_counter == {
+        "schema_version": "melix.privacy_audit_counter.v1",
+        "surface": "workspace_ingest",
+        "route_scope": "source_import",
+        "blocked_count": 0,
+        "redacted_count": 1,
+        "passed_count": 0,
+        "raw_sensitive_span_count": 0,
+    }
+    payload = json.dumps(
+        {
+            "redacted_text": result.redacted_text,
+            "receipt": result.receipt,
+            "audit_counter": result.audit_counter,
+        },
+        sort_keys=True,
+    )
+    for raw_fragment in ("alice@example.com", "sk-testsecret", "hf_abcdef123456"):
+        assert raw_fragment not in payload
+
+
+def test_pattern_privacy_detector_blocks_sensitive_text_without_returning_content() -> None:
+    result = detect_privacy_patterns(
+        "Send the report to bob@example.com",
+        surface="local_proxy_prompt",
+        route_scope="chat_completions",
+        policy_mode="block",
+    )
+
+    assert result.redacted_text == ""
+    assert result.receipt["action"] == "blocked"
+    assert result.receipt["blocked_reason"] == "pattern_match_blocked"
+    assert result.receipt["categories"] == ["email"]
+    assert result.receipt["match_count"] == 1
+    assert result.receipt["redacted_span_count"] == 0
+    assert result.audit_counter["blocked_count"] == 1
+    assert "bob@example.com" not in json.dumps(result.receipt, sort_keys=True)
+
+
+def test_pattern_privacy_detector_passes_clean_text() -> None:
+    clean_text = "Summarize the workspace manifest contract."
+
+    result = detect_privacy_patterns(
+        clean_text,
+        surface="workspace_ingest",
+        route_scope="source_import",
+    )
+
+    assert result.redacted_text == clean_text
+    assert result.receipt["action"] == "passed"
+    assert result.receipt["categories"] == []
+    assert result.receipt["match_count"] == 0
+    assert result.audit_counter["passed_count"] == 1
+
+
+def test_pattern_privacy_detector_defaults_unknown_mode_and_deduplicates_overlapping_secrets() -> None:
+    result = detect_privacy_patterns(
+        "OPENAI_API_KEY=hf_abcdef123456",
+        surface="workspace_ingest",
+        route_scope="source_import",
+        policy_mode="audit-only",
+    )
+
+    assert result.redacted_text == "[REDACTED_SECRET]"
+    assert result.receipt["policy_mode"] == "redact"
+    assert result.receipt["action"] == "redacted"
+    assert result.receipt["categories"] == ["secret"]
+    assert result.receipt["match_count"] == 1
+    assert "hf_abcdef123456" not in json.dumps(result.receipt, sort_keys=True)
+
+
+def test_privacy_detector_receipt_metadata_derivation_rejects_raw_text_receipts() -> None:
+    metadata = {
+        "melix.privacy.detector.schema_version": "melix.privacy_detector_receipt.v1",
+        "melix.privacy.detector.surface": "workspace_ingest",
+        "melix.privacy.detector.route_scope": "source_import",
+        "melix.privacy.detector.detector_id": "melix.pattern_detector.v1",
+        "melix.privacy.detector.policy_id": "melix.default_privacy_policy.v1",
+        "melix.privacy.detector.policy_mode": "redact",
+        "melix.privacy.detector.action": "redacted",
+        "melix.privacy.detector.categories": "secret,email",
+        "melix.privacy.detector.match_count": "3",
+        "melix.privacy.detector.redacted_span_count": "3",
+        "melix.privacy.detector.blocked_reason": "",
+        "melix.privacy.detector.confidence_source": "deterministic_pattern",
+        "melix.privacy.detector.raw_sensitive_span_count": "0",
+        "melix.privacy.detector.raw_text_included": "false",
+    }
+
+    assert privacy_detector_receipt_from_metadata(metadata) == {
+        "schema_version": "melix.privacy_detector_receipt.v1",
+        "surface": "workspace_ingest",
+        "route_scope": "source_import",
+        "detector_id": "melix.pattern_detector.v1",
+        "policy_id": "melix.default_privacy_policy.v1",
+        "policy_mode": "redact",
+        "action": "redacted",
+        "categories": ["email", "secret"],
+        "match_count": 3,
+        "redacted_span_count": 3,
+        "blocked_reason": "",
+        "confidence_source": "deterministic_pattern",
+        "raw_sensitive_span_count": 0,
+        "raw_text_included": False,
+    }
+
+    raw_text_metadata = dict(metadata)
+    raw_text_metadata["melix.privacy.detector.raw_text_included"] = "true"
+    assert privacy_detector_receipt_from_metadata(raw_text_metadata) == {}
+
+    incomplete_metadata = dict(metadata)
+    incomplete_metadata.pop("melix.privacy.detector.match_count")
+    assert privacy_detector_receipt_from_metadata(incomplete_metadata) == {}
+
+    wrong_schema_metadata = dict(metadata)
+    wrong_schema_metadata["melix.privacy.detector.schema_version"] = "melix.privacy_detector_receipt.v0"
+    assert privacy_detector_receipt_from_metadata(wrong_schema_metadata) == {}
+
+    wrong_action_metadata = dict(metadata)
+    wrong_action_metadata["melix.privacy.detector.action"] = "audit"
+    assert privacy_detector_receipt_from_metadata(wrong_action_metadata) == {}
+
+    wrong_category_metadata = dict(metadata)
+    wrong_category_metadata["melix.privacy.detector.categories"] = {"secret": True}
+    assert privacy_detector_receipt_from_metadata(wrong_category_metadata) == {}
+
+    wrong_count_metadata = dict(metadata)
+    wrong_count_metadata["melix.privacy.detector.match_count"] = "many"
+    assert privacy_detector_receipt_from_metadata(wrong_count_metadata) == {}
+
+    raw_span_metadata = dict(metadata)
+    raw_span_metadata["melix.privacy.detector.raw_sensitive_span_count"] = "1"
+    assert privacy_detector_receipt_from_metadata(raw_span_metadata) == {}
+
+    impossible_redaction_metadata = dict(metadata)
+    impossible_redaction_metadata["melix.privacy.detector.redacted_span_count"] = "4"
+    assert privacy_detector_receipt_from_metadata(impossible_redaction_metadata) == {}

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -521,6 +521,61 @@ def test_serving_diagnostics_effective_config_derives_privacy_policy_receipts_fr
     assert "sk-secret" not in payload
 
 
+def test_serving_diagnostics_effective_config_derives_privacy_detector_receipts_from_metadata(
+    tmp_path: Path,
+) -> None:
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-privacy-detector",
+        invocation={},
+        effective_config={
+            "execution_ext": {
+                "melix.privacy.detector.schema_version": "melix.privacy_detector_receipt.v1",
+                "melix.privacy.detector.surface": "workspace_ingest",
+                "melix.privacy.detector.route_scope": "source_import",
+                "melix.privacy.detector.detector_id": "melix.pattern_detector.v1",
+                "melix.privacy.detector.policy_id": "melix.default_privacy_policy.v1",
+                "melix.privacy.detector.policy_mode": "redact",
+                "melix.privacy.detector.action": "redacted",
+                "melix.privacy.detector.categories": ["secret", "email"],
+                "melix.privacy.detector.match_count": "3",
+                "melix.privacy.detector.redacted_span_count": "3",
+                "melix.privacy.detector.blocked_reason": "",
+                "melix.privacy.detector.confidence_source": "deterministic_pattern",
+                "melix.privacy.detector.raw_sensitive_span_count": "0",
+                "melix.privacy.detector.raw_text_included": "false",
+            }
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert effective_config["privacy_detector_receipts"] == [
+        {
+            "schema_version": "melix.privacy_detector_receipt.v1",
+            "surface": "workspace_ingest",
+            "route_scope": "source_import",
+            "detector_id": "melix.pattern_detector.v1",
+            "policy_id": "melix.default_privacy_policy.v1",
+            "policy_mode": "redact",
+            "action": "redacted",
+            "categories": ["email", "secret"],
+            "match_count": 3,
+            "redacted_span_count": 3,
+            "blocked_reason": "",
+            "confidence_source": "deterministic_pattern",
+            "raw_sensitive_span_count": 0,
+            "raw_text_included": False,
+        }
+    ]
+    payload = json.dumps(effective_config, sort_keys=True)
+    assert "alice@example.com" not in payload
+    assert "sk-secret" not in payload
+
+
 def test_serving_diagnostics_effective_config_skips_incomplete_privacy_policy_metadata(
     tmp_path: Path,
 ) -> None:
@@ -534,6 +589,9 @@ def test_serving_diagnostics_effective_config_skips_incomplete_privacy_policy_me
                 "melix.network_fetch.policy.action": "blocked",
                 "melix.privacy.audit.surface": "local_proxy_external_media",
                 "melix.privacy.audit.blocked_count": "1",
+                "melix.privacy.detector.surface": "workspace_ingest",
+                "melix.privacy.detector.action": "redacted",
+                "melix.privacy.detector.raw_text_included": "true",
             }
         },
         model_refs={"model_id": "melix-dev-text"},
@@ -545,6 +603,7 @@ def test_serving_diagnostics_effective_config_skips_incomplete_privacy_policy_me
     effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
     assert "network_fetch_policy" not in effective_config
     assert "privacy_audit_counters" not in effective_config
+    assert "privacy_detector_receipts" not in effective_config
 
 
 def test_serving_diagnostics_empty_effective_config_skips_profile_receipt_scan(

--- a/services/mlx-worker-python/worker/productization/privacy_policy_receipts.py
+++ b/services/mlx-worker-python/worker/productization/privacy_policy_receipts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from ipaddress import ip_address
@@ -8,9 +9,40 @@ from urllib.parse import urlsplit
 
 NETWORK_FETCH_POLICY_RECEIPT_SCHEMA_VERSION = "melix.network_fetch_policy_receipt.v1"
 PRIVACY_AUDIT_COUNTER_SCHEMA_VERSION = "melix.privacy_audit_counter.v1"
+PRIVACY_DETECTOR_RECEIPT_SCHEMA_VERSION = "melix.privacy_detector_receipt.v1"
+
+DEFAULT_PRIVACY_POLICY_ID = "melix.default_privacy_policy.v1"
+PATTERN_PRIVACY_DETECTOR_ID = "melix.pattern_detector.v1"
 
 _PRIVATE_IP_REDACTION = "[REDACTED_PRIVATE_IP]"
 _LOCAL_PATH_REDACTION = "[LOCAL_PATH]"
+_DETERMINISTIC_PATTERN_CONFIDENCE_SOURCE = "deterministic_pattern"
+
+_EMAIL_PATTERN = re.compile(
+    r"\b[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+\b"
+)
+_HF_TOKEN_PATTERN = re.compile(r"\bhf_[A-Za-z0-9][A-Za-z0-9_\-=]{5,}")
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"\b[A-Za-z0-9_]*(?:"
+    r"HF_TOKEN|HUGGINGFACE_HUB_TOKEN|MELIX_HF_TOKEN|MELIX_HUGGINGFACE_TOKEN|"
+    r"MELIX_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|"
+    r"API_KEY|ACCESS_TOKEN|AUTH_TOKEN|BEARER_TOKEN|SECRET_KEY|CLIENT_SECRET|"
+    r"PASSWORD"
+    r")=([^\s,;]+)",
+    flags=re.IGNORECASE,
+)
+_BEARER_TOKEN_PATTERN = re.compile(
+    r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}",
+    flags=re.IGNORECASE,
+)
+_PRIVACY_PATTERNS = (
+    ("secret", "[REDACTED_SECRET]", _SECRET_ASSIGNMENT_PATTERN),
+    ("secret", "[REDACTED_SECRET]", _BEARER_TOKEN_PATTERN),
+    ("secret", "[REDACTED_SECRET]", _HF_TOKEN_PATTERN),
+    ("email", "[REDACTED_EMAIL]", _EMAIL_PATTERN),
+)
 
 _NETWORK_FETCH_METADATA_FIELDS = {
     "melix.network_fetch.policy.surface": "surface",
@@ -53,6 +85,30 @@ _PRIVACY_AUDIT_METADATA_FIELDS = {
 }
 _PRIVACY_AUDIT_REQUIRED_FIELDS = frozenset(_PRIVACY_AUDIT_METADATA_FIELDS.values())
 
+_PRIVACY_DETECTOR_METADATA_FIELDS = {
+    "melix.privacy.detector.surface": "surface",
+    "melix.privacy.detector.route_scope": "route_scope",
+    "melix.privacy.detector.detector_id": "detector_id",
+    "melix.privacy.detector.policy_id": "policy_id",
+    "melix.privacy.detector.policy_mode": "policy_mode",
+    "melix.privacy.detector.action": "action",
+    "melix.privacy.detector.categories": "categories",
+    "melix.privacy.detector.match_count": "match_count",
+    "melix.privacy.detector.redacted_span_count": "redacted_span_count",
+    "melix.privacy.detector.blocked_reason": "blocked_reason",
+    "melix.privacy.detector.confidence_source": "confidence_source",
+    "melix.privacy.detector.raw_sensitive_span_count": "raw_sensitive_span_count",
+    "melix.privacy.detector.raw_text_included": "raw_text_included",
+}
+_PRIVACY_DETECTOR_REQUIRED_FIELDS = frozenset(_PRIVACY_DETECTOR_METADATA_FIELDS.values())
+
+
+@dataclass(frozen=True, slots=True)
+class _PrivacyPatternMatch:
+    start: int
+    end: int
+    category: str
+    placeholder: str
 
 @dataclass(frozen=True, slots=True)
 class NetworkFetchPolicyReceipt:
@@ -112,6 +168,57 @@ class PrivacyAuditCounter:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class PrivacyDetectorReceipt:
+    surface: str
+    route_scope: str
+    detector_id: str
+    policy_id: str
+    policy_mode: str
+    action: str
+    categories: tuple[str, ...] = ()
+    match_count: int = 0
+    redacted_span_count: int = 0
+    blocked_reason: str = ""
+    confidence_source: str = _DETERMINISTIC_PATTERN_CONFIDENCE_SOURCE
+    raw_sensitive_span_count: int = 0
+    raw_text_included: bool = False
+    schema_version: str = PRIVACY_DETECTOR_RECEIPT_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "surface": self.surface,
+            "route_scope": self.route_scope,
+            "detector_id": self.detector_id,
+            "policy_id": self.policy_id,
+            "policy_mode": self.policy_mode,
+            "action": self.action,
+            "categories": list(self.categories),
+            "match_count": int(self.match_count),
+            "redacted_span_count": int(self.redacted_span_count),
+            "blocked_reason": self.blocked_reason,
+            "confidence_source": self.confidence_source,
+            "raw_sensitive_span_count": int(self.raw_sensitive_span_count),
+            "raw_text_included": bool(self.raw_text_included),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PrivacyDetectionResult:
+    redacted_text: str
+    receipt_object: PrivacyDetectorReceipt
+    audit_counter_object: PrivacyAuditCounter
+
+    @property
+    def receipt(self) -> dict[str, object]:
+        return self.receipt_object.to_dict()
+
+    @property
+    def audit_counter(self) -> dict[str, object]:
+        return self.audit_counter_object.to_dict()
+
+
 def network_fetch_policy_receipt_for_url(
     raw_url: str,
     *,
@@ -146,6 +253,64 @@ def privacy_audit_counter(
         redacted_count=sum(1 for decision in decisions if decision == "redacted"),
         passed_count=sum(1 for decision in decisions if decision == "passed"),
         raw_sensitive_span_count=raw_sensitive_span_count,
+    )
+
+
+def detect_privacy_patterns(
+    value: str,
+    *,
+    surface: str,
+    route_scope: str,
+    policy_mode: str = "redact",
+    policy_id: str = DEFAULT_PRIVACY_POLICY_ID,
+    detector_id: str = PATTERN_PRIVACY_DETECTOR_ID,
+) -> PrivacyDetectionResult:
+    text = value if isinstance(value, str) else ""
+    normalized_mode = str(policy_mode).strip().lower() or "redact"
+    if normalized_mode not in {"redact", "block"}:
+        normalized_mode = "redact"
+
+    matches = _privacy_pattern_matches(text)
+    categories = tuple(sorted({match.category for match in matches}))
+    match_count = len(matches)
+
+    action = "passed"
+    blocked_reason = ""
+    redacted_span_count = 0
+    redacted_text = text
+    if match_count and normalized_mode == "block":
+        action = "blocked"
+        blocked_reason = "pattern_match_blocked"
+        redacted_text = ""
+    elif match_count:
+        action = "redacted"
+        redacted_span_count = match_count
+        redacted_text = _redacted_text_for_matches(text, matches)
+
+    receipt = PrivacyDetectorReceipt(
+        surface=surface,
+        route_scope=route_scope,
+        detector_id=detector_id,
+        policy_id=policy_id,
+        policy_mode=normalized_mode,
+        action=action,
+        categories=categories,
+        match_count=match_count,
+        redacted_span_count=redacted_span_count,
+        blocked_reason=blocked_reason,
+        confidence_source=_DETERMINISTIC_PATTERN_CONFIDENCE_SOURCE,
+        raw_sensitive_span_count=0,
+        raw_text_included=False,
+    )
+    return PrivacyDetectionResult(
+        redacted_text=redacted_text,
+        receipt_object=receipt,
+        audit_counter_object=privacy_audit_counter(
+            surface=surface,
+            route_scope=route_scope,
+            decisions=(action,),
+            raw_sensitive_span_count=0,
+        ),
     )
 
 
@@ -243,6 +408,62 @@ def privacy_audit_counter_from_metadata(
         redacted_count=parsed_counts["redacted_count"] or 0,
         passed_count=parsed_counts["passed_count"] or 0,
         raw_sensitive_span_count=parsed_counts["raw_sensitive_span_count"] or 0,
+    ).to_dict()
+
+
+def privacy_detector_receipt_from_metadata(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    receipt = {
+        receipt_key: metadata.get(audit_key)
+        for audit_key, receipt_key in _PRIVACY_DETECTOR_METADATA_FIELDS.items()
+        if metadata.get(audit_key) is not None
+    }
+    if not _PRIVACY_DETECTOR_REQUIRED_FIELDS.issubset(receipt):
+        return {}
+    schema_version = str(
+        metadata.get(
+            "melix.privacy.detector.schema_version",
+            PRIVACY_DETECTOR_RECEIPT_SCHEMA_VERSION,
+        )
+    )
+    if schema_version != PRIVACY_DETECTOR_RECEIPT_SCHEMA_VERSION:
+        return {}
+    action = str(receipt["action"])
+    if action not in {"passed", "redacted", "blocked"}:
+        return {}
+    categories = _category_values(receipt["categories"])
+    if categories is None:
+        return {}
+    parsed_match_count = _int_value(receipt["match_count"])
+    parsed_redacted_span_count = _int_value(receipt["redacted_span_count"])
+    parsed_raw_sensitive_span_count = _int_value(receipt["raw_sensitive_span_count"])
+    raw_text_included = _bool_value(receipt["raw_text_included"])
+    if (
+        parsed_match_count is None
+        or parsed_redacted_span_count is None
+        or parsed_raw_sensitive_span_count is None
+        or raw_text_included is None
+    ):
+        return {}
+    if raw_text_included or parsed_raw_sensitive_span_count > 0:
+        return {}
+    if parsed_redacted_span_count > parsed_match_count:
+        return {}
+    return PrivacyDetectorReceipt(
+        surface=str(receipt["surface"]),
+        route_scope=str(receipt["route_scope"]),
+        detector_id=str(receipt["detector_id"]),
+        policy_id=str(receipt["policy_id"]),
+        policy_mode=str(receipt["policy_mode"]),
+        action=action,
+        categories=tuple(categories),
+        match_count=parsed_match_count,
+        redacted_span_count=parsed_redacted_span_count,
+        blocked_reason=str(receipt["blocked_reason"]),
+        confidence_source=str(receipt["confidence_source"]),
+        raw_sensitive_span_count=parsed_raw_sensitive_span_count,
+        raw_text_included=raw_text_included,
     ).to_dict()
 
 
@@ -472,3 +693,50 @@ def _int_value(value: object) -> int | None:
     if parsed < 0:
         return None
     return parsed
+
+
+def _privacy_pattern_matches(text: str) -> tuple[_PrivacyPatternMatch, ...]:
+    matches: list[_PrivacyPatternMatch] = []
+    for category, placeholder, pattern in _PRIVACY_PATTERNS:
+        for match in pattern.finditer(text):
+            if match.start() == match.end():
+                continue
+            matches.append(
+                _PrivacyPatternMatch(
+                    start=match.start(),
+                    end=match.end(),
+                    category=category,
+                    placeholder=placeholder,
+                )
+            )
+    matches.sort(key=lambda item: (item.start, -(item.end - item.start)))
+    selected: list[_PrivacyPatternMatch] = []
+    selected_end = -1
+    for match in matches:
+        if match.start < selected_end:
+            continue
+        selected.append(match)
+        selected_end = match.end
+    return tuple(selected)
+
+
+def _redacted_text_for_matches(text: str, matches: tuple[_PrivacyPatternMatch, ...]) -> str:
+    parts: list[str] = []
+    cursor = 0
+    for match in matches:
+        parts.append(text[cursor : match.start])
+        parts.append(match.placeholder)
+        cursor = match.end
+    parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _category_values(value: object) -> tuple[str, ...] | None:
+    if isinstance(value, str):
+        raw_values = value.split(",")
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        raw_values = list(value)
+    else:
+        return None
+    categories = sorted({str(item).strip() for item in raw_values if str(item).strip()})
+    return tuple(categories)

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -15,6 +15,7 @@ from typing import Any
 from worker.productization.privacy_policy_receipts import (
     network_fetch_policy_receipt_from_metadata,
     privacy_audit_counter_from_metadata,
+    privacy_detector_receipt_from_metadata,
 )
 
 
@@ -608,6 +609,12 @@ def _effective_config_with_profile_receipt(
             counter = privacy_audit_counter_from_metadata(metadata)
             if counter:
                 enriched_config["privacy_audit_counters"] = [counter]
+                break
+    if "privacy_detector_receipts" not in enriched_config:
+        for metadata in metadata_sources:
+            receipt = privacy_detector_receipt_from_metadata(metadata)
+            if receipt:
+                enriched_config["privacy_detector_receipts"] = [receipt]
                 break
     if enriched_config == stable_config:
         return stable_config


### PR DESCRIPTION
## Summary
- Refs #2188.
- Added the `melix.privacy_detector_receipt.v1` receipt contract for deterministic privacy pattern detection without storing raw sensitive spans.
- Added a bounded pattern detector for email addresses, Hugging Face tokens, secret assignments, and bearer tokens with redact/block policy actions.
- Extended serving diagnostics profile metadata parsing so diagnostics bundles can include privacy detector receipts from namespaced metadata without scanning prompt, completion, document, or artifact content.
- Documented the detector receipt fields, metadata keys, and bundle privacy constraints in the serving diagnostics evidence runbook.

## Plan or Spec
- `docs/plans/2026-07-05-issue-2188-pattern-privacy-detector.md`
- `docs/runbooks/serving-diagnostics-evidence.md` privacy detector receipt section

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py -q
# Expected red result before implementation: ImportError for PrivacyDetectorReceipt.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py -q
# 66 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --branch -m pytest -q services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/privacy_policy_receipts.py services/mlx-worker-python/worker/productization/serving_diagnostics.py services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py
# TOTAL 206 1 100%; privacy_policy_receipts.py file coverage 99.21% with aggregate changed-scope coverage at 100%.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_workspace_manifest_contract.py services/mlx-worker-python/tests/test_log_privacy.py -q
# 109 passed in 0.50s.

git diff --check
# Passed.

git commit -m "Add pattern privacy detector receipts"
# Pre-commit full local gate passed:
# - make swift-test completed rc=0 elapsed=620.5s.
# - make py-test: 4662 passed, 14 skipped, 2 warnings in 170.04s.
# - make integration-test: 123 passed, 1 skipped in 747.11s.
# - Scoped performance report status ok, regressions 0.

git fetch origin main
# origin/main remained dc3f61122933d4ee750bb92805f48c01c85e0574.

git merge-base --is-ancestor origin/main HEAD
# Passed.
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 206 1 100%`; focused helper file coverage was 99.21% and aggregate changed-scope coverage was 100%.
- Local pre-commit performance report: `.runtime/pre-commit-performance/20260704-180303-dc3f6112/report/report.md`.
- Performance report summary: status `ok`; changed files `6`; selected probes `1`; direct/gated probes `1`; regressions `0`; context regressions `0`; verification failures `0`.
- Selected probe: `serving-diagnostics-debug-queue-bounds`; targeted tests `pass`; coverage `pass (100.0%)`; elapsed mean neutral at +3.58%; serialization elapsed mean improved by 68.54%; retained/dropped counts, checksum, and serialized bytes neutral.
- Observability mode: `debug` diagnostics metadata receipt enrichment only. The detector path is bounded regex work over caller-provided strings; this slice does not add network I/O, model inference, filesystem scanning, or content mutation.
- Probe overhead: covered by the direct PR-scoped serving diagnostics debug queue bounds probe above.

## Known Gaps
- This is the first deterministic receipt slice for #2188, so the issue remains open.
- No protobuf schema changes in this slice.
- No dependency changes in this slice.
- No model-backed NER detector in this slice.
- No live local-proxy or workspace-ingestion route integration in this slice.
- No streaming/non-streaming request execution path changes in this slice.
- No artifact, user-file, prompt, or completion mutation in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
