### PR TITLE
Add opt-in local proxy privacy detector

### DIFF
--- a/docs/plans/2026-07-05-issue-2188-local-proxy-privacy-detector.md
+++ b/docs/plans/2026-07-05-issue-2188-local-proxy-privacy-detector.md
@@ -1,0 +1,97 @@
+# Issue 2188 Local Proxy Privacy Detector Integration
+
+## Goal
+
+Land the next executable privacy-policy slice by applying the deterministic
+pattern privacy detector to local proxy text-generation requests before they
+reach worker execution, while keeping the policy explicitly opt-in.
+
+## Scope
+
+- Add a Swift detector receipt shape equivalent to
+  `melix.privacy_detector_receipt.v1`.
+- Add a deterministic Swift pattern detector for common email and secret-like
+  spans, matching the Python helper's receipt contract.
+- Gate local proxy prompt scanning behind `MELIX_PRIVACY_DETECTOR_MODE`.
+- Support `redact` mode by replacing matched text in worker request message
+  text parts before dispatch.
+- Support `block` mode by returning a sanitized 400 response before worker
+  dispatch.
+- Attach `melix.privacy.detector.*` and `melix.privacy.audit.*` metadata to
+  dispatched worker requests when the opt-in detector runs.
+- Keep raw matched values, raw prompt text, and raw sensitive spans out of
+  detector receipts, audit counters, and block responses.
+
+## Non-Goals
+
+- No protobuf schema changes.
+- No default-on privacy mutation.
+- No model-backed NER detector.
+- No workspace document-ingest integration in this slice.
+- No diagnostics bundle content scanning.
+- No streaming framing changes beyond using the already translated worker
+  request with redacted message text.
+
+## Operator Setting
+
+`MELIX_PRIVACY_DETECTOR_MODE` is the explicit opt-in switch for this slice:
+
+- unset, empty, `off`, or `disabled`: detector is not run and request behavior is
+  unchanged;
+- `redact`: matched sensitive text is replaced with stable placeholders before
+  the worker request is dispatched;
+- `block`: matched sensitive text blocks the local proxy request before worker
+  dispatch and returns a sanitized error response.
+
+Other values fail closed to disabled for this slice.
+
+## Receipt Metadata
+
+When the detector runs, local proxy text requests attach:
+
+- `melix.privacy.detector.schema_version`
+- `melix.privacy.detector.surface`
+- `melix.privacy.detector.route_scope`
+- `melix.privacy.detector.detector_id`
+- `melix.privacy.detector.policy_id`
+- `melix.privacy.detector.policy_mode`
+- `melix.privacy.detector.action`
+- `melix.privacy.detector.categories`
+- `melix.privacy.detector.match_count`
+- `melix.privacy.detector.redacted_span_count`
+- `melix.privacy.detector.blocked_reason`
+- `melix.privacy.detector.confidence_source`
+- `melix.privacy.detector.raw_sensitive_span_count`
+- `melix.privacy.detector.raw_text_included`
+- `melix.privacy.audit.*`
+
+The metadata is category/count evidence only. It must not contain raw matched
+values or prompt snippets.
+
+## Performance Probes And Metrics
+
+- Measurement points:
+  - detector execution over already-materialized local proxy message text;
+  - worker request metadata enrichment;
+  - block response construction.
+- Success metrics:
+  - changed-scope coverage at least 95 percent;
+  - zero raw sensitive spans in metadata and block responses;
+  - no worker dispatch in block mode;
+  - no behavior change while the opt-in setting is unset.
+- Probe overhead:
+  - bounded regular-expression scans over request-local text parts;
+  - small metadata dictionary writes.
+- PR-scoped performance:
+  - use the repository pre-commit scoped performance report. If no registered
+    probe matches the changed files, report the no-probe result explicitly.
+
+## Verification
+
+- Swift red test proving an enabled detector redacts a local proxy worker
+  request and emits metadata without leaking raw matched values.
+- Swift tests for block mode, disabled mode, and clean pass-through metadata.
+- Focused Swift test package run for `OpenAIHandlerTests`.
+- Relevant Python receipt parser tests to prove metadata remains compatible with
+  diagnostics enrichment.
+- Full repository pre-commit gate before PR update.

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -291,6 +291,24 @@ Detector receipt derivation is rejected when `raw_text_included` is true or
 `raw_sensitive_span_count` is greater than zero. Exported receipts must include
 only category/count evidence, never raw sensitive spans or matched snippets.
 
