### PR TITLE
perf: use direct open for quantization index reads

### DIFF
--- a/docs/plans/2026-07-05-quantization-index-direct-open.md
+++ b/docs/plans/2026-07-05-quantization-index-direct-open.md
@@ -1,0 +1,26 @@
+# Quantization index direct binary open performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the MLX-LM indexed shard smoke-file helper in `services/mlx-worker-python/worker/model_ops/quantization_pipeline.py`.
+
+The helper already caches parsed `model.safetensors.index.json` results by path, mtime, and size, and already finds the lexicographically first valid shard in a single pass. This follow-up keeps behavior identical while avoiding the `Path.read_bytes()` wrapper in the cache miss path by reading the index with direct binary `open(..., "rb")`.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe `quantization-index-shard-min-single-pass` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries, and reports:
+
+- `elapsed_ms_mean`
+- `sorted_calls_mean`
+- `peak_bytes_mean`
+
+## Verification plan
+
+1. Keep the existing shard selection, malformed index fallback, and cache invalidation semantics unchanged.
+2. Extend the regression test to prove the index loading path avoids both `Path.read_text()` and `Path.read_bytes()` wrapper calls.
+3. Run the registered focused tests, changed-scope coverage command, and `quantization-index-shard-min-single-pass` probe locally on Linux before pushing.
+4. Use the GitHub PR-scoped performance workflow as the final merge gate after opening the PR.
+
+## Metrics expectation
+
+The direct-open slice should be neutral-to-improved for `elapsed_ms_mean`, keep `sorted_calls_mean` at zero, and preserve peak memory within probe noise.

--- a/services/mlx-worker-python/tests/test_quantization_pipeline.py
+++ b/services/mlx-worker-python/tests/test_quantization_pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import os
 from pathlib import Path
@@ -1285,7 +1286,9 @@ def test_mlx_lm_index_weight_files_reads_index_as_bytes(
     )
 
     read_text = Mock(side_effect=AssertionError("index loading should stay on the bytes path"))
+    read_bytes = Mock(side_effect=AssertionError("index loading should avoid Path.read_bytes wrapper overhead"))
     monkeypatch.setattr(Path, "read_text", read_text)
+    monkeypatch.setattr(Path, "read_bytes", read_bytes)
 
     assert _smoke_required_files_for_backend(
         bundle,
@@ -1297,6 +1300,7 @@ def test_mlx_lm_index_weight_files_reads_index_as_bytes(
         "model-00001-of-00001.safetensors",
     )
     read_text.assert_not_called()
+    read_bytes.assert_not_called()
 
 
 def test_mlx_lm_index_weight_files_reuses_cached_index_payload(
@@ -1312,16 +1316,16 @@ def test_mlx_lm_index_weight_files_reuses_cached_index_payload(
     )
     quantization_pipeline_module._mlx_lm_index_weight_files_cached.cache_clear()
 
-    real_read_bytes = Path.read_bytes
+    real_open = builtins.open
     read_calls = 0
 
-    def tracked_read_bytes(self: Path) -> bytes:
+    def tracked_open(file, *args, **kwargs):
         nonlocal read_calls
-        if self == index_path:
+        if file == os.fspath(index_path):
             read_calls += 1
-        return real_read_bytes(self)
+        return real_open(file, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "read_bytes", tracked_read_bytes)
+    monkeypatch.setattr(builtins, "open", tracked_open)
 
     expected = (
         "config.json",

--- a/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/quantization_pipeline.py
@@ -943,7 +943,8 @@ def _mlx_lm_index_weight_files_cached(
     _ = size_bytes
     index_file = "model.safetensors.index.json"
     try:
-        payload = json.loads(Path(index_path).read_bytes())
+        with open(index_path, "rb") as index_stream:
+            payload = json.loads(index_stream.read())
     except (OSError, json.JSONDecodeError):
         return (index_file, "model.safetensors")
     weight_map = payload.get("weight_map")


### PR DESCRIPTION
## Summary
- Read MLX-LM `model.safetensors.index.json` cache misses with direct binary `open(..., "rb")` instead of `Path.read_bytes()`.
- Extend the quantization pipeline regression tests to prove the indexed-shard helper avoids both text reads and the `Path.read_bytes()` wrapper while preserving cache behavior.
- Add the governing performance-slice plan for this small Python-only change.

## Plan or Spec
- `docs/plans/2026-07-05-quantization-index-direct-open.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_smoke_required_files_scans_bundle_markers_once services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_reads_index_as_bytes services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_reuses_cached_index_payload services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_cache_invalidates_when_index_changes services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_stat_error_falls_back services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_index_shard_probe_script_emits_metrics
# 9 passed in 0.67s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_source_and_smoke_file_helpers_cover_edge_cases services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_smoke_required_files_scans_bundle_markers_once services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_reads_index_as_bytes services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_reuses_cached_index_payload services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_cache_invalidates_when_index_changes services/mlx-worker-python/tests/test_quantization_pipeline.py::test_mlx_lm_index_weight_files_stat_error_falls_back services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_quantization_qat_source_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantization_index_shard_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/quantization_pipeline.py services/mlx-worker-python/tests/test_quantization_pipeline.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/quantization_index_shard_probe.py
# 9 passed in 1.02s; TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZATION_INDEX_SHARD_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantization_index_shard_probe.py
# {"elapsed_ms_mean": 1.744764400064014, "iterations_per_sample": 8.0, "peak_bytes_mean": 234257.0, "sample_count": 5.0, "sorted_calls_mean": 0.0, "weight_map_entries": 5003.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id quantization-index-shard-min-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-quantization-index-direct-open-20260705 --head-repo "$PWD" --output /tmp/quantization_index_direct_open_probe.json
# head verification ok; coverage 100%; base/head probe ok

MELIX_QUANTIZATION_INDEX_SHARD_PROBE_SAMPLES=15 MELIX_QUANTIZATION_INDEX_SHARD_PROBE_ITERATIONS=16 ... scripts/quantization_index_shard_probe.py on base and head
# base elapsed_ms_mean=1.313242400889673; head elapsed_ms_mean=1.3130846673448104

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered probe: `quantization-index-shard-min-single-pass`.
- Local registered runner: base `elapsed_ms_mean=1.7034400007105432`, head `elapsed_ms_mean=1.7182406008942053` (+0.01480060018366214 ms, neutral under the 5% warning threshold), `sorted_calls_mean=0.0` for both.
- Longer local repeat (15 samples × 16 iterations): base `elapsed_ms_mean=1.313242400889673`, head `elapsed_ms_mean=1.3130846673448104` (-0.00015773354486259364 ms), `sorted_calls_mean=0.0` for both.
- CI PR-scoped performance is required as the final registered probe validation and merge gate.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused Python probe/test/coverage commands on Linux.
- The measured speedup is intentionally tiny and within local probe noise; the value of the slice is eliminating wrapper overhead on cache misses while keeping the registered probe neutral-to-improved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
