### PR TITLE
perf: pre-scan code eval assert mentions

### DIFF
--- a/docs/plans/2026-07-05-code-eval-assert-prescan.md
+++ b/docs/plans/2026-07-05-code-eval-assert-prescan.md
@@ -1,0 +1,51 @@
+# Code Eval Assert Pre-scan Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.engine.code_eval_runner._count_tests()` and the fallback test-count probe.
+
+The optimization avoids building a Python AST when executable-code evaluation test payloads only mention `assert` inside comments or string literals. The behavior remains unchanged: valid `assert` statements are still counted through the AST path, syntax-error payloads with real `assert` statements still fall back to the nonblank-line counter, and no-assert payloads continue to report nonblank test lines.
+
+## Registered Probe
+
+The affected path is covered by the existing registered PR-scoped probe `code-eval-count-tests-line-scan` and this slice adds the focused registered probe `code-eval-assert-mention-prescan` in `infra/perf/pr_scoped_probes.json` with dedicated `test_command`, `coverage_command`, and `probe_command` entries.
+
+The new probe uses the same comment/string-literal `assert` mention workload on base and head so CI can validate the pre-scan behavior against the previous implementation without changing the existing count-tests probe workload.
+
+## Verification Plan
+
+Run locally on Linux before pushing:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_for_syntax_error_input \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_reuses_cached_counts_for_repeated_payloads \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_counts_nested_asserts \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_uses_exact_type_for_direct_asserts \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_assert_nodes_fast_paths_all_top_level_asserts \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_fallback_counts_nonblank_lines \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_counts_nonblank_lines \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_preserves_inline_assert_statement_detection \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list \
+  services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_short_inputs_without_splitlines \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
+  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_count_tests_probe_script_emits_metrics
+```
+
+Also run the registered changed-scope coverage command and probe command from `infra/perf/pr_scoped_probes.json`. GitHub Actions PR-scoped performance remains the merge gate.
+
+## Metrics
+
+Target metrics:
+
+- `peak_bytes_mean`: lower is better for the assert-mention pre-scan workload because the slice avoids allocating an AST for common comment/string `assert` mentions.
+- `elapsed_ms_mean`: tracked as lower-is-better in the registered probe to surface CPU trade-offs; local Linux measurements showed the memory win with a small elapsed-time regression, so CI should be inspected before merge rather than treating this as an unconditional latency improvement.
+- `assert_elapsed_ms_mean`: should remain stable for true assert-node counting in the existing count-tests probe.
+
+## Known Boundaries
+
+This is a Linux-verifiable Python slice. It does not change sandbox execution behavior, candidate-code execution, Swift code, protobuf schemas, or generated artifacts.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3156,6 +3156,36 @@
     ]
   },
   {
+    "id": "code-eval-assert-mention-prescan",
+    "name": "Code evaluation assert mention pre-scan",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/engine/code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_code_eval_runner.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/code_eval_assert_prescan_probe.py"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_preserves_inline_assert_statement_detection services/mlx-worker-python/tests/test_code_eval_runner.py::test_assert_prescan_handles_boundary_and_literal_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_assert_prescan_probe_script_emits_metrics",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_preserves_inline_assert_statement_detection services/mlx-worker-python/tests/test_code_eval_runner.py::test_assert_prescan_handles_boundary_and_literal_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_assert_prescan_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_assert_prescan_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python python3 - <<'PYPROBE'\nimport json, statistics, sys, time, tracemalloc\nfrom pathlib import Path\nrepo_root = Path.cwd(); sys.path.insert(0, str(repo_root)); sys.path.insert(0, str(repo_root / \"services/mlx-worker-python\"))\nfrom worker.engine import code_eval_runner\ndef build(line_count):\n    def line_for(index):\n        remainder = index % 4\n        if remainder == 0: return \"\\t\"\n        if remainder == 1: return f\"# assert mention {index} should not force AST parsing\"\n        if remainder == 2: return f\"message_{index} = 'assert mention {index}'\"\n        return f\"value_{index} = candidate({index})\"\n    return \"def check(candidate):\\n\" + \"\\n\".join(line_for(index) for index in range(line_count)) + \"\\ncheck(identity)\"\ndef expected(text): return sum(1 for line in text.splitlines() if line.strip())\nline_count=8000; iterations=25; sample_count=7; test_code=build(line_count); expected_count=expected(test_code)\nelapsed=[]; peaks=[]; nonblank_count=0\nfor _ in range(sample_count):\n    code_eval_runner._count_tests.cache_clear(); tracemalloc.start(); started=time.perf_counter()\n    for _index in range(iterations): nonblank_count=code_eval_runner._count_tests(test_code)\n    elapsed_ms=(time.perf_counter()-started)*1000.0; _, peak=tracemalloc.get_traced_memory(); tracemalloc.stop()\n    if nonblank_count != expected_count: raise SystemExit(f\"unexpected assert-mention fallback count: {nonblank_count} != {expected_count}\")\n    elapsed.append(elapsed_ms); peaks.append(float(peak))\nprint(json.dumps({\"elapsed_ms_mean\": statistics.fmean(elapsed), \"peak_bytes_mean\": statistics.fmean(peaks), \"line_count\": float(line_count), \"iteration_count\": float(iterations), \"sample_count\": float(sample_count), \"nonblank_count\": float(nonblank_count)}, sort_keys=True))\nPYPROBE",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      }
+    ]
+  },
+  {
     "id": "code-eval-test-count-nonblank-streaming",
     "name": "Code evaluation nonblank test count streaming",
     "runner": "ubuntu-latest",

--- a/scripts/code_eval_assert_prescan_probe.py
+++ b/scripts/code_eval_assert_prescan_probe.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+REPO_ROOT = Path.cwd()
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.engine import code_eval_runner  # noqa: E402
+
+
+def _build_comment_string_assert_tests(line_count: int) -> str:
+    def line_for(index: int) -> str:
+        remainder = index % 4
+        if remainder == 0:
+            return "\t"
+        if remainder == 1:
+            return f"# assert mention {index} should not force AST parsing"
+        if remainder == 2:
+            return f"message_{index} = 'assert mention {index}'"
+        return f"value_{index} = candidate({index})"
+
+    body = "\n".join(line_for(index) for index in range(line_count))
+    return "def check(candidate):\n" + body + "\ncheck(identity)"
+
+
+def _expected_nonblank_lines(test_code: str) -> int:
+    return sum(1 for line in test_code.splitlines() if line.strip())
+
+
+def main() -> int:
+    line_count = 8000
+    iterations = 25
+    sample_count = 7
+    test_code = _build_comment_string_assert_tests(line_count)
+    expected_count = _expected_nonblank_lines(test_code)
+    code_eval_runner._count_tests.cache_clear()
+
+    elapsed_samples: list[float] = []
+    peak_samples: list[float] = []
+    nonblank_count = 0
+    for _ in range(sample_count):
+        code_eval_runner._count_tests.cache_clear()
+        tracemalloc.start()
+        started = time.perf_counter()
+        for _index in range(iterations):
+            nonblank_count = code_eval_runner._count_tests(test_code)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        if nonblank_count != expected_count:
+            raise SystemExit(
+                f"unexpected assert-mention fallback count: {nonblank_count} != {expected_count}"
+            )
+        elapsed_samples.append(elapsed_ms)
+        peak_samples.append(float(peak))
+
+    print(
+        json.dumps(
+            {
+                "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+                "peak_bytes_mean": statistics.fmean(peak_samples),
+                "line_count": float(line_count),
+                "iteration_count": float(iterations),
+                "sample_count": float(sample_count),
+                "nonblank_count": float(nonblank_count),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -537,6 +537,43 @@ def test_count_tests_no_assert_fast_path_skips_ast_parse(monkeypatch: pytest.Mon
     assert code_eval_runner._count_tests("setup()\nrun_case(identity)\n") == 2
 
 
+def test_count_tests_ignores_assert_tokens_in_comments_and_strings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    code_eval_runner._count_tests.cache_clear()
+    test_code = textwrap.dedent(
+        '''
+        # assert appears in prose, not as a statement
+        message = "assert should stay inside the string"
+        details = """multi-line assert mention"""
+        value = candidate(1)
+        '''
+    ).strip()
+
+    def fail_parse(*args, **kwargs):
+        raise AssertionError(  # pragma: no cover - regression-only failure path
+            "comment/string assert mentions should use the non-AST fallback"
+        )
+
+    monkeypatch.setattr(code_eval_runner.ast, "parse", fail_parse)
+
+    assert code_eval_runner._count_tests(test_code) == 4
+
+
+def test_count_tests_preserves_inline_assert_statement_detection() -> None:
+    code_eval_runner._count_tests.cache_clear()
+
+    assert code_eval_runner._count_tests("setup(); assert identity(1) == 1") == 1
+
+
+def test_assert_prescan_handles_boundary_and_literal_edges() -> None:
+    assert code_eval_runner._may_contain_assert_statement("# assert only in trailing comment") is False
+    assert code_eval_runner._may_contain_assert_statement("reassert = 'value'") is False
+    assert code_eval_runner._may_contain_assert_statement("text = 'escaped \\\' assert'") is False
+    assert code_eval_runner._may_contain_assert_statement('text = "unterminated assert') is False
+    assert code_eval_runner._may_contain_assert_statement("if ready: assert value") is True
+
+
 def test_count_tests_syntax_error_fallback_uses_nonblank_line_counter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1728,13 +1728,14 @@ def test_scope_report_selects_code_eval_stdio_probe() -> None:
     )
 
     probe_ids = {probe["id"] for probe in scope["selected_probes"]}
-    assert scope["selected_count"] == 6
+    assert scope["selected_count"] == 7
     assert probe_ids == {
         "code-eval-code-block-last-match-streaming",
         "code-eval-payload-json-bytes",
         "code-eval-stdio-tail-single-stat",
         "code-eval-runner-script-cache",
         "code-eval-count-tests-line-scan",
+        "code-eval-assert-mention-prescan",
         "code-eval-test-count-nonblank-streaming",
     }
 
@@ -4263,6 +4264,7 @@ def test_registered_probes_expose_focused_commands() -> None:
         "code-eval-stdio-tail-single-stat",
         "code-eval-runner-script-cache",
         "code-eval-count-tests-line-scan",
+        "code-eval-assert-mention-prescan",
         "code-eval-test-count-nonblank-streaming",
         "deterministic-embedding-duplicate-input-cache",
         "deterministic-embedding-project-digest-allocation",
@@ -5445,6 +5447,22 @@ def test_code_eval_count_tests_probe_script_emits_metrics(
     assert metrics["assert_line_count"] == 8000.0
     assert metrics["assert_node_iterations"] == 20.0
     assert metrics["assert_count"] == 8000.0
+
+
+def test_code_eval_assert_prescan_probe_script_emits_metrics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/code_eval_assert_prescan_probe.py"))
+
+    probe_script["main"]()
+    metrics = json.loads(capsys.readouterr().out)
+
+    assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["peak_bytes_mean"] > 0
+    assert metrics["line_count"] == 8000.0
+    assert metrics["iteration_count"] == 25.0
+    assert metrics["sample_count"] == 7.0
+    assert metrics["nonblank_count"] == 6002.0
 
 
 def test_code_eval_test_count_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -26,6 +26,8 @@ _ORD_QUOTE = ord('"')
 _ORD_COLON = ord(":")
 _ORD_OBJECT_START = ord("{")
 _ORD_OBJECT_END = ord("}")
+_ASSERT_PRECEDING_BOUNDARIES = frozenset("\n\r;:")
+_ASSERT_LINE_SPACING = frozenset(" \t")
 
 
 @dataclass(frozen=True, slots=True)
@@ -270,7 +272,7 @@ def run_python_code_evaluation(
 
 @lru_cache(maxsize=128)
 def _count_tests(test_code: str) -> int:
-    if "assert" not in test_code:
+    if not _may_contain_assert_statement(test_code):
         return _count_nonblank_test_lines(test_code)
     try:
         module = ast.parse(test_code, filename="<tests>", mode="exec")
@@ -278,6 +280,28 @@ def _count_tests(test_code: str) -> int:
         return _count_nonblank_test_lines(test_code)
     assert_count = _count_assert_nodes(module)
     return assert_count or _count_nonblank_test_lines(test_code)
+
+
+def _may_contain_assert_statement(test_code: str) -> bool:
+    if "assert" not in test_code:
+        return False
+    cursor = 0
+    text_length = len(test_code)
+    while True:
+        cursor = test_code.find("assert", cursor)
+        if cursor < 0:
+            return False
+        after_index = cursor + 6
+        after = test_code[after_index] if after_index < text_length else "\n"
+        if after == "_" or after.isalnum():
+            cursor = after_index
+            continue
+        before_index = cursor - 1
+        while before_index >= 0 and test_code[before_index] in _ASSERT_LINE_SPACING:
+            before_index -= 1
+        if before_index < 0 or test_code[before_index] in _ASSERT_PRECEDING_BOUNDARIES:
+            return True
+        cursor = after_index
 
 
 def _count_assert_nodes(


### PR DESCRIPTION
## Summary
- Adds a focused `code-eval-assert-mention-prescan` PR-scoped performance probe for `worker.engine.code_eval_runner._count_tests()`.
- Keeps the existing no-assert fast path and adds a lightweight assert-statement pre-scan so common comment/string `assert` mentions can avoid AST allocation.
- Restores the existing count-tests probe workload and moves the assert-mention workload into its own registered probe.

## Plan or Spec
- Updated `docs/plans/2026-07-05-code-eval-assert-prescan.md` with the registered probe, verification plan, and observed metric trade-off.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_preserves_inline_assert_statement_detection services/mlx-worker-python/tests/test_code_eval_runner.py::test_assert_prescan_handles_boundary_and_literal_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_assert_prescan_probe_script_emits_metrics` → 7 passed
- Registered coverage command for `code-eval-assert-mention-prescan` → 7 passed, changed-line coverage 100% (`TOTAL 29 0 100%`)
- Registered probe command for `code-eval-assert-mention-prescan` → `elapsed_ms_mean=16.1537`, `peak_bytes_mean=192.0`
- `scripts/pr_scoped_performance_run.py --probe-id code-eval-assert-mention-prescan` against `origin/main` baseline worktree → head verification passed, base/head probes completed
- `git diff --check` → passed

## Coverage and Metrics
- Focused changed-scope coverage: 100% (29/29 changed lines covered).
- Local Linux registered probe comparison:
  - `elapsed_ms_mean`: base `9.2416 ms`, head `11.3249 ms` in the latest full base/head run (CPU trade-off observed; lower is better).
  - `peak_bytes_mean`: base `264064 bytes`, head `1134 bytes` in the latest full base/head run (large allocation reduction; lower is better).
- CI PR-scoped performance is still the source of truth for the merge decision.

## Known Gaps
- Linux-only Python validation; no Swift/runtime effect is claimed.
- The pre-scan intentionally remains conservative: false positives may still fall through to AST parsing, but false negatives for common statement positions are covered by tests.
- Local metrics show a memory win with a small elapsed-time regression on the assert-mention synthetic workload; CI registered probe report should be inspected before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
