### PR TITLE
perf: inline video URI public authority validation

### DIFF
--- a/docs/plans/2026-07-06-video-uri-public-authority-inline-fastpath.md
+++ b/docs/plans/2026-07-06-video-uri-public-authority-inline-fastpath.md
@@ -1,0 +1,31 @@
+# Video URI public authority inline fast path
+
+This Python-only performance slice targets repeated URI-backed video preprocessing in `services/mlx-worker-python/worker/runtime/video_preprocessing.py`.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- Registered probe: `video-preprocessing-uri-byte-length-reuse`
+
+## Registered probe coverage
+
+The affected path is covered by the existing PR-scoped registered probe `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`. The probe entry already defines focused `test_command`, `coverage_command`, and `probe_command` values and watches the video preprocessing source, focused tests, PR-scoped performance selection tests, and `scripts/video_preprocessing_uri_probe.py`.
+
+## Optimization
+
+The common HTTPS public-host validation path now performs the plain-authority checks inline in `_validate_parsed_video_uri()`. This avoids an extra helper call for repeated public remote video references while preserving the slower non-plain parser for localhost, IP-literal, credential, and port-bearing authorities.
+
+## Behavior parity
+
+- Local paths and `file:` references remain accepted.
+- HTTPS references without a host remain rejected.
+- Public DNS-style hosts remain accepted on the fast path.
+- Localhost/private-host/IP-literal validation remains delegated to `_validate_non_plain_remote_video_reference()`.
+
+## Verification plan
+
+1. Run the focused video preprocessing tests and registered PR-scoped probe selection tests from the registry `test_command`.
+2. Run the registered changed-scope coverage command.
+3. Run the registered `video_preprocessing_uri_probe.py` probe locally on Linux and compare against the pre-change baseline.
+4. Use the PR-scoped performance workflow as the merge gate.

--- a/services/mlx-worker-python/tests/test_video_preprocessing.py
+++ b/services/mlx-worker-python/tests/test_video_preprocessing.py
@@ -467,3 +467,18 @@ def test_prepare_video_input_rejects_invalid_contracts(
 def test_validate_video_uri_accepts_parsed_and_string_remote_references() -> None:
     video_preprocessing._validate_video_uri(_parse_video_reference("https://example.com/demo.mov"))
     video_preprocessing._validate_video_uri("https://123-example.com/demo.mov")
+
+
+def test_validate_video_uri_public_host_fast_path_skips_non_plain_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_non_plain_parser(authority: str) -> None:  # pragma: no cover - regression only
+        raise AssertionError(f"public host should stay on the fast path: {authority}")
+
+    monkeypatch.setattr(
+        video_preprocessing,
+        "_validate_non_plain_remote_video_reference",
+        fail_non_plain_parser,
+    )
+
+    video_preprocessing._validate_video_uri("https://example.com/demo.mov")

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -187,7 +187,18 @@ def _validate_parsed_video_uri(reference: ParsedVideoReference) -> None:
         authority = reference.authority
         if not authority:
             raise VideoPreprocessError("Remote video URI requires a host.")
-        if _is_plain_allowed_remote_authority(authority):
+        first_character = authority[0]
+        if (
+            first_character != "["
+            and not first_character.isdigit()
+            and "@" not in authority
+            and ":" not in authority
+            and (
+                len(authority) < len("localhost")
+                or authority[-1] not in {"t", "T"}
+                or not _authority_mentions_localhost(authority.lower())
+            )
+        ):
             return
         _validate_non_plain_remote_video_reference(authority)
         return


### PR DESCRIPTION
## Summary
- Inline the common HTTPS public-authority validation branch in video URI preprocessing.
- Keep localhost/IP/credential/port-bearing authorities on the existing non-plain validation path.
- Add a focused regression test proving public DNS-style hosts do not enter the slower non-plain parser.

## Plan or Spec
- `docs/plans/2026-07-06-video-uri-public-authority-inline-fastpath.md`
- Registered PR-scoped probe: `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main (5efecd5d)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py
{"byte_length_getattrs_per_call": 1.0, "elapsed_ms_mean": 509.267565398477, "iterations_per_sample": 50000.0, "parse_calls_per_call": 1.0, "sample_count": 5.0}

# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
39 passed in 3.64s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py
39 passed in 7.28s
TOTAL 5 0 100%

# Registered probe script on this branch
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py
{"byte_length_getattrs_per_call": 1.0, "elapsed_ms_mean": 488.2478851999622, "iterations_per_sample": 50000.0, "parse_calls_per_call": 1.0, "sample_count": 5.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local Linux probe (`video_preprocessing_uri_probe.py`): old_mean=509.267565ms, new_mean=488.247885ms, delta_ms=-21.019680ms, speedup=1.043051x, improvement=4.127%.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effects are changed or claimed.
- The local probe measures a synthetic repeated public HTTPS URI workload; CI registered-probe evidence is required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead changes: N/A, no runtime observability path changed.
- [x] Deferred work and known gaps are stated explicitly.
