### PR TITLE
perf: bind dataset quality control lookups

### DIFF
--- a/docs/plans/2026-07-06-dataset-quality-controls-get-bind.md
+++ b/docs/plans/2026-07-06-dataset-quality-controls-get-bind.md
@@ -1,0 +1,22 @@
+# Dataset quality controls get binding performance slice
+
+This Python-only performance slice is limited to `worker.productization.dataset_preparation._quality_summary`.
+
+## Scope
+
+`_quality_summary` repeatedly reads values from the `quality_control_summary` mapping while building dataset version quality output. The slice keeps the output schema and quality scoring behavior unchanged while binding `quality_controls.get` once and reusing it for the source record, deduplication, and PII-mask fields.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. That registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries. The probe exercises `_quality_summary` over synthetic train and validation rows and also keeps the failed-segment partition metric in the same dataset-preparation hot-path report.
+
+## Validation plan
+
+This slice is Python-only and locally verifiable on Linux:
+
+1. Run the focused dataset preparation tests from the registered probe.
+2. Run changed-scope coverage over `dataset_preparation.py`, the dataset preparation tests, PR-scoped performance tests, and `scripts/dataset_quality_lengths_probe.py`.
+3. Run the registered `dataset-quality-lengths-chain` probe locally against `origin/main` and the branch with `scripts/pr_scoped_performance_run.py`.
+4. Use GitHub Actions PR-scoped performance as the merge gate after opening the PR.
+
+No Swift runtime behavior is changed.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1745,9 +1745,11 @@ def _quality_summary(
         validation_rows,
     )
     quality_controls = ingest_receipt.get("quality_control_summary", {})
-    source_record_count = float(quality_controls.get("source_record_count", 0) or 0)
-    exact_dedup_count = float(quality_controls.get("exact_dedup_count", 0) or 0)
-    fuzzy_dedup_count = float(quality_controls.get("fuzzy_dedup_count", 0) or 0)
+    quality_controls_get = quality_controls.get
+    source_record_count = float(quality_controls_get("source_record_count", 0) or 0)
+    exact_dedup_count = float(quality_controls_get("exact_dedup_count", 0) or 0)
+    fuzzy_dedup_count = float(quality_controls_get("fuzzy_dedup_count", 0) or 0)
+    pii_mask_count = int(quality_controls_get("pii_mask_count", 0) or 0)
     blocking_reasons = ["failed_generation"] if failed_count else []
     return {
         "schema_version": DATASET_QUALITY_SUMMARY_SCHEMA_VERSION,
@@ -1759,7 +1761,7 @@ def _quality_summary(
         "failed_count": failed_count,
         "train_count": train_count,
         "validation_count": validation_count,
-        "pii_mask_count": int(quality_controls.get("pii_mask_count", 0) or 0),
+        "pii_mask_count": pii_mask_count,
         "dedup_ratio": (exact_dedup_count + fuzzy_dedup_count) / source_record_count if source_record_count else 0,
         "mean_output_length": output_length_total / output_length_count if output_length_count else 0,
         "p95_output_length": p95_output_length,


### PR DESCRIPTION
## Summary
- Bind `quality_control_summary.get` once in `_quality_summary` and reuse it for source record, deduplication, and PII-mask fields.
- Keep dataset quality summary schema and scoring behavior unchanged.
- Add the governing performance-slice plan for the dataset quality controls lookup change.

## Plan or Spec
- `docs/plans/2026-07-06-dataset-quality-controls-get-bind.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# preflight/sync
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh auth status && GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh api user --jq .login
# login: Zigfreidish

git fetch origin && git reset --hard origin/main
# HEAD: c9d55292

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests
# 51 passed in 0.71s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# 51 passed in 1.35s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-quality-lengths-chain --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-quality-controls-get-bind-20260706 --head-repo "$PWD" --output /tmp/dataset_quality_controls_probe.json
# head verification: 54 passed in 1.53s; changed-scope coverage TOTAL 5 0 100%; base/head probes ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%` for `dataset_preparation.py` changed lines.
- Registered local probe `dataset-quality-lengths-chain`:
  - `elapsed_ms_mean`: base `2.571370 ms`, head `2.214897 ms`, delta `-0.356473 ms` (`13.86%` lower).
  - `elapsed_ms_p95`: base `2.615698 ms`, head `2.240684 ms`, delta `-0.375014 ms` (`14.34%` lower).
  - `failed_partition_elapsed_ms_mean`: base `1.289926 ms`, head `1.126303 ms`, delta `-0.163623 ms` (`12.68%` lower; same probe run, not directly changed by this slice).
  - Invariant metrics: `row_count=15000`, `mean_output_length=51.999`, `p95_output_length=100.0` for both base and head.
- CI PR-scoped performance is still required as the registered merge-gate validation.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR uses the registered focused Python probe/test/coverage gate and GitHub Actions as the broader merge gate.
- No Swift runtime effect is claimed; this is a Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
