### PR TITLE
perf: skip configured metrics runtime discovery

### DIFF
--- a/docs/plans/2026-06-15-metrics-snapshot-final-path-materialization.md
+++ b/docs/plans/2026-06-15-metrics-snapshot-final-path-materialization.md
@@ -25,6 +25,14 @@ Avoid materializing a `Path` object each time the current newest directory entry
 changes during the scan. Keep the current best `DirEntry.path` string in the hot
 loop and construct the returned `Path` only once after the scan completes.
 
+## Follow-up slice: configured-source discovery elision
+
+When all metrics sources are explicitly configured by CLI arguments or
+environment variables, `resolve_source_paths()` has no runtime source names left
+to discover. Skip the batched runtime-discovery helper entirely in that case so
+the configured-source hot path avoids the extra empty dispatch/allocation while
+preserving the existing no-`os.scandir()` behavior.
+
 ## Verification plan
 
 Run the registered focused tests, changed-scope coverage command, and registered

--- a/scripts/melix_metrics_snapshot.py
+++ b/scripts/melix_metrics_snapshot.py
@@ -199,7 +199,11 @@ def resolve_source_paths(
 
         runtime_source_names.append(name)
 
-    runtime_paths = discover_latest_metrics_paths(runtime_dir, tuple(runtime_source_names))
+    runtime_paths = (
+        discover_latest_metrics_paths(runtime_dir, tuple(runtime_source_names))
+        if runtime_source_names
+        else {}
+    )
     for name in runtime_source_names:
         runtime_path = runtime_paths[name]
         if runtime_path is not None:

--- a/tests/test_melix_metrics_snapshot.py
+++ b/tests/test_melix_metrics_snapshot.py
@@ -268,7 +268,17 @@ def test_resolve_source_paths_skips_runtime_scan_when_all_sources_are_configured
     def fail_scandir(path: object):  # pragma: no cover - regression guard
         raise AssertionError(f"runtime scan should be skipped when all sources are configured: {path!r}")
 
+    def fail_runtime_discovery(
+        runtime_dir: Path | None,
+        source_names: tuple[str, ...],
+    ):  # pragma: no cover - regression guard
+        raise AssertionError(
+            "runtime discovery should be skipped when all sources are configured: "
+            f"{runtime_dir!r} {source_names!r}"
+        )
+
     monkeypatch.setattr(snapshot_cli.os, "scandir", fail_scandir)
+    monkeypatch.setattr(snapshot_cli, "discover_latest_metrics_paths", fail_runtime_discovery)
 
     resolved = snapshot_cli.resolve_source_paths(
         swift_text_worker_metrics=swift_worker_arg_path,


### PR DESCRIPTION
## Summary
- Skip the batched runtime metrics discovery helper when all metrics sources are already configured by arguments or environment.
- Add a regression guard proving the all-configured path avoids both `os.scandir()` and runtime-discovery dispatch.
- Document the configured-source discovery elision follow-up slice in the governing metrics snapshot plan.

## Plan or Spec
- `docs/plans/2026-06-15-metrics-snapshot-final-path-materialization.md`
- Registered PR-scoped probe: `melix-metrics-snapshot-runtime-scandir` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# Baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/melix_metrics_snapshot_discovery_probe.py
=> exit 0; {"configured_elapsed_ms_mean": 0.021474, "configured_elapsed_ms_min": 0.013725, "elapsed_ms_mean": 11.140888, "elapsed_ms_min": 10.132193, "file_count": 4000.0, "noise_count": 200.0, "sample_count": 9.0, "source_count": 3.0}

# Registered focused test_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovers_latest_metrics_files tests/test_melix_metrics_snapshot.py::test_runtime_pattern_matcher_preserves_source_patterns_without_fnmatch tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_uses_single_scandir_without_path_glob tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_materializes_only_final_latest_path tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_discovers_runtime_sources_with_one_scandir tests/test_melix_metrics_snapshot.py::test_resolve_source_paths_skips_runtime_scan_when_all_sources_are_configured tests/test_melix_metrics_snapshot.py::test_runtime_dir_discovery_preserves_exact_and_multi_wildcard_patterns tests/test_melix_metrics_snapshot.py::test_batched_runtime_discovery_preserves_overlapping_source_matches services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_melix_metrics_snapshot_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_melix_metrics_snapshot_discovery_probe_script_emits_metrics
=> exit 0; 11 passed in 1.71s

# Registered coverage_command from infra/perf/pr_scoped_probes.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/melix_metrics_snapshot.py scripts/melix_metrics_snapshot_discovery_probe.py tests/test_melix_metrics_snapshot.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
=> exit 0; 11 passed in 0.99s; TOTAL 2 0 100%

# Head probe script after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/melix_metrics_snapshot_discovery_probe.py
=> exit 0; {"configured_elapsed_ms_mean": 0.018194, "configured_elapsed_ms_min": 0.013385, "elapsed_ms_mean": 10.5911, "elapsed_ms_min": 10.128757, "file_count": 4000.0, "noise_count": 200.0, "sample_count": 9.0, "source_count": 3.0}

# Registered probe_command from infra/perf/pr_scoped_probes.json
<registered melix-metrics-snapshot-runtime-scandir probe_command>
=> exit 0; {"configured_elapsed_ms_mean": 0.018842, "configured_elapsed_ms_min": 0.013114, "elapsed_ms_mean": 12.485803, "elapsed_ms_min": 11.198363, "file_count": 4000.0, "noise_count": 200.0, "sample_count": 9.0, "source_count": 3.0}

git diff --check
=> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` from the registered coverage command.
- Local before/after script probe: `configured_elapsed_ms_mean` improved from `0.021474` ms to `0.018194` ms (`-0.003280` ms, ~15.3% faster); `configured_elapsed_ms_min` improved from `0.013725` ms to `0.013385` ms.
- Runtime-discovery scan path is intentionally unchanged by this slice; local samples are noisy (`elapsed_ms_mean` after registered command was slower in one run), so the PR-scoped performance workflow remains the merge gate for registered probe validation.

## Known Gaps
- Linux local verification covers the Python metrics snapshot path only.
- No Swift runtime effects are claimed.
- Full repository gates are deferred to GitHub Actions; merge waits for green checks and the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
