### PR TITLE
perf: skip empty hub cardData size-hint lookup

### DIFF
--- a/docs/plans/2026-07-05-hub-size-hint-empty-carddata.md
+++ b/docs/plans/2026-07-05-hub-size-hint-empty-carddata.md
@@ -1,0 +1,28 @@
+# Hub catalog empty cardData size-hint fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._size_hint_bytes()`.
+It preserves Hub model size-hint behavior while avoiding the `cardData.description` lookup when
+`cardData` is empty and no direct `cardData.model_size` hint exists.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries and watches the Hub catalog module, focused tests, and
+`scripts/hub_catalog_size_hint_probe.py`.
+
+## Verification Plan
+
+- Run the registered focused Hub catalog and PR-scoped performance tests locally on Linux.
+- Run changed-scope coverage for the affected module/test/probe paths and require at least 95% coverage.
+- Run the registered probe locally on Linux against `origin/main` and this branch via
+  `scripts/pr_scoped_performance_run.py`.
+- Use GitHub Actions PR-scoped performance as the merge gate after opening the PR.
+
+## Acceptance
+
+Accept the slice only if the focused tests and changed-scope coverage pass and the registered probe
+shows a non-regressing or improved `elapsed_ms_mean` for the Hub size-hint workload.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -424,6 +424,44 @@ def test_size_hint_single_readme_falls_back_to_regex_when_direct_parse_misses(
     parser.assert_called_once_with("Model size:", allow_bare=False)
 
 
+def test_size_hint_empty_card_data_skips_card_description_lookup() -> None:
+    class EmptyCardData(dict):
+        def get(self, key: str, default: object = None) -> object:
+            if key == "description":  # pragma: no cover - regression sentinel
+                raise AssertionError("empty cardData should not probe description")
+            return super().get(key, default)
+
+    assert hub_catalog_module._size_hint_bytes({"cardData": EmptyCardData()}) == 0
+
+
+def test_size_hint_empty_card_data_scans_description_and_readme_without_card_lookup() -> None:
+    class EmptyCardData(dict):
+        def get(self, key: str, default: object = None) -> object:
+            if key == "description":  # pragma: no cover - regression sentinel
+                raise AssertionError("empty cardData should not probe description")
+            return super().get(key, default)
+
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {
+                "cardData": EmptyCardData(),
+                "description": "metadata without size",
+                "readme": "README\nModel size: 9 MB",
+            }
+        )
+        == 9 * MB
+    )
+
+
+def test_size_hint_nonempty_card_data_uses_single_readme_fast_path() -> None:
+    assert (
+        hub_catalog_module._size_hint_bytes(
+            {"cardData": {"license": "mit"}, "readme": "README\nModel size: 4 MB"}
+        )
+        == 4 * MB
+    )
+
+
 def test_direct_size_hint_rejects_extra_tokens_without_full_split() -> None:
     assert _direct_size_hint_from_text("12 GB extra") == 0
     assert _direct_size_hint_from_text("12") == 0

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -837,14 +837,21 @@ def _size_hint_bytes(payload: dict[str, Any], *, card_data: dict[str, Any] | Non
     description_text = raw_description_text if isinstance(raw_description_text, str) else ""
     raw_readme_text = payload.get("readme")
     readme_text = raw_readme_text if isinstance(raw_readme_text, str) else ""
-    raw_card_description_text = card_data.get("description")
-    card_description_text = raw_card_description_text if isinstance(raw_card_description_text, str) else ""
-    if not readme_text and not card_description_text:
-        return _size_hint_from_marked_text(description_text) if description_text else 0
-    if not description_text and not card_description_text:
-        return _size_hint_from_marked_text(readme_text) if readme_text else 0
-    if not description_text and not readme_text:
-        return _size_hint_from_marked_text(card_description_text) if card_description_text else 0
+    if not card_data:
+        if not readme_text:
+            return _size_hint_from_marked_text(description_text) if description_text else 0
+        if not description_text:
+            return _size_hint_from_marked_text(readme_text) if readme_text else 0
+        card_description_text = ""
+    else:
+        raw_card_description_text = card_data.get("description")
+        card_description_text = raw_card_description_text if isinstance(raw_card_description_text, str) else ""
+        if not readme_text and not card_description_text:
+            return _size_hint_from_marked_text(description_text) if description_text else 0
+        if not description_text and not card_description_text:
+            return _size_hint_from_marked_text(readme_text) if readme_text else 0
+        if not description_text and not readme_text:
+            return _size_hint_from_marked_text(card_description_text) if card_description_text else 0
 
     found_model_marker = False
     for text in (description_text, readme_text, card_description_text):


### PR DESCRIPTION
## Summary
- Skip the `cardData.description` lookup in Hub size-hint parsing when `cardData` is empty after the direct `model_size` check.
- Add focused regression tests for empty-cardData and non-empty-cardData size-hint branches.

## Plan or Spec
- `docs/plans/2026-07-05-hub-size-hint-empty-carddata.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 93 passed in 0.43s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 93 passed in 0.49s; TOTAL 26 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub_size_hint_pr_probe_1783253539.json
# head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Local registered probe (`hub-catalog-size-hint-regex-precompile`, lower is better):
  - `elapsed_ms_mean`: base `1716.4261805999558` ms, head `1707.7625499998248` ms, delta `-8.663630600131` ms (`~0.50%` faster).
  - `size_hint_calls_mean`: base `0.0`, head `0.0`.
  - `payload_compatibility_elapsed_ms_mean`: base `189.455856800123` ms, head `190.8757595996576` ms (`~0.75%` slower, adjacent compatibility loop unchanged and within probe noise / 5% warning threshold).
- GitHub Actions PR-scoped performance is the merge gate for CI validation.

## Known Gaps
- Local validation was Linux-only. No Swift runtime effect is claimed for this Python slice.
- The elapsed improvement is intentionally small because the slice only removes one empty-cardData dictionary lookup from the hot size-hint path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A; no observability change.
- [x] Deferred work and known gaps are stated explicitly.
