### PR TITLE
perf: inline deterministic embedding digest square sum

### DIFF
--- a/docs/plans/2026-07-06-embedding-digest-inline-sum.md
+++ b/docs/plans/2026-07-06-embedding-digest-inline-sum.md
@@ -1,0 +1,40 @@
+# Deterministic embedding digest inline square sum
+
+## Scope
+
+This Python-only performance slice targets deterministic embedding projection in
+`services/mlx-worker-python/worker/runtime/embedding_backends.py`.
+
+The affected path is covered by the registered PR-scoped performance probe
+`deterministic-embedding-project-digest-allocation` in
+`infra/perf/pr_scoped_probes.json`. The registry entry has focused
+`test_command`, `coverage_command`, and `probe_command` entries that exercise the
+embedding runtime behavior, changed-scope coverage, and digest projection metrics.
+
+## Optimization
+
+`DeterministicEmbeddingBackend._project_digest(...)` always projects eight
+SHA-256 digest lanes before either returning the default 8-dimensional vector or
+expanding those lanes to larger dimensions. This slice replaces the repeated
+`sum(value * value for value in base_values)` generator path with an explicit
+8-lane square-sum helper while preserving the existing in-place normalization
+shape for the default-dimension path.
+
+The generated vector values, allocation profile, and zero-norm fallback remain
+unchanged.
+
+## Verification plan
+
+1. Run the focused embedding parity tests and registered probe smoke tests from
+   the probe registry.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered `deterministic_embedding_project_digest_probe.py` probe
+   locally before and after the change and compare both default-dimension and
+   expanded-dimension metrics.
+4. Use GitHub Actions PR-scoped performance as the final registered probe merge
+   gate.
+
+## Verification boundary
+
+This is a Python-only slice and is locally verifiable on Linux. The PR-scoped CI
+probe report remains the required merge gate before merging.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -13,6 +13,20 @@ _UNPACK_DIGEST_UINT32 = struct.Struct("<8I").unpack
 _DIGEST_UINT32_SCALE = 2.0 / 0xFFFFFFFF
 
 
+def _sum_squares_8(values: list[float]) -> float:
+    value0, value1, value2, value3, value4, value5, value6, value7 = values
+    return (
+        value0 * value0
+        + value1 * value1
+        + value2 * value2
+        + value3 * value3
+        + value4 * value4
+        + value5 * value5
+        + value6 * value6
+        + value7 * value7
+    )
+
+
 @dataclass(frozen=True)
 class EmbeddingBackendDescriptor:
     backend_id: str
@@ -61,7 +75,7 @@ class DeterministicEmbeddingBackend:
             for raw in _UNPACK_DIGEST_UINT32(_sha256(seed_text.encode("utf-8")).digest())
         ]
         if dimensions == 8:
-            l2_norm = _sqrt(sum(value * value for value in base_values))
+            l2_norm = _sqrt(_sum_squares_8(base_values))
             if l2_norm == 0.0:
                 return [0.0] * 8
             inverse_l2_norm = 1.0 / l2_norm
@@ -79,7 +93,7 @@ class DeterministicEmbeddingBackend:
         _round=_ROUND,
     ) -> list[float]:
         full_repeats, remainder = divmod(dimensions, 8)
-        squared_sum = sum(value * value for value in base_values) * full_repeats
+        squared_sum = _sum_squares_8(base_values) * full_repeats
         if remainder == 1:
             value = base_values[0]
             squared_sum += value * value


### PR DESCRIPTION
## Summary
- Inline the deterministic embedding digest 8-lane square-sum path to avoid repeated generator allocation during projection normalization.
- Preserve legacy digest projection values and the existing default-dimension allocation profile.

## Plan or Spec
- `docs/plans/2026-07-06-embedding-digest-inline-sum.md`
- Registered PR-scoped probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe on origin/main before code changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
exit 0; elapsed_ms_mean=17.144263; default_dimension_elapsed_ms_mean=118.779816; default_dimension_peak_bytes_mean=1093.333333; checksum=8.325108; default_dimension_checksum=213.60249

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
exit 0; 21 passed in 14.63s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
exit 0; 21 passed in 49.86s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
exit 0; elapsed_ms_mean=15.261855; default_dimension_elapsed_ms_mean=106.16257; default_dimension_peak_bytes_mean=989.333333; checksum=8.325108; default_dimension_checksum=213.60249

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `embedding_backends.py` and registered probe/test files.
- Local Linux registered probe metrics:
  - expanded projection: `elapsed_ms_mean` 17.144263 -> 15.261855 ms (delta -1.882408 ms, ~11.0% faster)
  - default 8D projection: `default_dimension_elapsed_ms_mean` 118.779816 -> 106.162570 ms (delta -12.617246 ms, ~10.6% faster)
  - default peak bytes: 1093.333333 -> 989.333333 bytes (delta -104 bytes, ~9.5% lower)
  - parity checksums unchanged: `checksum=8.325108`, `default_dimension_checksum=213.60249`
- CI PR-scoped performance is still required as the final registered probe validation before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused tests, changed-scope coverage, and registered probe command on Linux.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