+Local proxy text privacy detection is explicitly opt-in. Set
+`MELIX_PRIVACY_DETECTOR_MODE=redact` to scan local proxy text request message
+parts before worker dispatch, replace matched spans with stable placeholders,
+and attach the detector receipt plus a `melix.privacy_audit_counter.v1` counter
+to worker request metadata. Set `MELIX_PRIVACY_DETECTOR_MODE=block` to reject
+matched local proxy text requests before worker dispatch with a sanitized
+`privacy_policy_blocked` error envelope. When the setting is unset, empty,
+`off`, `disabled`, or any unsupported value, the detector is not run and local
+proxy text request behavior is unchanged.
+
+The local proxy detector uses `surface = local_proxy_text_request` and route
+scopes such as `chat_completions`, `completions`, `responses`, and `messages`.
+The redacted placeholders are category-level values such as
+`[REDACTED_EMAIL]` and `[REDACTED_SECRET]`; detector metadata must still omit
+raw matched values and raw prompt snippets. This opt-in slice covers text
+message parts only. It does not scan diagnostics bundle content, mutate user
+files, inspect workspace documents, or run model-backed entity detection.
+
 `request-summary.json` records stable request-level fields:
 
 - request id

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -3047,6 +3047,7 @@ button.primary:active {
             )
             await recordMediaAdmissionFailure(mediaAdmissionFailure)
         }
