### PR TITLE
Add workspace ingest input guard

### DIFF
--- a/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
+++ b/docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md
@@ -63,6 +63,13 @@ The supported first-slice source kinds are:
 | `pdf` | Accept extracted text fixtures and a parser adapter boundary for optional real binary extraction. |
 | `docx` | Accept extracted text fixtures and a parser adapter boundary for optional real binary extraction. |
 
+Structured JSONL, JSON, CSV, and TSV rows with an explicit `text` field must
+provide a string value. Non-string explicit `text` values are rejected at the
+workspace ingest boundary with a typed operator failure before privacy
+detection, PII masking, deduplication, segmentation, or dataset versioning can
+stringify raw objects, arrays, numbers, booleans, or nulls into downstream
+artifacts.
+
 Every source record receives a stable `source_id`, `source_uri`, `source_kind`,
 `content_sha256`, `byte_size`, and optional `page`, `row_index`, `language`, or
 `section_path` metadata.
@@ -125,6 +132,7 @@ failure codes are:
 
 - `DATASET_INGEST_PRIVACY_DETECTOR_BLOCKED`
 - `DATASET_INGEST_UNSUPPORTED_SOURCE`
+- `DATASET_INGEST_UNSUPPORTED_TEXT_VALUE`
 - `DATASET_INGEST_PARSE_FAILED`
 - `DATASET_INGEST_EMPTY_SOURCE`
 - `DATASET_INGEST_PII_POLICY_INVALID`

