### PR TITLE
perf: fast-path export diagnostic phrases

### DIFF
--- a/docs/plans/2026-07-06-export-diagnostic-common-phrase-fastpath.md
+++ b/docs/plans/2026-07-06-export-diagnostic-common-phrase-fastpath.md
@@ -1,0 +1,42 @@
+# Runtime export diagnostic common-phrase fast path
+
+## Scope
+
+This Python-only performance slice is limited to common runtime export diagnostic
+failure classification in
+`services/mlx-worker-python/worker/productization/export_target_diagnostics.py`.
+
+The affected path is covered by the registered PR-scoped performance probe
+`runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`. That
+probe has focused `test_command`, `coverage_command`, and `probe_command`
+entries and reports both aggregate diagnostic report latency and
+`diagnosis_matching_elapsed_ms_mean` for parser classification.
+
+## Optimization
+
+`_diagnoses_from_excerpt()` already lowercases each candidate log line and gates
+unrelated text with diagnosis markers. This slice adds a narrow fast phrase table
+for the most common literal runtime failure phrases emitted by fixtures and
+runtime smoke checks. When a phrase maps directly to a known diagnosis pattern,
+the parser emits the same diagnosis payload without walking the regex expression
+table for that line. Lines that do not hit the phrase table keep the existing
+marker and regex behavior unchanged.
+
+## Verification
+
+Local Linux validation for this slice must include:
+
+1. Focused export diagnostic tests from the registered probe.
+2. Changed-scope coverage from the registered probe.
+3. The registered `runtime-export-diagnostic-parser` probe command with local
+   metrics compared against the pre-change baseline.
+
+GitHub Actions PR-scoped performance remains the final registered probe
+validation and merge gate.
+
+## Success Criteria
+
+- Focused tests pass locally on Linux.
+- Changed-scope coverage for touched files is at least 95%.
+- The registered probe reports lower `diagnosis_matching_elapsed_ms_mean` with no
+  behavior regressions in diagnostic parser coverage.

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -51,6 +51,27 @@ FIXTURE_ROOT = (
 )
 
 