+        finalTranslated = try await translatedRequestApplyingLocalProxyPrivacyDetector(finalTranslated)
         await recordShapingMetrics(for: finalTranslated, startedAt: shapingStartedAt)
         return ResolvedOpenAITextRequest(
             translated: finalTranslated,
@@ -3343,6 +3344,132 @@ button.primary:active {
             workerRequest: workerRequest,
             stream: translated.stream
         )
+    }
+
+    private func translatedRequestApplyingLocalProxyPrivacyDetector(
+        _ translated: TranslatedChatRequest
+    ) async throws -> TranslatedChatRequest {
+        guard let policyMode = localProxyPrivacyDetectorMode() else {
+            return translated
+        }
+
+        let routeScope = localProxyPrivacyRouteScope(from: translated.workerRequest.execution.ext)
+        let textSegments = localProxyTextSegments(from: translated.workerRequest)
+        let result = await Task.detached(priority: .userInitiated) {
+            PatternPrivacyDetector.detect(
+                textSegments: textSegments,
+                surface: "local_proxy_text_request",
+                routeScope: routeScope,
+                policyMode: policyMode
+            )
+        }.value
+        await recordLocalProxyPrivacyDetectorMetrics(result)
+
+        guard result.receipt.action != "blocked" else {
+            throw HTTPRequestHandlingError.gatewayResponse(localProxyPrivacyDetectorBlockedResponse(result))
+        }
+
+        var workerRequest = translated.workerRequest
+        if result.receipt.action == "redacted" {
+            applyRedactedLocalProxyTextSegments(result.redactedTexts, to: &workerRequest)
+        }
+        for (key, value) in result.receipt.metadataFields(prefix: "melix.privacy.detector") {
+            workerRequest.execution.ext[key] = value
+        }
+        for (key, value) in result.auditCounter.metadataFields(prefix: "melix.privacy.audit") {
+            workerRequest.execution.ext[key] = value
+        }
+
+        return TranslatedChatRequest(
+            requestID: translated.requestID,
+            modelID: translated.modelID,
+            responseModelID: translated.responseModelID,
+            workerRequest: workerRequest,
+            stream: translated.stream
+        )
+    }
+
+    private func localProxyPrivacyDetectorMode() -> String? {
+        let rawValue = environment["MELIX_PRIVACY_DETECTOR_MODE"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        switch rawValue {
+        case "redact", "block":
+            return rawValue
+        default:
+            return nil
+        }
+    }
+
+    private func localProxyPrivacyRouteScope(from executionExt: [String: String]) -> String {
+        let endpoint = executionExt["melix.endpoint"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !endpoint.isEmpty else {
+            return "text_generation"
+        }
+        return endpoint.replacingOccurrences(of: ".", with: "_")
+    }
+
+    private func localProxyTextSegments(from request: Melix_Worker_V1_GenerateRequest) -> [String] {
+        var textSegments: [String] = []
+        for message in request.messages {
+            for part in message.parts where !part.text.isEmpty {
+                textSegments.append(part.text)
+            }
+        }
+        return textSegments
+    }
+
+    private func applyRedactedLocalProxyTextSegments(
+        _ redactedTexts: [String],
+        to request: inout Melix_Worker_V1_GenerateRequest
+    ) {
+        var textIndex = 0
+        for messageIndex in request.messages.indices {
+            for partIndex in request.messages[messageIndex].parts.indices {
+                guard !request.messages[messageIndex].parts[partIndex].text.isEmpty,
+                      textIndex < redactedTexts.count
+                else {
+                    continue
+                }
+                request.messages[messageIndex].parts[partIndex].text = redactedTexts[textIndex]
+                textIndex += 1
+            }
+        }
+    }
+
+    private func localProxyPrivacyDetectorBlockedResponse(
+        _ result: PatternPrivacyDetectionResult
+    ) -> HTTPResponse {
+        jsonResponse(
+            statusCode: 400,
+            payload: [
+                "error": [
+                    "code": "privacy_policy_blocked",
+                    "message": "Local proxy privacy policy blocked this request.",
+                    "privacy_receipt": result.receipt.jsonObject,
+                    "privacy_audit_counters": [result.auditCounter.jsonObject],
+                ],
+            ]
+        )
+    }
+
+    private func recordLocalProxyPrivacyDetectorMetrics(
+        _ result: PatternPrivacyDetectionResult
+    ) async {
+        await metricsStore.increment("privacy_detector.local_proxy_text_request.\(result.receipt.action)_count")
+        await metricsStore.increment(
+            "privacy_detector.local_proxy_text_request.match_count",
+            by: Double(result.receipt.matchCount)
+        )
+        switch result.receipt.action {
+        case "blocked":
+            await metricsStore.increment("privacy_audit.blocked_count")
+        case "redacted":
+            await metricsStore.increment("privacy_audit.redacted_count")
+        default:
+            await metricsStore.increment("privacy_audit.passed_count")
+        }
     }
 
     private func recordMediaAdmissionFailure(_ failure: MediaAdmissionFailure) async {

--- a/services/control-plane-swift/Sources/Requests/PrivacyPolicyReceipts.swift
+++ b/services/control-plane-swift/Sources/Requests/PrivacyPolicyReceipts.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+public struct PrivacyDetectorReceipt: Equatable, Sendable {
+    public let schemaVersion: String
+    public let surface: String
+    public let routeScope: String
+    public let detectorID: String
+    public let policyID: String
+    public let policyMode: String
+    public let action: String
+    public let categories: [String]
+    public let matchCount: Int
+    public let redactedSpanCount: Int
+    public let blockedReason: String
+    public let confidenceSource: String
+    public let rawSensitiveSpanCount: Int
+    public let rawTextIncluded: Bool
+
+    public init(
+        schemaVersion: String = "melix.privacy_detector_receipt.v1",
+        surface: String,
+        routeScope: String,
+        detectorID: String = "melix.pattern_detector.v1",
+        policyID: String = "melix.default_privacy_policy.v1",
+        policyMode: String,
+        action: String,
+        categories: [String] = [],
+        matchCount: Int = 0,
+        redactedSpanCount: Int = 0,
+        blockedReason: String = "",
+        confidenceSource: String = "deterministic_pattern",
+        rawSensitiveSpanCount: Int = 0,
+        rawTextIncluded: Bool = false
+    ) {
+        self.schemaVersion = schemaVersion
+        self.surface = surface
+        self.routeScope = routeScope
+        self.detectorID = detectorID
+        self.policyID = policyID
+        self.policyMode = policyMode
+        self.action = action
+        self.categories = categories
+        self.matchCount = matchCount
+        self.redactedSpanCount = redactedSpanCount
+        self.blockedReason = blockedReason
+        self.confidenceSource = confidenceSource
+        self.rawSensitiveSpanCount = rawSensitiveSpanCount
+        self.rawTextIncluded = rawTextIncluded
+    }
+
+    public var jsonObject: [String: Any] {
+        [
+            "schema_version": schemaVersion,
+            "surface": surface,
+            "route_scope": routeScope,
+            "detector_id": detectorID,
+            "policy_id": policyID,
+            "policy_mode": policyMode,
+            "action": action,
+            "categories": categories,
+            "match_count": matchCount,
+            "redacted_span_count": redactedSpanCount,
+            "blocked_reason": blockedReason,
+            "confidence_source": confidenceSource,
+            "raw_sensitive_span_count": rawSensitiveSpanCount,
+            "raw_text_included": rawTextIncluded,
+        ]
+    }
+
+    public func metadataFields(prefix: String) -> [String: String] {
+        [
+            "\(prefix).schema_version": schemaVersion,
+            "\(prefix).surface": surface,
+            "\(prefix).route_scope": routeScope,
+            "\(prefix).detector_id": detectorID,
+            "\(prefix).policy_id": policyID,
+            "\(prefix).policy_mode": policyMode,
+            "\(prefix).action": action,
+            "\(prefix).categories": categories.joined(separator: ","),
+            "\(prefix).match_count": String(matchCount),
+            "\(prefix).redacted_span_count": String(redactedSpanCount),
+            "\(prefix).blocked_reason": blockedReason,
+            "\(prefix).confidence_source": confidenceSource,
+            "\(prefix).raw_sensitive_span_count": String(rawSensitiveSpanCount),
+            "\(prefix).raw_text_included": String(rawTextIncluded),
+        ]
+    }
+}
+
+public struct PatternPrivacyDetectionResult: Equatable, Sendable {
+    public let redactedTexts: [String]
+    public let receipt: PrivacyDetectorReceipt
+    public let auditCounter: PrivacyAuditCounter
+}
+
+public enum PatternPrivacyDetector {
+    public static func detect(
+        textSegments: [String],
+        surface: String,
+        routeScope: String,
+        policyMode: String
+    ) -> PatternPrivacyDetectionResult {
+        let normalizedMode = normalizedPolicyMode(policyMode)
+        var redactedTexts: [String] = []
+        var categories = Set<String>()
+        var matchCount = 0
+
+        for text in textSegments {
+            let matches = privacyPatternMatches(in: text)
+            for match in matches {
+                categories.insert(match.category)
+            }
+            matchCount += matches.count
+            redactedTexts.append(redactedText(for: text, matches: matches))
+        }
+
+        let action: String
+        let redactedSpanCount: Int
+        let blockedReason: String
+        if matchCount == 0 {
+            action = "passed"
+            redactedSpanCount = 0
+            blockedReason = ""
+        } else if normalizedMode == "block" {
+            action = "blocked"
+            redactedSpanCount = 0
+            blockedReason = "pattern_match_blocked"
+        } else {
+            action = "redacted"
+            redactedSpanCount = matchCount
+            blockedReason = ""
+        }
+
+        let receipt = PrivacyDetectorReceipt(
+            surface: surface,
+            routeScope: routeScope,
+            policyMode: normalizedMode,
+            action: action,
+            categories: categories.sorted(),
+            matchCount: matchCount,
+            redactedSpanCount: redactedSpanCount,
+            blockedReason: blockedReason
+        )
+        let counter = PrivacyAuditCounter(
+            surface: surface,
+            routeScope: routeScope,
+            blockedCount: action == "blocked" ? 1 : 0,
+            redactedCount: action == "redacted" ? 1 : 0,
+            passedCount: action == "passed" ? 1 : 0
+        )
+        return PatternPrivacyDetectionResult(
+            redactedTexts: redactedTexts,
+            receipt: receipt,
+            auditCounter: counter
+        )
+    }
+
+    private static func normalizedPolicyMode(_ value: String) -> String {
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == "block" ? "block" : "redact"
+    }
+
+    private struct PatternMatch {
+        let range: NSRange
+        let category: String
+        let placeholder: String
+    }
+
+    private static let privacyPatterns: [(category: String, placeholder: String, regex: NSRegularExpression)] = [
+        (
+            "secret",
+            "[REDACTED_SECRET]",
+            try! NSRegularExpression(
+                pattern: #"\b[A-Za-z0-9_]*(?:HF_TOKEN|HUGGINGFACE_HUB_TOKEN|MELIX_HF_TOKEN|MELIX_HUGGINGFACE_TOKEN|MELIX_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|API_KEY|ACCESS_TOKEN|AUTH_TOKEN|BEARER_TOKEN|SECRET_KEY|CLIENT_SECRET|PASSWORD)\s*=\s*(?:"[^"]*"|'[^']*'|\S+)"#,
+                options: [.caseInsensitive]
+            )
+        ),
+        (
+            "secret",
+            "[REDACTED_SECRET]",
+            try! NSRegularExpression(
+                pattern: #"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}"#,
+                options: [.caseInsensitive]
+            )
+        ),
+        (
+            "secret",
+            "[REDACTED_SECRET]",
+            try! NSRegularExpression(
+                pattern: #"\bhf_[A-Za-z0-9][A-Za-z0-9_\-=]{5,}"#,
+                options: [.caseInsensitive]
+            )
+        ),
+        (
+            "email",
+            "[REDACTED_EMAIL]",
+            try! NSRegularExpression(
+                pattern: #"\b[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+\b"#
+            )
+        ),
+    ]
+
+    private static func privacyPatternMatches(in text: String) -> [PatternMatch] {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var accepted: [PatternMatch] = []
+        for pattern in privacyPatterns {
+            let matches = pattern.regex.matches(in: text, range: fullRange)
+            for match in matches {
+                guard match.range.length > 0 else {
+                    continue
+                }
+                let candidate = PatternMatch(
+                    range: match.range,
+                    category: pattern.category,
+                    placeholder: pattern.placeholder
+                )
+                guard !accepted.contains(where: { rangesOverlap($0.range, candidate.range) }) else {
+                    continue
+                }
+                accepted.append(candidate)
+            }
+        }
+        return accepted.sorted { lhs, rhs in
+            lhs.range.location < rhs.range.location
+        }
+    }
+
+    private static func redactedText(for text: String, matches: [PatternMatch]) -> String {
+        guard !matches.isEmpty else {
+            return text
+        }
+        let redacted = NSMutableString(string: text)
+        for match in matches.sorted(by: { $0.range.location > $1.range.location }) {
+            redacted.replaceCharacters(in: match.range, with: match.placeholder)
+        }
+        return redacted as String
+    }
+
+    private static func rangesOverlap(_ lhs: NSRange, _ rhs: NSRange) -> Bool {
+        lhs.location < rhs.location + rhs.length && rhs.location < lhs.location + lhs.length
+    }
+}

--- a/services/control-plane-swift/Tests/ControlPlaneTests/PrivacyPolicyReceiptsTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/PrivacyPolicyReceiptsTests.swift
@@ -1,0 +1,33 @@
+import Testing
+
+@testable import MelixControlPlaneCore
+
+struct PrivacyPolicyReceiptsTests {
+    @Test("pattern privacy detector redacts unquoted assignment values through punctuation")
+    func patternPrivacyDetectorRedactsUnquotedAssignmentValuesThroughPunctuation() {
+        let result = PatternPrivacyDetector.detect(
+            textSegments: ["Use API_KEY=abc,def;ghi before sending."],
+            surface: "local_proxy_text_request",
+            routeScope: "chat_completions",
+            policyMode: "redact"
+        )
+
+        #expect(result.redactedTexts == ["Use [REDACTED_SECRET] before sending."])
+        #expect(result.receipt.matchCount == 1)
+        #expect(result.receipt.categories == ["secret"])
+    }
+
+    @Test("pattern privacy detector redacts uppercase standalone Hugging Face tokens")
+    func patternPrivacyDetectorRedactsUppercaseStandaloneHuggingFaceTokens() {
+        let result = PatternPrivacyDetector.detect(
+            textSegments: ["Use token HF_ABCDEF123456."],
+            surface: "local_proxy_text_request",
+            routeScope: "chat_completions",
+            policyMode: "redact"
+        )
+
+        #expect(result.redactedTexts == ["Use token [REDACTED_SECRET]."])
+        #expect(result.receipt.matchCount == 1)
+        #expect(result.receipt.categories == ["secret"])
+    }
+}

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift
@@ -2137,6 +2137,239 @@ struct OpenAIHandlerTests {
         #expect(payload.contains("data: [DONE]"))
     }
 
+    @Test("local proxy privacy detector redacts text requests when explicitly enabled")
+    func localProxyPrivacyDetectorRedactsTextRequestsWhenExplicitlyEnabled() async throws {
+        let catalog = ModelCatalog(seedModels: [warmModel()])
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-privacy", seq: 1, text: "ok"),
+            makeCompletedEvent(requestID: "req-privacy", seq: 2, finishReason: "stop", assistantText: "ok"),
+        ])
+        let coordinator = RequestCoordinator(
+            workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+            abortRegistry: AbortRegistry()
+        )
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-privacy" })
+        let handler = OpenAIHandler(
+            modelCatalog: catalog,
+            requestCoordinator: coordinator,
+            translator: translator,
+            environment: ["MELIX_PRIVACY_DETECTOR_MODE": "redact"]
+        )
+
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Email alice@example.test and use token hf_ABC12345 and PASSWORD = \\\"my secret password\\\"" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let redactedText = try #require(request.messages.first?.parts.first?.text)
+        let metadata = request.execution.ext
+        let metadataText = metadata.values.joined(separator: " ")
+
+        #expect(response.statusCode == 200)
+        #expect(redactedText == "Email [REDACTED_EMAIL] and use token [REDACTED_SECRET] and [REDACTED_SECRET]")
+        #expect(redactedText.contains("alice@example.test") == false)
+        #expect(redactedText.contains("hf_ABC12345") == false)
+        #expect(redactedText.contains("my secret password") == false)
+        #expect(metadata["melix.privacy.detector.schema_version"] == "melix.privacy_detector_receipt.v1")
+        #expect(metadata["melix.privacy.detector.surface"] == "local_proxy_text_request")
+        #expect(metadata["melix.privacy.detector.route_scope"] == "chat_completions")
+        #expect(metadata["melix.privacy.detector.detector_id"] == "melix.pattern_detector.v1")
+        #expect(metadata["melix.privacy.detector.policy_id"] == "melix.default_privacy_policy.v1")
+        #expect(metadata["melix.privacy.detector.policy_mode"] == "redact")
+        #expect(metadata["melix.privacy.detector.action"] == "redacted")
+        #expect(metadata["melix.privacy.detector.categories"] == "email,secret")
+        #expect(metadata["melix.privacy.detector.match_count"] == "3")
+        #expect(metadata["melix.privacy.detector.redacted_span_count"] == "3")
+        #expect(metadata["melix.privacy.detector.raw_sensitive_span_count"] == "0")
+        #expect(metadata["melix.privacy.detector.raw_text_included"] == "false")
+        #expect(metadata["melix.privacy.audit.schema_version"] == "melix.privacy_audit_counter.v1")
+        #expect(metadata["melix.privacy.audit.surface"] == "local_proxy_text_request")
+        #expect(metadata["melix.privacy.audit.route_scope"] == "chat_completions")
+        #expect(metadata["melix.privacy.audit.blocked_count"] == "0")
+        #expect(metadata["melix.privacy.audit.redacted_count"] == "1")
+        #expect(metadata["melix.privacy.audit.passed_count"] == "0")
+        #expect(metadata["melix.privacy.audit.raw_sensitive_span_count"] == "0")
+        #expect(metadataText.contains("alice@example.test") == false)
+        #expect(metadataText.contains("hf_ABC12345") == false)
+        #expect(metadataText.contains("my secret password") == false)
+    }
+
+    @Test("local proxy privacy detector is disabled by default")
+    func localProxyPrivacyDetectorIsDisabledByDefault() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-privacy-off", seq: 1, text: "ok"),
+            makeCompletedEvent(requestID: "req-privacy-off", seq: 2, finishReason: "stop", assistantText: "ok"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-privacy-off" }),
+            environment: [:]
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Email alice@example.test and use token hf_ABC12345" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let request = try #require(await workerClient.lastGenerateRequest)
+
+        #expect(response.statusCode == 200)
+        #expect(request.messages.first?.parts.first?.text == "Email alice@example.test and use token hf_ABC12345")
+        #expect(request.execution.ext["melix.privacy.detector.schema_version"] == nil)
+        #expect(request.execution.ext["melix.privacy.audit.schema_version"] == nil)
+    }
+
+    @Test("local proxy privacy detector blocks text requests before worker dispatch")
+    func localProxyPrivacyDetectorBlocksTextRequestsBeforeWorkerDispatch() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-privacy-block", seq: 1, text: "never"),
+        ])
+        let metricsStore = MetricsStore()
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            metricsStore: metricsStore,
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-privacy-block" }),
+            environment: ["MELIX_PRIVACY_DETECTOR_MODE": "block"]
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Use bearer Bearer abcdefgh12345678 for alice@example.test" }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let bodyData = try await collectBodyData(response.body)
+        let bodyText = try #require(String(data: bodyData, encoding: .utf8))
+        let payload = try jsonPayload(from: bodyData)
+        let error = try #require(payload["error"] as? [String: Any])
+        let receipt = try #require(error["privacy_receipt"] as? [String: Any])
+        let counters = try #require(error["privacy_audit_counters"] as? [[String: Any]])
+        let counter = try #require(counters.first)
+
+        #expect(response.statusCode == 400)
+        #expect(error["code"] as? String == "privacy_policy_blocked")
+        #expect(receipt["schema_version"] as? String == "melix.privacy_detector_receipt.v1")
+        #expect(receipt["surface"] as? String == "local_proxy_text_request")
+        #expect(receipt["route_scope"] as? String == "chat_completions")
+        #expect(receipt["policy_mode"] as? String == "block")
+        #expect(receipt["action"] as? String == "blocked")
+        #expect(receipt["blocked_reason"] as? String == "pattern_match_blocked")
+        #expect(receipt["match_count"] as? Int == 2)
+        #expect(receipt["redacted_span_count"] as? Int == 0)
+        #expect(receipt["raw_sensitive_span_count"] as? Int == 0)
+        #expect(receipt["raw_text_included"] as? Bool == false)
+        #expect(counter["blocked_count"] as? Int == 1)
+        #expect(counter["redacted_count"] as? Int == 0)
+        #expect(counter["passed_count"] as? Int == 0)
+        #expect(bodyText.contains("Bearer abcdefgh12345678") == false)
+        #expect(bodyText.contains("alice@example.test") == false)
+        #expect(await workerClient.lastGenerateRequest == nil)
+        #expect(await metricsStore.value(forKey: "privacy_detector.local_proxy_text_request.blocked_count") == 1)
+        #expect(await metricsStore.value(forKey: "privacy_audit.blocked_count") == 1)
+    }
+
+    @Test("local proxy privacy detector records passed metadata for clean opt-in text")
+    func localProxyPrivacyDetectorRecordsPassedMetadataForCleanOptInText() async throws {
+        let workerClient = ScriptedWorkerClient(events: [
+            makeTokenEvent(requestID: "req-privacy-clean", seq: 1, text: "ok"),
+            makeCompletedEvent(requestID: "req-privacy-clean", seq: 2, finishReason: "stop", assistantText: "ok"),
+        ])
+        let handler = OpenAIHandler(
+            modelCatalog: ModelCatalog(seedModels: [warmModel()]),
+            requestCoordinator: RequestCoordinator(
+                workerRegistry: WorkerRegistry(defaultTextClient: workerClient),
+                abortRegistry: AbortRegistry()
+            ),
+            translator: ChatRequestTranslator(requestIDGenerator: { "req-privacy-clean" }),
+            environment: ["MELIX_PRIVACY_DETECTOR_MODE": "redact"]
+        )
+        let body = try #require(
+            """
+            {
+              "model": "melix-dev-text",
+              "stream": true,
+              "messages": [
+                { "role": "user", "content": "Summarize the release checklist." }
+              ]
+            }
+            """.data(using: .utf8)
+        )
+
+        let response = try await handler.handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: body
+            )
+        )
+        let request = try #require(await workerClient.lastGenerateRequest)
+        let metadata = request.execution.ext
+
+        #expect(response.statusCode == 200)
+        #expect(request.messages.first?.parts.first?.text == "Summarize the release checklist.")
+        #expect(metadata["melix.privacy.detector.action"] == "passed")
+        #expect(metadata["melix.privacy.detector.categories"] == "")
+        #expect(metadata["melix.privacy.detector.match_count"] == "0")
+        #expect(metadata["melix.privacy.detector.redacted_span_count"] == "0")
+        #expect(metadata["melix.privacy.audit.blocked_count"] == "0")
+        #expect(metadata["melix.privacy.audit.redacted_count"] == "0")
+        #expect(metadata["melix.privacy.audit.passed_count"] == "1")
+        #expect(metadata["melix.privacy.audit.raw_sensitive_span_count"] == "0")
+    }
+
     @Test("POST /v1/chat/completions normalizes generation bounds stop and passthrough receipts")
     func postChatCompletionsNormalizesGenerationBoundsStopAndPassthroughReceipts() async throws {
         let catalog = ModelCatalog(seedModels: [warmModel()])

--- a/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
+++ b/services/mlx-worker-python/tests/test_privacy_policy_receipts.py
@@ -369,3 +369,39 @@ def test_privacy_detector_receipt_metadata_derivation_rejects_raw_text_receipts(
     impossible_redaction_metadata = dict(metadata)
     impossible_redaction_metadata["melix.privacy.detector.redacted_span_count"] = "4"
     assert privacy_detector_receipt_from_metadata(impossible_redaction_metadata) == {}
+
+
+def test_privacy_detector_receipt_metadata_derivation_accepts_clean_local_proxy_pass() -> None:
+    metadata = {
+        "melix.privacy.detector.schema_version": "melix.privacy_detector_receipt.v1",
+        "melix.privacy.detector.surface": "local_proxy_text_request",
+        "melix.privacy.detector.route_scope": "chat_completions",
+        "melix.privacy.detector.detector_id": "melix.pattern_detector.v1",
+        "melix.privacy.detector.policy_id": "melix.default_privacy_policy.v1",
+        "melix.privacy.detector.policy_mode": "redact",
+        "melix.privacy.detector.action": "passed",
+        "melix.privacy.detector.categories": "",
+        "melix.privacy.detector.match_count": "0",
+        "melix.privacy.detector.redacted_span_count": "0",
+        "melix.privacy.detector.blocked_reason": "",
+        "melix.privacy.detector.confidence_source": "deterministic_pattern",
+        "melix.privacy.detector.raw_sensitive_span_count": "0",
+        "melix.privacy.detector.raw_text_included": "false",
+    }
+
+    assert privacy_detector_receipt_from_metadata(metadata) == {
+        "schema_version": "melix.privacy_detector_receipt.v1",
+        "surface": "local_proxy_text_request",
+        "route_scope": "chat_completions",
+        "detector_id": "melix.pattern_detector.v1",
+        "policy_id": "melix.default_privacy_policy.v1",
+        "policy_mode": "redact",
+        "action": "passed",
+        "categories": [],
+        "match_count": 0,
+        "redacted_span_count": 0,
+        "blocked_reason": "",
+        "confidence_source": "deterministic_pattern",
+        "raw_sensitive_span_count": 0,
+        "raw_text_included": False,
+    }


### PR DESCRIPTION
## Summary
- Adds an explicit `MELIX_PRIVACY_DETECTOR_MODE=redact|block` local proxy text detector before worker dispatch.
- Emits Swift `melix.privacy_detector_receipt.v1` metadata plus `melix.privacy_audit_counter.v1` counters without raw matched values or prompt snippets.
- Redacts quoted and unquoted secret assignments, including values that contain punctuation, and matches standalone Hugging Face tokens case-insensitively.
- Runs deterministic pattern scanning off the cooperative Swift executor and documents the opt-in local proxy behavior.
- Extends Python diagnostics receipt parsing coverage for clean local proxy passes.

## Plan or Spec
- Refs #2188
- Governing plan: `docs/plans/2026-07-05-issue-2188-local-proxy-privacy-detector.md`
- Updated runbook: `docs/runbooks/serving-diagnostics-evidence.md`

## Commands Run
```text
# Pre-implementation red check:
xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetectorRedactsTextRequestsWhenExplicitlyEnabled
# Failed as expected before implementation: worker text stayed raw and detector/audit metadata was nil.

xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetectorRedactsTextRequestsWhenExplicitlyEnabled
# Passed: 1 test.

xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetector
# Passed: 4 tests.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py -q
# 11 passed in 0.04s.

# Review red check for quoted assignment values:
xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetectorRedactsTextRequestsWhenExplicitlyEnabled
# Failed as expected: "my secret password" stayed in the worker text and match_count stayed 2 instead of 3.

xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetectorRedactsTextRequestsWhenExplicitlyEnabled
# Passed: 1 test.

xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetector
# Passed: 4 tests.

xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests
# 230 tests in 1 suite passed.

# Review red check for unquoted punctuation and uppercase standalone HF tokens:
xcrun swift test --package-path services/control-plane-swift --filter PrivacyPolicyReceiptsTests
# Failed as expected: unquoted assignment kept ",def;ghi" and uppercase HF_ token had match_count 0.

xcrun swift test --package-path services/control-plane-swift --filter PrivacyPolicyReceiptsTests
# Passed: 2 tests.

xcrun swift test --package-path services/control-plane-swift --filter OpenAIHandlerTests/localProxyPrivacyDetector
# Passed: 4 tests.

xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'PrivacyPolicyReceiptsTests|OpenAIHandlerTests/localProxyPrivacyDetector'
# 6 tests in 2 suites passed.

uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Sources/Requests/PrivacyPolicyReceipts.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIHandlerTests.swift services/control-plane-swift/Tests/ControlPlaneTests/PrivacyPolicyReceiptsTests.swift
# TOTAL 99.21% 505/509.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run --data-file=.runtime/coverage/issue2188_local_proxy_python.coverage -m pytest -q services/mlx-worker-python/tests/test_privacy_policy_receipts.py
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json --data-file=.runtime/coverage/issue2188_local_proxy_python.coverage -o .runtime/coverage/issue2188_local_proxy_python.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/changed_scope_coverage.py --coverage-json .runtime/coverage/issue2188_local_proxy_python.json services/mlx-worker-python/tests/test_privacy_policy_receipts.py
# TOTAL 3 0 100%.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_privacy_policy_receipts.py services/mlx-worker-python/tests/test_serving_diagnostics.py -q
# 67 passed in 0.06s.

git diff --check
# Passed.

git commit --amend --no-edit
# Pre-commit ran the full local gate:
# make swift-test: rc=0, elapsed=206.2s
# make py-test: rc=0, 4663 passed, 14 skipped, 2 warnings in 156.45s
# make integration-test: rc=0, 123 passed, 1 skipped in 446.41s
# Scoped performance report: Status ok, Regressions 0, Context regressions 0, Verification failures 0.
```

## Coverage and Metrics
- Swift changed-line coverage: `TOTAL 99.21% 505/509`.
- Python changed-scope coverage: `TOTAL 3 0 100%`.
- Latest pre-commit performance report: `.runtime/pre-commit-performance/20260704-203621-735fe4e8/report/report.md`.
- Latest amend pre-commit performance status: `ok`; changed files `2`; selected probes `0`; direct/gated probes `0`; regressions `0`; context regressions `0`; verification failures `0`.
- Observability mode: default `off`; opt-in runtime counters and request metadata when `MELIX_PRIVACY_DETECTOR_MODE` is `redact` or `block`.
- Probe overhead: bounded deterministic regex scans over request-local text parts plus small metadata dictionary writes; no network, model, filesystem, diagnostics bundle, or workspace document scans.

## Known Gaps
- No default-on privacy mutation.
- No protobuf schema changes or regenerated protocol artifacts.
- No workspace ingest integration, diagnostics bundle content scanning, model-backed NER detector, or operator UI controls in this slice.
- No user file mutation.
- `make bootstrap` was not rerun because hooks were already installed (`core.hooksPath=.githooks`); `make proto` was not rerun because no protobuf schema changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protobuf schema changed.
- [x] Dependency changes include updated lockfiles, or N/A because no dependency changed.
- [x] Relevant tests were run.
- [x] A metrics report is included, or N/A is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.