--- a/docs/plans/2026-07-05-issue-2188-workspace-input-guard.md
+++ b/docs/plans/2026-07-05-issue-2188-workspace-input-guard.md
@@ -1,0 +1,358 @@
+# Issue 2188 Workspace Ingest Input Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden workspace ingest against non-string structured `text` values by rejecting them with typed, redacted operator failures before they reach cleaning, privacy detection, segmentation, or dataset version artifacts.
+
+**Architecture:** `worker.productization.dataset_preparation` remains the workspace ingest boundary. Structured source readers validate explicit `text` fields at row-construction time, emit a typed unsupported-input failure for non-string values, and skip those rows without stringifying raw objects, arrays, numbers, booleans, or nulls. The existing receipt and metrics pipeline carries the failure without introducing a new protobuf schema or a diagnostics content scan.
+
+**Tech Stack:** Python 3.12 worker productization code, pytest, existing dataset ingest receipt JSON contracts, existing Melix pre-commit and PR-scoped performance gates.
+
+---
+
+## Scope
+
+- Validate structured JSONL, JSON, CSV, and TSV rows that contain an explicit `text` field.
+- Accept string `text` values unchanged, including empty strings that are already handled by existing empty-source behavior where applicable.
+- Reject non-string explicit `text` values with `DATASET_INGEST_UNSUPPORTED_TEXT_VALUE`.
+- Keep raw row values, raw structured payloads, object reprs, and raw sensitive fragments out of operator failures, receipts, CLI JSON, and diagnostics-ready metadata.
+- Preserve the existing fallback behavior for structured rows without a `text` field: build text from sorted key/value summaries, because those rows are already non-explicit text records.
+- Preserve existing privacy detector `off`, `redact`, and `block` behavior for accepted records.
+
+## Non-Goals
+
+- No model-backed privacy detector.
+- No default-on policy change for privacy detection.
+- No local proxy or Swift route behavior change.
+- No protobuf schema change.
+- No diagnostics bundle content scanning.
+- No broad rewrite of structured CSV/JSON parsing.
+
+## Files
+
+- Modify `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+  - Add a small structured text extraction helper that can return a sanitized failure instead of coercing explicit non-string `text` values.
+  - Thread `operator_failures` and row identity into `_structured_records(...)`.
+  - Keep `_structured_text(...)` behavior for rows without explicit `text`.
+- Modify `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+  - Add focused tests for JSONL/JSON/CSV non-string explicit `text` rows.
+  - Assert sanitized failure payloads and absence of raw row fragments.
+  - Assert valid string rows still ingest, segment, and privacy-detect normally.
+- Modify `docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md`
+  - Add `DATASET_INGEST_UNSUPPORTED_TEXT_VALUE` to typed ingest failures.
+  - Describe explicit structured `text` field validation.
+- Modify this plan as implementation evidence when commands or metrics are finalized.
+
+## Task 1: Add Failing Structured Input Guard Tests
+
+**Files:**
+- Test: `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+
+- [x] **Step 1: Add JSONL coverage for non-string explicit `text` values**
+
+Add the JSONL guard scenario to the existing
+`test_dataset_ingest_privacy_detector_redacts_source_records_before_segments`
+nodeid so the registered dataset preparation PR-scoped probes include the new
+behavior in their targeted coverage command. The scenario includes one accepted
+string row and two rejected rows with dict/list `text` values, and asserts the
+receipt omits the raw secret, email, and Python repr fragments.
+
+- [x] **Step 2: Add JSON array coverage for mixed valid and invalid rows**
+
+In the same selected nodeid, add a JSON array source with one valid string
+`text` row, one rejected dict `text` row, and one fallback row without explicit
+`text`. Assert that the fallback row still segments as derived structured text
+and that the invalid dict value is represented only by sanitized failure
+metadata.
+
+- [x] **Step 3: Add CSV coverage for a missing `text` cell**
+
+In the same selected nodeid, add a CSV source with a `text` header and a row
+that omits the cell. Assert the row is rejected as
+`DATASET_INGEST_UNSUPPORTED_TEXT_VALUE` with `value_type: NoneType`, while the
+valid CSV row still produces a segment.
+
+- [x] **Step 4: Run RED tests before implementation**
+
+Initial standalone RED tests for the JSONL and JSON scenarios failed with
+`status == "ready"` instead of `blocked`, proving `_structured_text(...)` was
+still stringifying explicit non-string `text` values. After the implementation
+and pre-commit targeted coverage diagnosis, the scenarios were folded into the
+existing selected privacy detector nodeid described above.
+
+## Task 2: Implement The Guard
+
+**Files:**
+- Modify: `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+
+- [x] **Step 1: Thread operator failures into structured record parsing**
+
+Change the structured-data branch in `_iter_source_records(...)` from:
+
+```python
+if source_kind == "structured_data":
+    yield from _structured_records(path, text)
+else:
+```
+
+to:
+
+```python
+if source_kind == "structured_data":
+    yield from _structured_records(path, text, operator_failures)
+else:
+```
+
+- [x] **Step 2: Update `_structured_records(...)` to skip invalid explicit text**
+
+Replace the current `_structured_records(...)` implementation with:
+
+```python
+def _structured_records(
+    path: Path,
+    text: str,
+    operator_failures: list[dict[str, Any]],
+) -> Iterable[dict[str, Any]]:
+    suffix = path.suffix.lower()
+    if suffix == ".jsonl":
+        for index, line in enumerate(text.splitlines(), start=1):
+            if not line or line.isspace():
+                continue
+            payload = json.loads(line)
+            row_text = _structured_text_or_failure(path, payload, index, operator_failures)
+            if row_text is None:
+                continue
+            yield _record(
+                path=path,
+                source_kind="structured_data",
+                text=row_text,
+                metadata={"row_index": index},
+            )
+        return
+    if suffix == ".json":
+        payload = json.loads(text)
+        rows = payload if isinstance(payload, list) else [payload]
+        for index, row in enumerate(rows, start=1):
+            row_text = _structured_text_or_failure(path, row, index, operator_failures)
+            if row_text is None:
+                continue
+            yield _record(
+                path=path,
+                source_kind="structured_data",
+                text=row_text,
+                metadata={"row_index": index},
+            )
+        return
+    dialect = "excel-tab" if suffix == ".tsv" else "excel"
+    reader = csv.DictReader(text.splitlines(), dialect=dialect)
+    for index, row in enumerate(reader, start=1):
+        row_text = _structured_text_or_failure(path, row, index, operator_failures)
+        if row_text is None:
+            continue
+        yield _record(
+            path=path,
+            source_kind="structured_data",
+            text=row_text,
+            metadata={"row_index": index},
+        )
+```
+
+- [x] **Step 3: Add a sanitized helper and failure builder**
+
+Add these helpers near `_structured_text(...)`:
+
+```python
+def _structured_text_or_failure(
+    path: Path,
+    payload: Any,
+    row_index: int,
+    operator_failures: list[dict[str, Any]],
+) -> str | None:
+    if isinstance(payload, dict) and "text" in payload and not isinstance(payload["text"], str):
+        operator_failures.append(
+            _unsupported_structured_text_failure(
+                path=path,
+                row_index=row_index,
+                value=payload["text"],
+            )
+        )
+        return None
+    return _structured_text(payload)
+
+
+def _unsupported_structured_text_failure(
+    *,
+    path: Path,
+    row_index: int,
+    value: Any,
+) -> dict[str, Any]:
+    value_type = type(value).__name__
+    return {
+        "id": _failure_id("unsupported-text-value", f"{path.name}-{row_index}"),
+        "code": "DATASET_INGEST_UNSUPPORTED_TEXT_VALUE",
+        "path": path.name,
+        "detail": (
+            "Structured source rows with an explicit text field must provide a string "
+            f"value; row {row_index} provided {value_type}."
+        ),
+        "recovery_hint": (
+            "Convert the row text field to a string or remove it so Melix can derive "
+            "structured fallback text from non-sensitive fields."
+        ),
+        "reason": "unsupported_text_value",
+        "metadata": {
+            "source_uri": path.name,
+            "row_index": row_index,
+            "value_type": value_type,
+        },
+    }
+```
+
+- [x] **Step 4: Preserve existing fallback behavior**
+
+Keep `_structured_text(...)` as:
+
+```python
+def _structured_text(payload: Any) -> str:
+    if isinstance(payload, dict):
+        if "text" in payload:
+            return str(payload["text"])
+        return " ".join(f"{key}: {value}" for key, value in sorted(payload.items()))
+    return str(payload)
+```
+
+This is now only reached for explicit `text` strings, dicts without `text`, and non-dict rows.
+
+- [x] **Step 5: Run the focused tests**
+
+Run the command from Task 1 Step 4 again.
+
+Expected: both tests pass.
+
+## Task 3: Update The Canonical Dataset Plan
+
+**Files:**
+- Modify: `docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md`
+
+- [x] **Step 1: Document explicit structured text validation**
+
+In `U1.2.1 Ingest And Cleaning Controls`, add this paragraph after the supported source kinds table:
+
+```markdown
+Structured JSONL, JSON, CSV, and TSV rows with an explicit `text` field must
+provide a string value. Non-string explicit `text` values are rejected at the
+workspace ingest boundary with a typed operator failure before privacy
+detection, PII masking, deduplication, segmentation, or dataset versioning can
+stringify raw objects, arrays, numbers, booleans, or nulls into downstream
+artifacts.
+```
+
+- [x] **Step 2: Add the failure code**
+
+Add this item to the required operator failure code list:
+
+```markdown
+- `DATASET_INGEST_UNSUPPORTED_TEXT_VALUE`
+```
+
+## Task 4: Verification And Metrics
+
+**Files:**
+- Modify: `docs/plans/2026-07-05-issue-2188-workspace-input-guard.md`
+
+- [x] **Step 1: Run focused test coverage for changed Python scope**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+UV_PYTHON=3.12 \
+uv run --project services/mlx-worker-python --extra mlx pytest -q \
+  services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+```
+
+Expected: all dataset preparation ingest tests pass.
+
+- [x] **Step 2: Run changed-line coverage for the touched Python scope**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+UV_PYTHON=3.12 \
+uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+UV_PYTHON=3.12 \
+uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py \
+  --coverage-json coverage.json \
+  services/mlx-worker-python/worker/productization/dataset_preparation.py \
+  services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+```
+
+Expected: touched scope reports at least 95 percent measured coverage.
+
+- [x] **Step 3: Run syntax and whitespace checks**
+
+Run:
+
+```bash
+python3 -m py_compile \
+  services/mlx-worker-python/worker/productization/dataset_preparation.py \
+  services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+git diff --check
+```
+
+Expected: both commands exit successfully.
+
+- [x] **Step 4: Run the repository pre-commit gate before committing**
+
+Run:
+
+```bash
+.githooks/pre-commit
+```
+
+Expected:
+
+- `make swift-test` passes.
+- `make py-test` passes.
+- `make integration-test` passes.
+- The scoped performance report has `Status: ok`, `Regressions: 0`, and `Verification failures: 0`; any context regressions are reviewed and documented as out of scope before proceeding.
+
+- [x] **Step 5: Record final evidence in this plan**
+
+Append the exact local verification results and scoped performance report path to a `## Verification Results` section in this document before opening the pull request.
+
+## PR And Issue Evidence
+
+- PR body must use `.github/pull_request_template.md` headings exactly.
+- `## Plan or Spec` must point to this plan and the dataset preparation quality/versioning plan.
+- `## Commands Run` must include focused tests, changed-scope coverage, `git diff --check`, pre-commit gate, and any reruns.
+- `## Coverage and Metrics` must include measured coverage and scoped performance report status.
+- After merge, comment on #2188 with the required AI triage prefix and keep the umbrella issue open unless all remaining privacy-policy surfaces are complete.
+
+## Self-Review
+
+- Spec coverage: this plan covers the non-string workspace text input guard, typed failure, redacted receipt behavior, tests, docs, and verification.
+- Placeholder scan: no placeholder tasks are present; each implementation step names exact files, commands, and expected outcomes.
+- Type consistency: helper signatures use existing `Path`, `Any`, and `operator_failures` conventions from `dataset_preparation.py`.
+
+## Verification Results
+
+- Initial RED run for the standalone JSONL and JSON guard tests: both failed as expected with `status == "ready"` instead of `blocked`.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_privacy_detector_redacts_source_records_before_segments`: `1 passed in 0.08s`.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`: `23 passed in 0.13s`.
+- Pre-commit snapshot coverage rerun for `dataset-version-listing-scandir`, `dataset-quality-lengths-chain`, and `dataset-source-records-scandir`: all three registered `coverage_command` values passed with `TOTAL 58 0 100%`; `dataset_preparation.py` changed-line coverage `100.00%`; `test_dataset_preparation_ingest.py` changed-line coverage `100.00%`.
+- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`: passed.
+- `git diff --check`: passed.
+- `git diff --cached --check`: passed.
+- First `.githooks/pre-commit` attempt before folding the guard scenarios into a selected PR-scoped nodeid: `make swift-test` passed, `make py-test` passed (`4681 passed, 14 skipped, 2 warnings`), `make integration-test` passed (`123 passed, 1 skipped`), and the scoped performance report failed with `Status: verification_failed`, `Regressions: 0`, `Verification failures: 3` because the probe targeted coverage commands did not execute the newly added standalone guard tests. The tests were then folded into the existing selected privacy detector nodeid and snapshot coverage was rerun as recorded above.
+- Final `.githooks/pre-commit` before committing:
+  - `make swift-test`: passed, elapsed `154.7s`.
+  - `make py-test`: passed, `4678 passed, 14 skipped, 2 warnings in 158.88s`.
+  - `make integration-test`: passed, `123 passed, 1 skipped in 418.74s`.
+  - Scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-2188-workspace-input-guard-20260705/.runtime/pre-commit-performance/20260705-063848-0df2921f/report/report.md`.
+  - Performance status: `Status: ok`, `Changed files: 4`, `Selected probes: 3`, `Direct/gated probes: 3`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
+  - Probe coverage: `dataset-version-listing-scandir`, `dataset-quality-lengths-chain`, and `dataset-source-records-scandir` all had targeted tests pass and coverage pass at `100.0%`.

