### PR TITLE
perf: index metrics snapshot latest tracking

### DIFF
--- a/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
+++ b/docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md
@@ -97,3 +97,17 @@ future behavior slices are gated on meaningful configured-path regressions rathe
 than measurement noise. The behavior contract remains unchanged: configured
 sources still bypass runtime scanning, and runtime-scan `elapsed_ms_*` metrics
 remain percentage-gated.
+
+## 2026-07-05 follow-up slice: indexed latest-path tracking
+
+This Python-only follow-up keeps the same registered
+`melix-metrics-snapshot-runtime-scandir` probe and narrows to the hot latest-file
+tracking structures inside `discover_latest_metrics_paths(...)`. The runtime
+source names are now mapped to compact integer indexes before the directory scan,
+so the per-entry path updates use list indexing instead of repeated source-name
+dictionary get/set operations.
+
+The behavior contract remains unchanged: exact, prefix/suffix, empty-prefix, and
+multi-wildcard runtime pattern matches still select the newest regular file per
+source; configured sources still bypass runtime scanning; and only the final
+winning path for each source is materialized as a `Path`.

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -84,81 +84,86 @@ def discover_latest_metrics_paths(runtime_dir: Path | None, source_names: tuple[
     discovered: dict[str, Path | None] = {name: None for name in source_names}
     if runtime_dir is None or not source_names:
         return discovered
-    exact_matchers: dict[str, str] = {}
-    prefix_matchers_by_initial: dict[str, list[tuple[str, str, str]]] = {}
-    wildcard_matchers: list[tuple[str, str]] = []
+    source_indexes = {name: index for index, name in enumerate(source_names)}
+    exact_matchers: dict[str, int] = {}
+    prefix_matchers_by_initial: dict[str, list[tuple[int, str, str]]] = {}
+    wildcard_matchers: list[tuple[int, str]] = []
     for source_name in source_names:
+        source_index = source_indexes[source_name]
         pattern = SOURCE_DEFINITIONS[source_name]["runtime_pattern"]
         wildcard_index = pattern.find("*")
         if wildcard_index == -1:
-            exact_matchers[pattern] = source_name
+            exact_matchers[pattern] = source_index
         elif pattern.find("*", wildcard_index + 1) == -1:
             prefix = pattern[:wildcard_index]
             suffix = pattern[wildcard_index + 1 :]
             initial = prefix[:1]
             prefix_matchers_by_initial.setdefault(initial, []).append(
-                (source_name, prefix, suffix)
+                (source_index, prefix, suffix)
             )
         else:
-            wildcard_matchers.append((source_name, pattern))
+            wildcard_matchers.append((source_index, pattern))
     try:
-        latest_paths: dict[str, str | None] = {name: None for name in source_names}
-        latest_mtimes: dict[str, float | None] = {name: None for name in source_names}
+        source_count = len(source_names)
+        latest_paths: list[str | None] = [None] * source_count
+        latest_mtimes: list[float | None] = [None] * source_count
         latest_paths_set = latest_paths.__setitem__
-        latest_mtimes_get = latest_mtimes.get
         latest_mtimes_set = latest_mtimes.__setitem__
-        empty_prefix_matchers = prefix_matchers_by_initial.get("", ())
+        exact_matchers_get = exact_matchers.get
+        prefix_matchers_get = prefix_matchers_by_initial.get
+        matches_runtime_pattern = _matches_runtime_pattern
+        empty_prefix_matchers = prefix_matchers_get("", ())
         with os.scandir(os.fspath(runtime_dir.expanduser())) as entries:
             for entry in entries:
                 entry_name = entry.name
-                matched_source_name = exact_matchers.get(entry_name)
-                matched_source_names: list[str] | None = None
-                for source_name, prefix, suffix in prefix_matchers_by_initial.get(
+                matched_source_index = exact_matchers_get(entry_name)
+                matched_source_indexes: list[int] | None = None
+                for source_index, prefix, suffix in prefix_matchers_get(
                     entry_name[:1], ()
                 ):
                     if entry_name.startswith(prefix) and entry_name.endswith(suffix):
-                        if matched_source_name is None:
-                            matched_source_name = source_name
-                        elif matched_source_names is None:
-                            matched_source_names = [matched_source_name, source_name]
+                        if matched_source_index is None:
+                            matched_source_index = source_index
+                        elif matched_source_indexes is None:
+                            matched_source_indexes = [matched_source_index, source_index]
                         else:
-                            matched_source_names.append(source_name)
+                            matched_source_indexes.append(source_index)
                 if empty_prefix_matchers:
-                    for source_name, prefix, suffix in empty_prefix_matchers:
+                    for source_index, prefix, suffix in empty_prefix_matchers:
                         if entry_name.endswith(suffix):
-                            if matched_source_name is None:
-                                matched_source_name = source_name
-                            elif matched_source_names is None:
-                                matched_source_names = [matched_source_name, source_name]
+                            if matched_source_index is None:
+                                matched_source_index = source_index
+                            elif matched_source_indexes is None:
+                                matched_source_indexes = [matched_source_index, source_index]
                             else:
-                                matched_source_names.append(source_name)
-                for source_name, pattern in wildcard_matchers:
-                    if _matches_runtime_pattern(entry_name, pattern):
-                        if matched_source_name is None:
-                            matched_source_name = source_name
-                        elif matched_source_names is None:
-                            matched_source_names = [matched_source_name, source_name]
+                                matched_source_indexes.append(source_index)
+                for source_index, pattern in wildcard_matchers:
+                    if matches_runtime_pattern(entry_name, pattern):
+                        if matched_source_index is None:
+                            matched_source_index = source_index
+                        elif matched_source_indexes is None:
+                            matched_source_indexes = [matched_source_index, source_index]
                         else:
-                            matched_source_names.append(source_name)
-                if matched_source_name is None:
+                            matched_source_indexes.append(source_index)
+                if matched_source_index is None:
                     continue
                 if not entry.is_file():
                     continue
                 mtime = entry.stat().st_mtime
-                if matched_source_names is None:
-                    latest_mtime = latest_mtimes_get(matched_source_name)
+                if matched_source_indexes is None:
+                    latest_mtime = latest_mtimes[matched_source_index]
                     if latest_mtime is None or mtime > latest_mtime:
-                        latest_paths_set(matched_source_name, entry.path)
-                        latest_mtimes_set(matched_source_name, mtime)
+                        latest_paths_set(matched_source_index, entry.path)
+                        latest_mtimes_set(matched_source_index, mtime)
                     continue
-                for source_name in matched_source_names:
-                    latest_mtime = latest_mtimes_get(source_name)
+                for source_index in matched_source_indexes:
+                    latest_mtime = latest_mtimes[source_index]
                     if latest_mtime is None or mtime > latest_mtime:
-                        latest_paths_set(source_name, entry.path)
-                        latest_mtimes_set(source_name, mtime)
-        for source_name, latest_path in latest_paths.items():
+                        latest_paths_set(source_index, entry.path)
+                        latest_mtimes_set(source_index, mtime)
+        for index, latest_path in enumerate(latest_paths):
             if latest_path is not None:
-                discovered[source_name] = Path(latest_path)
+                discovered[source_names[index]] = Path(latest_path)
         return discovered
     except OSError:
         return discovered


### PR DESCRIPTION
## Summary
- Optimizes `discover_latest_metrics_paths(...)` by mapping runtime source names to compact integer indexes before scanning.
- Replaces hot latest-path/latest-mtime dictionary updates with list indexing while preserving exact, prefix/suffix, empty-prefix, and multi-wildcard matching behavior.
- Updates the governing metrics snapshot source-discovery plan with the 2026-07-05 indexed latest-path tracking slice.

## Plan or Spec
- `docs/plans/2026-06-15-metrics-snapshot-source-single-scan.md`
- Registered PR-scoped probe: `melix-metrics-snapshot-runtime-scandir` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
$ git fetch origin main --prune
$ git worktree add -b perf/metrics-snapshot-csv-dialect-20260705 /root/.hermes/profiles/coder/workspace/worktrees/melix-metrics-snapshot-csv-dialect-20260705 origin/main

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_skips_runtime_scan_when_all_sources_are_configured tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics
11 passed in 0.56s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_skips_runtime_scan_when_all_sources_are_configured tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/melix_metrics_snapshot.py scripts/melix_metrics_snapshot_discovery_probe.py tests/test_melix_metrics_snapshot.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
11 passed in 0.90s
TOTAL 46 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id melix-metrics-snapshot-runtime-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-metrics-snapshot-indexed-latest-20260705 --head-repo "$PWD" --output /tmp/melix_metrics_snapshot_runtime_probe.json
head verification: 11 passed; changed-scope coverage 100%; base/head probes ok

$ git diff --check
passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 46 0 100%`.
- Registered local Linux probe `melix-metrics-snapshot-runtime-scandir`:
  - `elapsed_ms_mean`: base `12.921665` ms → head `11.615624` ms (`-1.306041` ms, ~`10.11%` faster)
  - `elapsed_ms_min`: base `12.041902` ms → head `11.074065` ms (`-0.967837` ms, ~`8.04%` faster)
  - `configured_elapsed_ms_mean`: base `0.019383` ms → head `0.019244` ms (`-0.000139` ms)
  - `configured_elapsed_ms_min`: base `0.014457` ms → head `0.012984` ms (`-0.001473` ms)
- Observability mode: evidence (PR-scoped synthetic probe). Probe overhead: N/A, no runtime observability was added or changed.
- GitHub Actions PR-scoped performance report is required as the merge gate after PR creation.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this slice used the registered focused Python test, coverage, and probe commands on Linux.
- Swift/macOS runtime effects are not applicable for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