+def test_export_target_diagnostics_common_phrase_fast_path_skips_regex_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(export_target_diagnostics_module, "_DIAGNOSIS_PATTERNS", ())
+    source_lines = [
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text="runtime load failed while opening model",
+        )
+    ]
+
+    diagnoses = _diagnoses_from_excerpt(
+        source_lines,
+        {0: 1},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert [diagnosis["code"] for diagnosis in diagnoses] == [CODE_RUNTIME_LOAD_FAILED]
+    assert diagnoses[0]["matched_pattern_id"] == "runtime-load-failed-v1"
+
+
 def test_export_target_diagnostics_source_line_extension_matches_split_helper() -> None:
     lines: list[_SourceLine] = []
 
@@ -550,7 +571,7 @@ def test_export_target_diagnostics_preserves_overlap_priority_after_prior_match(
     ]
 
 
-def test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes(
+def test_export_target_diagnostics_runtime_load_fast_phrase_skips_regexes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     runtime_load_pattern = next(
@@ -590,7 +611,7 @@ def test_export_target_diagnostics_runtime_load_markers_skip_progress_regexes(
     )
 
     assert [diagnosis["code"] for diagnosis in diagnoses] == [CODE_RUNTIME_LOAD_FAILED]
-    assert [expression.search.call_count for expression in expressions] == [1, 1, 1, 0, 0]
+    assert [expression.search.call_count for expression in expressions] == [0, 0, 0, 0, 0]
 
 
 def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -280,6 +280,20 @@ _DIAGNOSIS_PATTERNS = (
 _DIAGNOSIS_MARKERS = tuple(
     dict.fromkeys(marker for pattern in _DIAGNOSIS_PATTERNS for marker in pattern.markers)
 )
+_DIAGNOSIS_PATTERN_BY_CODE = {pattern.code: pattern for pattern in _DIAGNOSIS_PATTERNS}
+_DIAGNOSIS_FAST_PHRASE_PATTERNS = (
+    ("unsupported architecture", _DIAGNOSIS_PATTERN_BY_CODE[CODE_UNSUPPORTED_ARCHITECTURE]),
+    ("bad cpu type", _DIAGNOSIS_PATTERN_BY_CODE[CODE_UNSUPPORTED_ARCHITECTURE]),
+    ("duplicate tensor", _DIAGNOSIS_PATTERN_BY_CODE[CODE_DUPLICATE_TENSOR_NAME]),
+    ("missing blob", _DIAGNOSIS_PATTERN_BY_CODE[CODE_MISSING_BLOB]),
+    ("runtime binary not installed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_MISSING_BINARY]),
+    ("invalid runtime path", _DIAGNOSIS_PATTERN_BY_CODE[CODE_INVALID_RUNTIME_PATH]),
+    ("timed out", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_TIMEOUT]),
+    ("permission denied", _DIAGNOSIS_PATTERN_BY_CODE[CODE_PERMISSION_DENIED]),
+    ("out of memory", _DIAGNOSIS_PATTERN_BY_CODE[CODE_INSUFFICIENT_MEMORY]),
+    ("runtime load failed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED]),
+    ("model load failed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED]),
+)
 
 
 def write_export_diagnostics_receipt(
@@ -804,6 +818,7 @@ def _diagnoses_from_excerpt(
     seen_codes: set[str] = set()
     seen_codes_add = seen_codes.add
     patterns = _DIAGNOSIS_PATTERNS
+    fast_phrase_patterns = _DIAGNOSIS_FAST_PHRASE_PATTERNS
     source_lines_local = source_lines
     has_diagnosis_marker = _has_diagnosis_marker
     remaining_known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
@@ -813,6 +828,28 @@ def _diagnoses_from_excerpt(
         text = source_lines_local[index].text
         lowered_text = text.lower()
         if not has_diagnosis_marker(lowered_text):
+            continue
+        fast_pattern = None
+        for phrase, pattern in fast_phrase_patterns:
+            if phrase in lowered_text:
+                pattern_code = pattern.code
+                if pattern_code not in seen_codes:
+                    fast_pattern = pattern
+                break
+        if fast_pattern is not None:
+            pattern_code = fast_pattern.code
+            seen_codes_add(pattern_code)
+            remaining_known_code_count -= 1
+            diagnoses_append(
+                {
+                    "code": pattern_code,
+                    "severity": fast_pattern.severity,
+                    "matched_pattern_id": fast_pattern.pattern_id,
+                    "operator_message": fast_pattern.operator_message,
+                    "remediation": fast_pattern.remediation,
+                    "evidence_path": f"{excerpt_path}#line-{line_number}",
+                }
+            )
             continue
         for pattern in patterns:
             pattern_code = pattern.code


### PR DESCRIPTION
## Summary
- Add a common-phrase fast path for runtime export diagnostic classification.
- Preserve the existing marker/regex parser fallback for non-fast-path log lines.
- Add regression coverage proving common runtime-load phrases bypass the regex table.

## Plan or Spec
- `docs/plans/2026-07-06-export-diagnostic-common-phrase-fastpath.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 80 passed in 0.65s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 80 passed in 1.51s; TOTAL 24 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# {"diagnosis_matching_elapsed_ms_mean": 0.40293159836437553, "diagnostic_parser_coverage": 1.0, "elapsed_ms_mean": 2636.228910999489, ...}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (24/24 measurable changed lines).
- Local registered probe baseline before the change: `diagnosis_matching_elapsed_ms_mean=0.5699394008843228`, `diagnostic_parser_coverage=1.0`, `elapsed_ms_mean=2628.6868036026135`.
- Local registered probe after the change: `diagnosis_matching_elapsed_ms_mean=0.40293159836437553`, `diagnostic_parser_coverage=1.0`, `elapsed_ms_mean=2636.228910999489`.
- Diagnostic matching delta: `-0.16700780251994725 ms` mean, about `29.30%` faster for the focused matching metric.
- CI PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR is verified with the focused registered probe commands on Linux and must use GitHub Actions as the full gate.
- No Swift runtime effect is claimed; this is a Python-only parser slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