--- a/docs/plans/2026-07-05-issue-2188-workspace-input-guard.md
+++ b/docs/plans/2026-07-05-issue-2188-workspace-input-guard.md
@@ -17,6 +17,9 @@
 - Reject non-string explicit `text` values with `DATASET_INGEST_UNSUPPORTED_TEXT_VALUE`.
 - Keep raw row values, raw structured payloads, object reprs, and raw sensitive fragments out of operator failures, receipts, CLI JSON, and diagnostics-ready metadata.
 - Preserve the existing fallback behavior for structured rows without a `text` field: build text from sorted key/value summaries, because those rows are already non-explicit text records.
+- Preserve RFC-style quoted newlines in CSV and TSV fields by passing the full
+  source text into `csv.DictReader` instead of splitting physical lines before
+  parsing.
 - Preserve existing privacy detector `off`, `redact`, and `block` behavior for accepted records.
 
 ## Non-Goals
@@ -356,3 +359,7 @@ Append the exact local verification results and scoped performance report path t
   - Scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-2188-workspace-input-guard-20260705/.runtime/pre-commit-performance/20260705-063848-0df2921f/report/report.md`.
   - Performance status: `Status: ok`, `Changed files: 4`, `Selected probes: 3`, `Direct/gated probes: 3`, `Regressions: 0`, `Context regressions: 0`, `Verification failures: 0`.
   - Probe coverage: `dataset-version-listing-scandir`, `dataset-quality-lengths-chain`, and `dataset-source-records-scandir` all had targeted tests pass and coverage pass at `100.0%`.
+- Review follow-up for CSV/TSV quoted newlines:
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_privacy_detector_redacts_source_records_before_segments`: `1 passed in 0.08s`.
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`: passed.
+  - `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`: `23 passed in 0.13s`.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -592,7 +592,8 @@ def test_dataset_ingest_privacy_detector_redacts_source_records_before_segments(
     csv_root.mkdir()
     (csv_root / "rows.csv").write_text(
         "id,text\n"
-        "row-1,first csv row\n"
+        'row-1,"first csv row\n'
+        'second csv line"\n'
         "row-2\n",
         encoding="utf-8",
     )
@@ -626,7 +627,7 @@ def test_dataset_ingest_privacy_detector_redacts_source_records_before_segments(
             encoding="utf-8"
         ).splitlines()
     ]
-    assert [segment["text"] for segment in csv_segments] == ["first csv row"]
+    assert [segment["text"] for segment in csv_segments] == ["first csv row\nsecond csv line"]
 
 
 def test_dataset_ingest_privacy_detector_block_mode_stops_before_segments(

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -497,6 +497,137 @@ def test_dataset_ingest_privacy_detector_redacts_source_records_before_segments(
     for raw_fragment in ("OPENAI_API_KEY", "sk-workspace-secret", "HF_ABCDEF123456"):
         assert raw_fragment not in payload
 
+    structured_root = tmp_path / "structured-text-guard-inputs"
+    structured_output = tmp_path / "prepared-structured-text-guard"
+    structured_root.mkdir()
+    (structured_root / "rows.jsonl").write_text(
+        '{"id":"row-1","text":"safe workspace note"}\n'
+        '{"id":"row-2","text":{"secret":"sk-raw-object-secret"}}\n'
+        '{"id":"row-3","text":["alice@example.com"]}\n',
+        encoding="utf-8",
+    )
+
+    structured_receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=structured_root,
+            output_dir=structured_output,
+            dataset_preparation_id="prep-structured-text-guard",
+            privacy_detector_mode="redact",
+        )
+    )
+
+    assert structured_receipt["status"] == "blocked"
+    failures = [
+        failure
+        for failure in structured_receipt["operator_failures"]
+        if failure["code"] == "DATASET_INGEST_UNSUPPORTED_TEXT_VALUE"
+    ]
+    assert [failure["metadata"]["row_index"] for failure in failures] == [2, 3]
+    assert {failure["metadata"]["value_type"] for failure in failures} == {"dict", "list"}
+    assert structured_receipt["quality_control_summary"]["source_record_count"] == 1
+    assert structured_receipt["quality_control_summary"]["segment_count"] == 1
+
+    structured_payload = json.dumps(structured_receipt, sort_keys=True)
+    assert "sk-raw-object-secret" not in structured_payload
+    assert "alice@example.com" not in structured_payload
+    assert "{'secret'" not in structured_payload
+    assert "[\"alice@example.com\"]" not in structured_payload
+
+    json_array_root = tmp_path / "structured-json-array-inputs"
+    json_array_output = tmp_path / "prepared-json-array-text-guard"
+    json_array_root.mkdir()
+    (json_array_root / "array.json").write_text(
+        json.dumps(
+            [
+                {"text": "first string row"},
+                {"text": {"secret": "sk-json-array-object-secret"}},
+                {"title": "fallback row", "body": "still supported"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    json_array_receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=json_array_root,
+            output_dir=json_array_output,
+            dataset_preparation_id="prep-json-array-text-guard",
+        )
+    )
+
+    assert json_array_receipt["status"] == "blocked"
+    assert json_array_receipt["quality_control_summary"]["source_record_count"] == 2
+    assert json_array_receipt["quality_control_summary"]["segment_count"] == 2
+    assert any(
+        failure["code"] == "DATASET_INGEST_UNSUPPORTED_TEXT_VALUE"
+        and failure["metadata"] == {
+            "source_uri": "array.json",
+            "row_index": 2,
+            "value_type": "dict",
+        }
+        for failure in json_array_receipt["operator_failures"]
+    )
+
+    json_array_segments = [
+        json.loads(line)
+        for line in Path(json_array_receipt["segment_artifacts"]["segments_path"]).read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert [segment["text"] for segment in json_array_segments] == [
+        "first string row",
+        "body: still supported title: fallback row",
+    ]
+    assert "sk-json-array-object-secret" not in json.dumps(
+        json_array_receipt,
+        sort_keys=True,
+    )
+
+    csv_root = tmp_path / "structured-csv-inputs"
+    csv_output = tmp_path / "prepared-csv-text-guard"
+    csv_root.mkdir()
+    (csv_root / "rows.csv").write_text(
+        "id,text\n"
+        "row-1,first csv row\n"
+        "row-2\n",
+        encoding="utf-8",
+    )
+
+    csv_receipt = prepare_dataset_ingest(
+        DatasetIngestRequest(
+            workspace_project_id="m-courtyard-demo",
+            workspace_manifest_path=_write_ready_workspace_manifest(tmp_path),
+            input_path=csv_root,
+            output_dir=csv_output,
+            dataset_preparation_id="prep-csv-text-guard",
+        )
+    )
+
+    assert csv_receipt["status"] == "blocked"
+    assert csv_receipt["quality_control_summary"]["source_record_count"] == 1
+    assert csv_receipt["quality_control_summary"]["segment_count"] == 1
+    assert any(
+        failure["code"] == "DATASET_INGEST_UNSUPPORTED_TEXT_VALUE"
+        and failure["metadata"] == {
+            "source_uri": "rows.csv",
+            "row_index": 2,
+            "value_type": "NoneType",
+        }
+        for failure in csv_receipt["operator_failures"]
+    )
+
+    csv_segments = [
+        json.loads(line)
+        for line in Path(csv_receipt["segment_artifacts"]["segments_path"]).read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ]
+    assert [segment["text"] for segment in csv_segments] == ["first csv row"]
+
 
 def test_dataset_ingest_privacy_detector_block_mode_stops_before_segments(
     tmp_path: Path,

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 import csv
 from datetime import datetime, timezone
 import hashlib
+import io
 import json
 import os
 import re
@@ -1320,7 +1321,7 @@ def _structured_records(
             )
         return
     dialect = "excel-tab" if suffix == ".tsv" else "excel"
-    reader = csv.DictReader(text.splitlines(), dialect=dialect)
+    reader = csv.DictReader(io.StringIO(text), dialect=dialect)
     for index, row in enumerate(reader, start=1):
         row_text = _structured_text_or_failure(path, row, index, operator_failures)
         if row_text is None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1102,7 +1102,7 @@ def _iter_source_records(
             )
             continue
         if source_kind == "structured_data":
-            yield from _structured_records(path, text)
+            yield from _structured_records(path, text, operator_failures)
         else:
             normalized_text = _normalize_line_endings(text)
             yield _record(
@@ -1284,17 +1284,24 @@ def _segmentation_policy(request: DatasetIngestRequest) -> dict[str, Any]:
     }
 
 
-def _structured_records(path: Path, text: str) -> Iterable[dict[str, Any]]:
+def _structured_records(
+    path: Path,
+    text: str,
+    operator_failures: list[dict[str, Any]],
+) -> Iterable[dict[str, Any]]:
     suffix = path.suffix.lower()
     if suffix == ".jsonl":
         for index, line in enumerate(text.splitlines(), start=1):
             if not line or line.isspace():
                 continue
             payload = json.loads(line)
+            row_text = _structured_text_or_failure(path, payload, index, operator_failures)
+            if row_text is None:
+                continue
             yield _record(
                 path=path,
                 source_kind="structured_data",
-                text=_structured_text(payload),
+                text=row_text,
                 metadata={"row_index": index},
             )
         return
@@ -1302,22 +1309,74 @@ def _structured_records(path: Path, text: str) -> Iterable[dict[str, Any]]:
         payload = json.loads(text)
         rows = payload if isinstance(payload, list) else [payload]
         for index, row in enumerate(rows, start=1):
+            row_text = _structured_text_or_failure(path, row, index, operator_failures)
+            if row_text is None:
+                continue
             yield _record(
                 path=path,
                 source_kind="structured_data",
-                text=_structured_text(row),
+                text=row_text,
                 metadata={"row_index": index},
             )
         return
     dialect = "excel-tab" if suffix == ".tsv" else "excel"
     reader = csv.DictReader(text.splitlines(), dialect=dialect)
     for index, row in enumerate(reader, start=1):
+        row_text = _structured_text_or_failure(path, row, index, operator_failures)
+        if row_text is None:
+            continue
         yield _record(
             path=path,
             source_kind="structured_data",
-            text=_structured_text(row),
+            text=row_text,
             metadata={"row_index": index},
         )
+
+
+def _structured_text_or_failure(
+    path: Path,
+    payload: Any,
+    row_index: int,
+    operator_failures: list[dict[str, Any]],
+) -> str | None:
+    if isinstance(payload, dict) and "text" in payload and not isinstance(payload["text"], str):
+        operator_failures.append(
+            _unsupported_structured_text_failure(
+                path=path,
+                row_index=row_index,
+                value=payload["text"],
+            )
+        )
+        return None
+    return _structured_text(payload)
+
+
+def _unsupported_structured_text_failure(
+    *,
+    path: Path,
+    row_index: int,
+    value: Any,
+) -> dict[str, Any]:
+    value_type = type(value).__name__
+    return {
+        "id": _failure_id("unsupported-text-value", f"{path.name}-{row_index}"),
+        "code": "DATASET_INGEST_UNSUPPORTED_TEXT_VALUE",
+        "path": path.name,
+        "detail": (
+            "Structured source rows with an explicit text field must provide a string "
+            f"value; row {row_index} provided {value_type}."
+        ),
+        "recovery_hint": (
+            "Convert the row text field to a string or remove it so Melix can derive "
+            "structured fallback text from non-sensitive fields."
+        ),
+        "reason": "unsupported_text_value",
+        "metadata": {
+            "source_uri": path.name,
+            "row_index": row_index,
+            "value_type": value_type,
+        },
+    }
 
 
 def _structured_text(payload: Any) -> str:


### PR DESCRIPTION
## Summary
- Reject structured JSONL/JSON/CSV/TSV rows that provide an explicit non-string `text` field before privacy detection, segmentation, or dataset versioning can stringify raw values.
- Emit sanitized `DATASET_INGEST_UNSUPPORTED_TEXT_VALUE` operator failures with row/type metadata only, while preserving existing fallback behavior for rows without explicit `text`.
- Preserve RFC-style quoted newlines in CSV/TSV `text` fields by passing the full source text to `csv.DictReader` through `io.StringIO`.
- Update the dataset preparation plan and add a focused issue plan for this #2188 slice.

## Plan or Spec
- `docs/plans/2026-07-05-issue-2188-workspace-input-guard.md`
- `docs/plans/2026-05-24-dataset-preparation-quality-and-versioning.md`
- Part of #2188.

## Commands Run
```text
# RED before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_rejects_non_string_structured_text_without_raw_value services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_json_array_keeps_string_text_rows_when_others_are_invalid
# result: 2 failed as expected; status was ready instead of blocked.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_privacy_detector_redacts_source_records_before_segments
# result: 1 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
# result: 23 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
# result: passed

