### PR TITLE
perf: countdown runtime diagnostic code matches

### DIFF
--- a/docs/plans/2026-07-05-runtime-export-diagnostic-known-countdown.md
+++ b/docs/plans/2026-07-05-runtime-export-diagnostic-known-countdown.md
@@ -1,0 +1,36 @@
+# Runtime export diagnostic known-code countdown
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.export_target_diagnostics._diagnoses_from_excerpt`.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe
+`runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for the diagnostic parser, diagnostics tests, and probe
+script.
+
+## Optimization
+
+The diagnosis scan already stops once every known diagnosis code has matched.
+This slice replaces the per-line `len(seen_codes)` check with a small remaining
+known-code countdown that is decremented only when a new code is admitted. The
+behavior stays equivalent because `seen_codes` still guards duplicates and the
+counter only reaches zero after every known code has been inserted.
+
+## Verification plan
+
+Run the registered focused tests, changed-scope coverage, and the registered
+probe locally on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/runtime_export_diagnostic_parser_probe.json
+```
+
+GitHub Actions PR-scoped performance remains the final merge gate for the
+registered probe.

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -806,9 +806,9 @@ def _diagnoses_from_excerpt(
     patterns = _DIAGNOSIS_PATTERNS
     source_lines_local = source_lines
     has_diagnosis_marker = _has_diagnosis_marker
-    known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
+    remaining_known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
     for index, line_number in line_numbers.items():
-        if len(seen_codes) == known_code_count:
+        if remaining_known_code_count == 0:
             break
         text = source_lines_local[index].text
         lowered_text = text.lower()
@@ -833,6 +833,7 @@ def _diagnoses_from_excerpt(
             if not expression_matched:
                 continue
             seen_codes_add(pattern_code)
+            remaining_known_code_count -= 1
             diagnoses_append(
                 {
                     "code": pattern_code,


### PR DESCRIPTION
## Summary
- Replace the runtime export diagnostic parser's per-line `len(seen_codes)` completion check with a remaining known-code countdown.
- Keep duplicate-code guarding unchanged while avoiding repeated set length reads in the hot diagnosis scan.

## Plan or Spec
- `docs/plans/2026-07-05-runtime-export-diagnostic-known-countdown.md`
- Registered probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (includes focused test, coverage, and probe commands).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 79 passed in 1.66s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 79 passed in 1.37s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-export-diagnostic-known-countdown-20260705 --head-repo "$PWD" --output /tmp/runtime_export_diagnostic_parser_probe.json
# completed rc=0; registered probe base/head comparison emitted metrics below

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Registered probe `runtime-export-diagnostic-parser` local Linux metrics:
  - `diagnosis_matching_elapsed_ms_mean`: base `0.5775248000645661`, head `0.560054200104787` ms (targeted scan metric improved by ~3.02%).
  - `diagnostic_latency_ms`: base `7.514136000281724`, head `7.205842998700973` ms (improved by ~4.10%).
  - `path_redaction_elapsed_ms_mean`: base `17.217608999817458`, head `16.978899000059755` ms (improved by ~1.39%).
  - `elapsed_ms_mean`: base `2606.62575380029`, head `2619.2786736000926` ms (0.49% slower; below the 5% warning threshold and dominated by fixture materialization outside this slice).
  - `peak_bytes_mean`: base `198896.8`, head `202412.0` bytes (1.77% higher; below the 5% warning threshold).
- CI PR-scoped performance is required as the final registered probe validation source.

## Known Gaps
- Local validation is Linux-only; no Swift runtime effect is claimed for this Python-only slice.
- The aggregate fixture-materialization metric is noisy and not the targeted hot loop for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
