### PR TITLE
perf: use set intersection for dense changed-scope filters

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md
+++ b/docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md
@@ -8,6 +8,15 @@ Reduce hot-loop prefix checks in `scripts/changed_scope_coverage.py` by dispatch
 
 This slice is Python-only and limited to the changed-scope coverage diff parser path. It keeps parser output identical while reducing repeated `str.startswith(...)` work for ordinary context, deletion, addition, hunk, and file-marker lines.
 
+## 2026-07 dense measured-line intersection slice
+
+This follow-up slice is limited to the dense changed-line filter in
+`scripts/changed_scope_coverage.py`. When the changed line set is large enough
+to scan measured coverage lines instead of bisecting every changed line, the
+implementation can use C-level `set.intersection(...)` against the executed and
+missing line lists. The fallback path still supports generic `Set[int]`
+implementations, and coverage classification remains identical.
+
 ## Registered performance probe
 
 The affected path is already covered by the registered PR-scoped probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries. The probe builds a deterministic synthetic multi-file diff and reports:
@@ -15,11 +24,20 @@ The affected path is already covered by the registered PR-scoped probe `changed-
 - `elapsed_ms_mean` (lower is better)
 - `line_count` and `changed_line_count` guard-rail metrics
 
+The dense measured-line filter slice is covered by the registered PR-scoped
+probe `changed-scope-coverage-measured-set-filter`, including focused
+`test_command`, `coverage_command`, and `probe_command` entries. Its metrics
+include `dense_elapsed_ms_mean` for the changed-path measured-line scan,
+`source_read_calls_mean`, and `dense_source_read_calls_mean` guard rails.
+
 ## Verification plan
 
 - Run the focused parser and PR-scoped registry tests.
 - Run changed-scope coverage for the touched files and require at least 95% changed-line coverage.
 - Run the registered parser probe locally on Linux against both `origin/main` and this branch via `scripts/pr_scoped_performance_run.py`.
+- For the dense measured-line slice, run the registered
+  `changed-scope-coverage-measured-set-filter` probe locally on Linux against
+  both `origin/main` and this branch via `scripts/pr_scoped_performance_run.py`.
 - Use the GitHub PR-scoped performance workflow as the merge gate after opening the PR.
 
 ## Success criteria

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -280,9 +280,14 @@ def _measurable_changed_lines(
                 and len(changed) >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
                 and len(changed) * 4 >= measured_line_count
             ):
-                executed_lookup = {line_no for line_no in executed_lines if line_no in changed}
-                missing_lookup = {line_no for line_no in missing_lines if line_no in changed}
-                measured_changed = list(executed_lookup | missing_lookup)
+                if isinstance(changed, (set, frozenset)):
+                    executed_lookup = changed.intersection(executed_lines)
+                    missing_lookup = changed.intersection(missing_lines)
+                else:
+                    executed_lookup = {line_no for line_no in executed_lines if line_no in changed}
+                    missing_lookup = {line_no for line_no in missing_lines if line_no in changed}
+                measured_changed = list(executed_lookup)
+                measured_changed.extend(missing_lookup)
             else:
                 measured_changed = [
                     line_no

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -607,6 +607,43 @@ def test_measurable_changed_lines_handles_large_measured_sets_without_union(tmp_
     assert missed == [2]
 
 
+def test_measurable_changed_lines_dense_filter_keeps_generic_set_fallback(tmp_path: Path) -> None:
+    class GenericChangedSet:
+        def __init__(self, values: set[int]) -> None:
+            self.values = values
+
+        def __contains__(self, value: object) -> bool:
+            return value in self.values
+
+        def __iter__(self):
+            return iter(self.values)
+
+        def __len__(self) -> int:
+            return len(self.values)
+
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 81)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 80, 2)),
+                "missing_lines": list(range(2, 81, 2)),
+            }
+        }
+    }
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        GenericChangedSet(set(range(1, 81))),
+    )
+
+    assert measurable == list(range(1, 81))
+    assert covered == list(range(1, 80, 2))
+    assert missed == list(range(2, 81, 2))
+
+
 def test_measurable_changed_lines_uses_dense_membership_scan(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Use C-level `set.intersection(...)` for dense changed-scope coverage measured-line filters when the changed line container is a built-in set/frozenset.
- Keep the generic `Set[int]` fallback and add regression coverage for that fallback.
- Update the governing changed-scope coverage performance plan for this dense measured-line slice.

## Plan or Spec
- `docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md`
- Registered PR-scoped probe: `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 49 passed in 0.32s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 49 passed; TOTAL 24 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-measured-set-filter --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-changed-scope-intersection-filter-20260705 --head-repo "$PWD" --output /tmp/changed_scope_intersection_probe.json
# ok; base/head probe completed successfully

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 24 0 100%`.
- Local registered probe (`changed-scope-coverage-measured-set-filter`, Linux):
  - `elapsed_ms_mean`: base `0.2855002847874338` ms -> head `0.27702557157941293` ms (lower is better; -2.97%).
  - `dense_elapsed_ms_mean`: base `53.866198429334744` ms -> head `49.535682142699706` ms (lower is better; -8.04%).
  - `source_read_calls_mean`: base `0.0` -> head `0.0`.
  - `dense_source_read_calls_mean`: base `300.0` -> head `300.0`.
- GitHub Actions PR-scoped performance remains the merge gate for registered probe validation after push.

## Known Gaps
- None for the Python slice. Full repository gates were not run locally; this PR relies on GitHub Actions for the broader CI matrix.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