git diff --check
# result: passed

git diff --cached --check
# result: passed

.githooks/pre-commit
# result before first commit: make swift-test passed; make py-test passed, 4678 passed, 14 skipped, 2 warnings in 158.88s; make integration-test passed, 123 passed, 1 skipped in 418.74s; scoped performance Status: ok, Regressions: 0, Verification failures: 0.

git commit -m "Add workspace ingest input guard"
# result: commit hook passed; make swift-test elapsed 592.6s; make py-test passed, 4678 passed, 14 skipped, 2 warnings in 156.76s; make integration-test passed, 123 passed, 1 skipped in 750.03s; scoped performance Status: ok, Regressions: 0, Verification failures: 0.

# Review follow-up for quoted CSV newlines
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_privacy_detector_redacts_source_records_before_segments
# result: 1 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python -m py_compile services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
# result: passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
# result: 23 passed in 0.13s

git diff --cached --check
# result: passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts import pre_commit_gate
root = Path.cwd()
base_ref = pre_commit_gate.pre_commit_base_ref(root)
changed = pre_commit_gate.staged_changed_files(root, base_ref=base_ref)
outcome = pre_commit_gate.run_performance_report(root, changed, base_ref=base_ref)
print(f"OUTCOME status={outcome.status} report_dir={outcome.report_dir} selected={outcome.selected_probe_count}")
PY
# result: Status: ok, Regressions: 0, Verification failures: 0; report 20260705-072935-b4bbbf7e.

