### PR TITLE
perf: fast path Swift CLI metric placeholder names

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -11,6 +11,18 @@ enum MelixCLIJSONMetricPatch {
     private static let metricLiteralLocale = Locale(identifier: "en_US_POSIX")
     private static let metricNameAlphanumerics = CharacterSet.alphanumerics
 
+    private static func asciiMetricNameScalarOrUnderscore(_ scalar: Unicode.Scalar) -> Unicode.Scalar? {
+        guard scalar.isASCII else {
+            return nil
+        }
+        switch scalar {
+        case "0"..."9", "A"..."Z", "a"..."z":
+            return scalar
+        default:
+            return "_"
+        }
+    }
+
     struct Placeholder {
         let token: String
         let jsonLiteral: String
@@ -27,9 +39,13 @@ enum MelixCLIJSONMetricPatch {
         var safeMetricName = String()
         safeMetricName.reserveCapacity(metricName.count)
         for scalar in metricName.unicodeScalars {
-            safeMetricName.unicodeScalars.append(
-                metricNameAlphanumerics.contains(scalar) ? scalar : "_"
-            )
+            if let replacement = asciiMetricNameScalarOrUnderscore(scalar) {
+                safeMetricName.unicodeScalars.append(replacement)
+            } else {
+                safeMetricName.unicodeScalars.append(
+                    metricNameAlphanumerics.contains(scalar) ? scalar : "_"
+                )
+            }
         }
         return Placeholder(token: "__MELIX_METRIC_\(safeMetricName)_\(UUID().uuidString)__")
     }

--- a/docs/plans/2026-07-06-swift-cli-metric-name-ascii-fastpath.md
+++ b/docs/plans/2026-07-06-swift-cli-metric-name-ascii-fastpath.md
@@ -1,0 +1,19 @@
+# Swift CLI Metric Name ASCII Fast Path
+
+## Goal
+
+Reduce JSON envelope metric placeholder construction overhead for the common ASCII metric-name path without changing emitted JSON schema or placeholder token shape.
+
+## Scope
+
+- Affected code path: `Sources/MelixCLICore/MelixCLIJSON.swift`
+- Registered PR-scoped probe: `swift-cli-json-envelope-encoding`
+- Focused tests: `MelixCLIRunnerTests` JSON envelope and metric-placeholder cases
+
+## Implementation
+
+`MelixCLIJSONMetricPatch.makePlaceholder(metricName:)` previously checked every Unicode scalar through `CharacterSet.alphanumerics`. This slice adds an ASCII-only branch for the common metric-name characters (`A-Z`, `a-z`, `0-9`) and maps other ASCII punctuation to `_` directly. Non-ASCII scalars continue through the existing `CharacterSet.alphanumerics` behavior, preserving compatibility.
+
+## Validation Boundary
+
+This is a Swift/macOS path. The local scheduled Linux worker can inspect and edit the Swift source, but it cannot validate Swift runtime performance effects locally. The registered macOS PR-scoped performance probe (`swift-cli-json-envelope-encoding`) is the source of truth for performance validation before merge.

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -771,11 +771,13 @@ struct MelixCLIRunnerTests {
     @Test("json metric placeholders sanitize scalar names without changing token shape")
     func jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape() {
         let placeholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.json_encode-ms")
+        let unicodePlaceholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.測試-ms")
 
         #expect(placeholder.token.hasPrefix("__MELIX_METRIC_melix_cli_json_encode_ms_"))
         #expect(placeholder.token.hasSuffix("__"))
         #expect(placeholder.jsonLiteral == "\"\(placeholder.token)\"")
         #expect(placeholder.jsonLiteralData == Data(placeholder.jsonLiteral.utf8))
+        #expect(unicodePlaceholder.token.hasPrefix("__MELIX_METRIC_melix_cli_測試_ms_"))
     }
 
     @Test("settings show resolves precedence and reports source metadata")


### PR DESCRIPTION
## Summary
- Add an ASCII fast path for Swift CLI metric placeholder-name sanitization.
- Preserve the existing Unicode `CharacterSet.alphanumerics` fallback for non-ASCII metric names.
- Extend the focused placeholder test to cover the Unicode fallback while keeping the token-shape assertion.

## Plan or Spec
- `docs/plans/2026-07-06-swift-cli-metric-name-ascii-fastpath.md`
- Registered PR-scoped probe: `swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ git diff --check
exit 0

$ swift --version && swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'
swift not installed
exit 127
```

## Coverage and Metrics
- Local coverage: N/A — this scheduled worker is Linux and does not have the Swift toolchain installed.
- Local metrics: N/A — Swift runtime performance is not validated locally on this Linux worker.
- CI-required metric source: the registered macOS PR-scoped performance probe `swift-cli-json-envelope-encoding` must complete successfully before merge.

## Known Gaps
- Swift tests/probe were not run locally because `swift` is not installed in the scheduled Linux environment.
- No Python/runtime behavior is changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A — no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A — no dependency changes.
- [ ] Relevant tests were run. Pending macOS CI; local Swift toolchain unavailable.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A — no observability-mode changes.
- [x] Deferred work and known gaps are stated explicitly.
