### PR TITLE
perf: hoist dataset code language suffix map

### DIFF
--- a/docs/plans/2026-07-06-dataset-language-map-constant.md
+++ b/docs/plans/2026-07-06-dataset-language-map-constant.md
@@ -1,0 +1,45 @@
+# Dataset source language suffix map constant
+
+## Scope
+
+This Python-only performance slice targets
+`worker.productization.dataset_preparation._language_for_suffix(...)`, which runs
+while dataset ingest creates source records for code files. Behavior remains
+unchanged: known code suffixes map to Melix language labels, unknown suffixes
+fall back to the suffix text, and an empty suffix falls back to `text`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry has focused `test_command`, `coverage_command`, and
+`probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+## Optimization
+
+Hoist the code-source suffix-to-language lookup table from a per-call dictionary
+literal inside `_language_for_suffix(...)` to a module-level constant, then use a
+direct lookup on known suffixes so the fallback string normalization only runs
+for unknown suffixes. This avoids allocating the same mapping for every code
+source record while preserving the same lookup and fallback semantics.
+
+## Verification plan
+
+1. Keep behavior parity explicit with a focused unit test for known and unknown
+   code suffixes.
+2. Run the registered focused test command locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered `dataset-source-records-scandir` probe locally before and
+   after the change.
+5. Use the PR-scoped GitHub Actions performance workflow as the merge gate for
+   the registered probe report.
+
+## Verification boundary
+
+This is a Python-only slice and is locally verifiable on Linux. The PR-scoped CI
+probe report remains the required merge gate for repository performance evidence.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -16,6 +16,7 @@ from worker.productization.dataset_preparation import (
     _SOURCE_KIND_NAME_CACHE_MAX,
     _blocked_ingest_receipt,
     _iter_source_file_paths,
+    _language_for_suffix,
     _normalize_line_endings,
     _record,
     _read_source_text,
@@ -184,6 +185,14 @@ def test_dataset_ingest_source_kind_name_cache_bypasses_insert_at_bound() -> Non
     assert _source_kind_for_name("next.txt") == "text"
 
     assert _SOURCE_KIND_BY_NAME == cached_entries
+
+
+def test_dataset_ingest_code_language_suffix_map_preserves_known_and_unknown_suffixes() -> None:
+    assert _language_for_suffix(".py") == "python"
+    assert _language_for_suffix(".swift") == "swift"
+    assert _language_for_suffix(".h") == "c"
+    assert _language_for_suffix(".zig") == "zig"
+    assert _language_for_suffix("") == "text"
 
 
 def test_dataset_ingest_record_copies_nonempty_metadata_and_fast_paths_empty_metadata() -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -35,6 +35,18 @@ _CODE_SOURCE_SUFFIXES = frozenset(
     (".py", ".swift", ".js", ".ts", ".java", ".go", ".rs", ".cpp", ".c", ".h")
 )
 _STRUCTURED_DATA_SOURCE_SUFFIXES = frozenset((".jsonl", ".json", ".csv", ".tsv"))
+_CODE_SOURCE_LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".swift": "swift",
+    ".js": "javascript",
+    ".ts": "typescript",
+    ".java": "java",
+    ".go": "go",
+    ".rs": "rust",
+    ".cpp": "cpp",
+    ".c": "c",
+    ".h": "c",
+}
 _SOURCE_KIND_NAME_CACHE_MAX = 4096
 _SOURCE_KIND_BY_NAME: dict[str, str | None] = {}
 _MISSING = object()
@@ -1498,18 +1510,10 @@ def _metadata_for_path(path: Path, source_kind: str) -> dict[str, Any]:
 
 
 def _language_for_suffix(suffix: str) -> str:
-    return {
-        ".py": "python",
-        ".swift": "swift",
-        ".js": "javascript",
-        ".ts": "typescript",
-        ".java": "java",
-        ".go": "go",
-        ".rs": "rust",
-        ".cpp": "cpp",
-        ".c": "c",
-        ".h": "c",
-    }.get(suffix, suffix.lstrip(".") or "text")
+    try:
+        return _CODE_SOURCE_LANGUAGE_BY_SUFFIX[suffix]
+    except KeyError:
+        return suffix.lstrip(".") or "text"
 
 
 def _source_inventory(records: list[dict[str, Any]]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Hoist dataset code suffix language mapping to a module-level constant.
- Use direct known-suffix lookup so fallback normalization only runs for unknown suffixes.
- Add focused behavior coverage for known and fallback suffixes.

## Plan or Spec
- `docs/plans/2026-07-06-dataset-language-map-constant.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json` (focused test, coverage, and probe commands already present).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting` (45 passed)
- Registered coverage command for `dataset-source-records-scandir` (45 passed; changed-scope coverage 100%)
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-language-map-constant-20260706 --output /tmp/dataset-language-map-pr-probe-v2.json`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (11/11 measurable changed lines).
- Registered local probe (`dataset-source-records-scandir`, lower is better):
  - `elapsed_ms_mean`: 12.6294 ms → 11.6460 ms (delta -0.9833 ms, -7.79%)
  - `source_kind_elapsed_ms_mean`: 21.4182 ms → 20.0500 ms (delta -1.3682 ms, -6.39%)
  - `record_elapsed_ms_mean`: 23.8661 ms → 22.3418 ms (delta -1.5243 ms, -6.39%)
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Python-only slice; validated locally on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Branch started from synced `origin/main`.
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally above 95%.
- [x] Registered local probe showed improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