git commit -m "Preserve quoted CSV text rows"
# result: commit hook passed; make swift-test elapsed 183.6s; make py-test passed, 4678 passed, 14 skipped, 2 warnings in 157.53s; make integration-test passed, 123 passed, 1 skipped in 415.03s; scoped performance Status: ok, Regressions: 0, Verification failures: 0.
```

## Coverage and Metrics
- First guard commit changed-line coverage from registered PR-scoped dataset probes: `TOTAL 58 0 100%`.
- Review follow-up changed-line coverage from registered PR-scoped dataset probes: `TOTAL 3 0 100%`.
- `dataset-version-listing-scandir`: targeted tests pass, coverage pass `100.0%`; metrics neutral, no regressions.
- `dataset-quality-lengths-chain`: targeted tests pass, coverage pass `100.0%`; metrics neutral, no regressions.
- `dataset-source-records-scandir`: targeted tests pass, coverage pass `100.0%`; metrics neutral, no regressions.
- First commit hook scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-2188-workspace-input-guard-20260705/.runtime/pre-commit-performance/20260705-070451-0df2921f/report/report.md`.
- Review follow-up direct performance rerun report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-2188-workspace-input-guard-20260705/.runtime/pre-commit-performance/20260705-072935-b4bbbf7e/report/report.md`.
- Review follow-up commit hook scoped performance report: `/Users/chenyu/Documents/github/melix/.runtime/worktrees/issue-2188-workspace-input-guard-20260705/.runtime/pre-commit-performance/20260705-074245-b4bbbf7e/report/report.md`.
- A first review-follow-up commit attempt produced a local scoped performance regression in unrelated `_quality_summary` and `_record` microbench metrics; the direct rerun and final commit hook both reported `Status: ok`, so this was treated as transient probe noise, not an accepted regression.
- Observability mode: `minimal`, existing operator failure receipts only; probe overhead: N/A, no new runtime/evidence/debug probe added.

## Known Gaps
- None for this slice. #2188 remains open for the remaining privacy-policy receipt surfaces.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
