### PR TITLE
Emit resolved acceleration config receipts

### DIFF
--- a/apps/macos-menubar/Tests/MenuBarTests/ProductInstallStateTests.swift
+++ b/apps/macos-menubar/Tests/MenuBarTests/ProductInstallStateTests.swift
@@ -262,8 +262,12 @@ struct ProductInstallStateTests {
     }
 
     @Test("filesystem provider returns nil without a resolvable manifest")
-    func returnsNilWithoutResolvableManifest() {
-        let provider = FilesystemProductInstallStateProvider(environment: ["HOME": ""])
+    func returnsNilWithoutResolvableManifest() throws {
+        let temporaryRoot = try makeTemporaryRoot(prefix: "melix-missing-manifest")
+        let manifestURL = temporaryRoot.appendingPathComponent("missing-install-manifest.json")
+        defer { try? FileManager.default.removeItem(at: temporaryRoot) }
+
+        let provider = FilesystemProductInstallStateProvider(manifestURL: manifestURL)
 
         #expect(provider.updateStatus() == nil)
         #expect(provider.startupFailureDiagnostic(for: MenuBarTestError(description: "handshake failed")) == nil)

--- a/docs/plans/2026-07-06-issue-350-resolved-acceleration-config.md
+++ b/docs/plans/2026-07-06-issue-350-resolved-acceleration-config.md
@@ -1,0 +1,124 @@
+# Issue 350 Resolved Acceleration Config Receipt Plan
+
+## Goal
+
+Normalize low-level serving acceleration knobs into one typed diagnostics-only
+`ResolvedAccelerationConfig` receipt before changing runtime acceleration
+behavior.
+
+## Scope
+
+This slice implements the next executable #350 step from the July 6 watch
+update: add a control-plane fixture that normalizes existing low-level
+acceleration fields into a single resolved config receipt, then wire that
+receipt into diagnostics metadata.
+
+In scope:
+
+- Define a control-plane `ResolvedAccelerationConfig` value derived from the
+  already-resolved worker acceleration policy, capability receipt, and profile
+  admission receipt.
+- Emit `melix.serving.acceleration_config.*` metadata from the existing request
+  acceleration resolution path.
+- Materialize a top-level `serving_acceleration_config` receipt in Python
+  serving diagnostics when upstream metadata is complete.
+- Cover baseline, admitted speculative, forced-off speculative, unsupported
+  mode, invalid draft, and unverified-profile rows in tests.
+- Document the receipt shape and passive diagnostics contract.
+
+Out of scope:
+
+- New protobuf fields or generated artifacts.
+- New acceleration algorithms, scheduler behavior, controller state, or output
+  hashing behavior.
+- Model discovery, optional dependency probing, health polling, prefetch, or
+  route admission during bundle writing.
+- Changing existing fallback/refusal semantics.
+
+## End-State Architecture
+
+The best Melix end state is one acceleration contract shared by parser,
+profile, admission, runtime launch, diagnostics, and benchmark evidence. Low
+level fields such as `accelerationMode`, `draftModelID`, `numDraftTokens`,
+profile id, and route policy should be parsed once into a typed resolved config
+with explicit method, sidecar model, token count, conflicts, controller scope,
+and disabled reason. Runtime controllers can later consume the same contract
+without guessing from legacy flags.
+
+This slice only builds the observable receipt boundary. The existing
+`RequestCoordinator` still owns runtime dispatch, and
+`ModelCapabilityReceipts` remains the model/profile admission source of truth.
+The diagnostics writer stays passive and records only metadata supplied by
+upstream control-plane code.
+
+## Receipt Mapping
+
+The control plane should emit:
+
+- `melix.serving.acceleration_config.schema_version`:
+  `melix.resolved_acceleration_config.v1`
+- `melix.serving.acceleration_config.method`: effective method such as
+  `baseline`, `speculative_decode`, `accelerated_prefill`,
+  `active_kv_quantized`, or `sparse_prefill`.
+- `melix.serving.acceleration_config.requested_method`: operator/model
+  requested method after parser normalization.
+- `melix.serving.acceleration_config.sidecar_model`: draft/sidecar model id, or
+  an empty string.
+- `melix.serving.acceleration_config.num_speculative_tokens`: resolved draft
+  token count as a decimal string.
+- `melix.serving.acceleration_config.profile`: resolved or requested serving
+  acceleration profile.
+- `melix.serving.acceleration_config.conflicting_flags`: comma-separated flags
+  ignored or rejected during resolution.
+- `melix.serving.acceleration_config.controller_scope`: `none` for baseline and
+  `request` for speculative requests in this slice.
+- `melix.serving.acceleration_config.disabled_reason`: typed reason for a
+  disabled or refused acceleration path, or `none`.
+
+Python diagnostics materializes the same fields under
+`serving_acceleration_config`, converting `conflicting_flags` to a list and
+`num_speculative_tokens` to an integer.
+
+## Test Plan
+
+Follow TDD:
+
+1. Add Swift RED tests in `ModelCatalogTests` proving
+   `ResolvedAccelerationConfig` normalizes baseline, admitted speculative,
+   forced-off speculative, invalid draft, unsupported mode, and unverified
+   profile rows.
+2. Add a Swift RED request-coordinator test proving dispatched worker metadata
+   contains the `melix.serving.acceleration_config.*` receipt for an admitted
+   speculative request.
+3. Add a Python RED diagnostics test proving complete metadata materializes as
+   `serving_acceleration_config`, with list and integer normalization.
+4. Implement the minimal Swift helper and RequestCoordinator wire-up.
+5. Implement the passive Python diagnostics materializer.
+6. Update `docs/runbooks/serving-diagnostics-evidence.md`.
+
+Focused verification commands:
+
+```bash
+xcrun swift test --no-parallel --package-path services/control-plane-swift --filter ModelCatalogTests/resolvedAccelerationConfigReceiptNormalizesLowLevelAccelerationFields
+xcrun swift test --no-parallel --package-path services/control-plane-swift --filter RequestCoordinatorTests/gatewaySpeculativeDefaultsPopulateWorkerAccelerationWhenModelDefaultsAreUnspecified
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py
+```
+
+Before commit, run `git diff --check` and `.githooks/pre-commit` for the full
+local gate and scoped performance report on this host.
+
+## Performance And Metrics
+
+Performance probe points:
+
+- Metadata construction happens once per request during existing acceleration
+  resolution.
+- Python bundle materialization performs one additional metadata scan over the
+  same existing metadata sources.
+
+Success metrics:
+
+- Focused Swift and Python tests pass.
+- Full pre-commit local gate passes.
+- Scoped performance report status is `ok` with 0 regressions before commit and
+  on the PR.

--- a/docs/runbooks/serving-diagnostics-evidence.md
+++ b/docs/runbooks/serving-diagnostics-evidence.md
@@ -228,6 +228,48 @@ draft is missing or refused, `acceleration_mode` when the requested mode or
 acceleration capability is unsupported, and `acceleration_profile` when profile
 admission is refused after acceleration capability admission succeeds.
 
+When upstream serving code has normalized low-level acceleration fields into one
+typed config contract, `effective-config.json` should also include a
+`serving_acceleration_config` receipt. This receipt is diagnostics-only: it
+records the already-resolved control-plane parser and admission result and must
+not start an acceleration controller, probe optional runtimes, load a sidecar,
+or alter fallback behavior during bundle writing.
+
+`serving_acceleration_config` fields:
+
+- `schema_version` - `melix.resolved_acceleration_config.v1`.
+- `method` - effective acceleration method, such as `baseline` or
+  `speculative_decode`.
+- `requested_method` - requested method after compatibility normalization.
+- `sidecar_model` - resolved draft or companion model id, or an empty string.
+- `num_speculative_tokens` - resolved speculative token count.
+- `profile` - serving acceleration profile tied to the resolved config.
+- `conflicting_flags` - low-level flags or overrides rejected, suppressed, or
+  ignored during config resolution.
+- `controller_scope` - `request` for request-scoped speculative controllers or
+  `none` when no controller is active.
+- `disabled_reason` - typed reason for a disabled or refused acceleration path,
+  or `none`.
+
+Diagnostics writers may derive `serving_acceleration_config` from namespaced
+metadata when all of these keys are present:
+
+- `melix.serving.acceleration_config.schema_version`
+- `melix.serving.acceleration_config.method`
+- `melix.serving.acceleration_config.requested_method`
+- `melix.serving.acceleration_config.sidecar_model`
+- `melix.serving.acceleration_config.num_speculative_tokens`
+- `melix.serving.acceleration_config.profile`
+- `melix.serving.acceleration_config.conflicting_flags`
+- `melix.serving.acceleration_config.controller_scope`
+- `melix.serving.acceleration_config.disabled_reason`
+
+The `conflicting_flags` metadata value is a comma-separated list. Empty list
+items are ignored. `num_speculative_tokens` must be a decimal integer. If any
+required key is missing or the token count is invalid, the writer leaves the
+original metadata in place and does not synthesize a partial top-level
+`serving_acceleration_config` receipt.
+
 When a proxy, workspace-ingest, or worker path has already evaluated network
 fetch safety, `effective-config.json` may include a `network_fetch_policy`
 receipt and `privacy_audit_counters`. These receipts are diagnostics-only:

--- a/services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
+++ b/services/control-plane-swift/Sources/ModelCatalog/ModelCapabilityReceipts.swift
@@ -26,6 +26,19 @@ public struct ServingProfileAdmissionReceipt: Sendable, Equatable {
     }
 }
 
+public struct ResolvedAccelerationConfig: Sendable, Equatable {
+    public static let schemaVersion = "melix.resolved_acceleration_config.v1"
+
+    public let method: String
+    public let requestedMethod: String
+    public let sidecarModel: String
+    public let numSpeculativeTokens: UInt32
+    public let profile: String
+    public let conflictingFlags: [String]
+    public let controllerScope: String
+    public let disabledReason: String
+}
+
 public enum ModelCapabilityReceipts {
     public static let schemaVersion = "melix.model_capability_receipt.v1"
 
@@ -332,6 +345,114 @@ public enum ModelCapabilityReceipts {
             "melix.acceleration.profile.fallback_reason": receipt.fallbackReason,
             "melix.acceleration.profile.recovery_hint": receipt.recoveryHint,
         ]
+    }
+
+    public static func resolvedAccelerationConfig(
+        for acceleration: Melix_Worker_V1_AccelerationPolicy,
+        executionMetadata: [String: String],
+        validation: AccelerationReceiptValidation
+    ) -> ResolvedAccelerationConfig {
+        let disabledReason = resolvedAccelerationDisabledReason(
+            validation: validation,
+            executionMetadata: executionMetadata
+        )
+        let conflictingFlags = resolvedAccelerationConflictingFlags(
+            receipt: validation.receipt,
+            profileReceipt: validation.profileReceipt,
+            executionMetadata: executionMetadata
+        )
+        let requestedMethod = resolvedAccelerationRequestedMethod(
+            receipt: validation.receipt,
+            conflictingFlags: conflictingFlags
+        )
+        let disabled = disabledReason != "none"
+        let method = disabled
+            ? "baseline"
+            : accelerationModeIdentifier(validation.receipt.resolvedAccelerationMode)
+        let sidecarModel = method == "speculative_decode"
+            ? acceleration.draftModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+            : ""
+        let numSpeculativeTokens = method == "speculative_decode"
+            ? acceleration.numDraftTokens
+            : 0
+        return ResolvedAccelerationConfig(
+            method: method,
+            requestedMethod: requestedMethod,
+            sidecarModel: sidecarModel,
+            numSpeculativeTokens: numSpeculativeTokens,
+            profile: servingCapabilityAccelerationProfile(validation.profileReceipt),
+            conflictingFlags: conflictingFlags,
+            controllerScope: method == "speculative_decode" ? "request" : "none",
+            disabledReason: disabledReason
+        )
+    }
+
+    public static func resolvedAccelerationConfigAuditMetadata(
+        _ config: ResolvedAccelerationConfig
+    ) -> [String: String] {
+        [
+            "melix.serving.acceleration_config.schema_version": ResolvedAccelerationConfig.schemaVersion,
+            "melix.serving.acceleration_config.method": config.method,
+            "melix.serving.acceleration_config.requested_method": config.requestedMethod,
+            "melix.serving.acceleration_config.sidecar_model": config.sidecarModel,
+            "melix.serving.acceleration_config.num_speculative_tokens": String(config.numSpeculativeTokens),
+            "melix.serving.acceleration_config.profile": config.profile,
+            "melix.serving.acceleration_config.conflicting_flags": config.conflictingFlags.joined(separator: ","),
+            "melix.serving.acceleration_config.controller_scope": config.controllerScope,
+            "melix.serving.acceleration_config.disabled_reason": config.disabledReason,
+        ]
+    }
+
+    private static func resolvedAccelerationDisabledReason(
+        validation: AccelerationReceiptValidation,
+        executionMetadata: [String: String]
+    ) -> String {
+        if let disabledReason = executionMetadata["melix.gateway.speculative.disabled_reason"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty,
+            disabledReason != "none" {
+            return disabledReason
+        }
+        guard !validation.ok else {
+            return "none"
+        }
+        if validation.receipt.state != .capabilitySupported {
+            let reason = unsupportedReasonIdentifier(validation.unsupportedReason)
+            return reason == "none" ? "unsupported_mode" : reason
+        }
+        return validation.profileReceipt.fallbackReason.nilIfEmpty
+            ?? validation.profileReceipt.profileAdmissionStatus.nilIfEmpty
+            ?? "experimental_unverified"
+    }
+
+    private static func resolvedAccelerationConflictingFlags(
+        receipt: Melix_Controlplane_V1_AccelerationCapabilityReceipt,
+        profileReceipt: ServingProfileAdmissionReceipt,
+        executionMetadata: [String: String]
+    ) -> [String] {
+        var flags = servingCapabilityIgnoredFlags(receipt, profileReceipt: profileReceipt)
+        for flag in parsedList(executionMetadata["melix.gateway.suppressed_overrides"]) {
+            appendUnique(flag, to: &flags)
+        }
+        return flags
+    }
+
+    private static func resolvedAccelerationRequestedMethod(
+        receipt: Melix_Controlplane_V1_AccelerationCapabilityReceipt,
+        conflictingFlags: [String]
+    ) -> String {
+        if conflictingFlags.contains("speculative_decode") {
+            return "speculative_decode"
+        }
+        return accelerationModeIdentifier(receipt.requestedAccelerationMode)
+    }
+
+    private static func appendUnique(_ value: String, to values: inout [String]) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !values.contains(trimmed) else {
+            return
+        }
+        values.append(trimmed)
     }
 
     private static func servingCapabilityAccelerationProfile(

--- a/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
+++ b/services/control-plane-swift/Sources/Requests/RequestCoordinator.swift
@@ -2077,12 +2077,22 @@ public actor RequestCoordinator {
         )
         let receipt = validation.receipt
         let accelerationRefusal: AccelerationReceiptValidation? = validation.ok ? nil : validation
+        var accelerationMetadata = ModelCapabilityReceipts.accelerationAuditMetadata(
+            receipt,
+            profileReceipt: validation.profileReceipt,
+            model: model
+        )
+        let resolvedAccelerationConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: workerRequest.execution.acceleration,
+            executionMetadata: workerRequest.execution.ext,
+            validation: validation
+        )
+        accelerationMetadata.merge(
+            ModelCapabilityReceipts.resolvedAccelerationConfigAuditMetadata(resolvedAccelerationConfig),
+            uniquingKeysWith: { _, receiptValue in receiptValue }
+        )
         workerRequest.execution.ext.merge(
-            ModelCapabilityReceipts.accelerationAuditMetadata(
-                receipt,
-                profileReceipt: validation.profileReceipt,
-                model: model
-            ),
+            accelerationMetadata,
             uniquingKeysWith: { _, receiptValue in receiptValue }
         )
 

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ModelCatalogTests.swift
@@ -440,6 +440,149 @@ struct ModelCatalogTests {
         #expect(metadata["melix.serving.capability.output_modalities"] == "text,audio,image")
     }
 
+    @Test("resolved acceleration config receipt normalizes low-level acceleration fields")
+    func resolvedAccelerationConfigReceiptNormalizesLowLevelAccelerationFields() async throws {
+        let baselineValidation = ModelCapabilityReceipts.validateAcceleration(
+            model: ModelCatalog.devTextModel(),
+            requestedMode: .baseline,
+            draftModelID: "",
+            requestedProfileID: "balanced"
+        )
+        var baselinePolicy = Melix_Worker_V1_AccelerationPolicy()
+        baselinePolicy.mode = .baseline
+        baselinePolicy.profileID = "balanced"
+
+        let baselineConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: baselinePolicy,
+            executionMetadata: [:],
+            validation: baselineValidation
+        )
+        #expect(baselineConfig.method == "baseline")
+        #expect(baselineConfig.requestedMethod == "baseline")
+        #expect(baselineConfig.sidecarModel == "")
+        #expect(baselineConfig.numSpeculativeTokens == 0)
+        #expect(baselineConfig.profile == "balanced")
+        #expect(baselineConfig.conflictingFlags == [])
+        #expect(baselineConfig.controllerScope == "none")
+        #expect(baselineConfig.disabledReason == "none")
+
+        let forcedOffConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: baselinePolicy,
+            executionMetadata: [
+                "melix.gateway.suppressed_overrides": "speculative_decode",
+                "melix.gateway.speculative.disabled_reason": "operator_disabled",
+            ],
+            validation: baselineValidation
+        )
+        #expect(forcedOffConfig.method == "baseline")
+        #expect(forcedOffConfig.requestedMethod == "speculative_decode")
+        #expect(forcedOffConfig.conflictingFlags == ["speculative_decode"])
+        #expect(forcedOffConfig.controllerScope == "none")
+        #expect(forcedOffConfig.disabledReason == "operator_disabled")
+
+        var admittedModel = ModelCatalog.devTextModel()
+        admittedModel.settings.ext["melix.acceleration.supported_modes"] = "baseline,speculative_decode"
+        admittedModel.settings.ext["melix.acceleration.valid_draft_model_ids"] = "melix-dev-draft"
+        admittedModel.settings.ext["melix.acceleration.target_capability"] = "speculative_decode"
+        admittedModel.settings.ext["melix.acceleration.drafter_capability"] = "speculative_draft"
+        admittedModel.settings.ext["melix.acceleration.profile.proof_matrix_id"] = "profile-proof-throughput-v1"
+        admittedModel.settings.ext["melix.acceleration.profile.verification_status"] = "passed"
+        let admittedValidation = ModelCapabilityReceipts.validateAcceleration(
+            model: admittedModel,
+            requestedMode: .speculativeDecode,
+            draftModelID: "melix-dev-draft",
+            requestedProfileID: "throughput"
+        )
+        var speculativePolicy = Melix_Worker_V1_AccelerationPolicy()
+        speculativePolicy.mode = .speculativeDecode
+        speculativePolicy.profileID = "throughput"
+        speculativePolicy.draftModelID = "melix-dev-draft"
+        speculativePolicy.numDraftTokens = 6
+
+        let admittedConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: speculativePolicy,
+            executionMetadata: [:],
+            validation: admittedValidation
+        )
+        #expect(admittedConfig.method == "speculative_decode")
+        #expect(admittedConfig.requestedMethod == "speculative_decode")
+        #expect(admittedConfig.sidecarModel == "melix-dev-draft")
+        #expect(admittedConfig.numSpeculativeTokens == 6)
+        #expect(admittedConfig.profile == "throughput")
+        #expect(admittedConfig.conflictingFlags == [])
+        #expect(admittedConfig.controllerScope == "request")
+        #expect(admittedConfig.disabledReason == "none")
+
+        let admittedMetadata = ModelCapabilityReceipts.resolvedAccelerationConfigAuditMetadata(admittedConfig)
+        #expect(admittedMetadata["melix.serving.acceleration_config.schema_version"] == "melix.resolved_acceleration_config.v1")
+        #expect(admittedMetadata["melix.serving.acceleration_config.method"] == "speculative_decode")
+        #expect(admittedMetadata["melix.serving.acceleration_config.sidecar_model"] == "melix-dev-draft")
+        #expect(admittedMetadata["melix.serving.acceleration_config.num_speculative_tokens"] == "6")
+        #expect(admittedMetadata["melix.serving.acceleration_config.controller_scope"] == "request")
+
+        var invalidDraftModel = admittedModel
+        invalidDraftModel.settings.ext["melix.acceleration.valid_draft_model_ids"] = "melix-dev-draft"
+        let invalidDraftValidation = ModelCapabilityReceipts.validateAcceleration(
+            model: invalidDraftModel,
+            requestedMode: .speculativeDecode,
+            draftModelID: "other-draft",
+            requestedProfileID: "throughput"
+        )
+        speculativePolicy.draftModelID = "other-draft"
+        let invalidDraftConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: speculativePolicy,
+            executionMetadata: [:],
+            validation: invalidDraftValidation
+        )
+        #expect(invalidDraftConfig.method == "baseline")
+        #expect(invalidDraftConfig.requestedMethod == "speculative_decode")
+        #expect(invalidDraftConfig.sidecarModel == "")
+        #expect(invalidDraftConfig.numSpeculativeTokens == 0)
+        #expect(invalidDraftConfig.profile == "throughput")
+        #expect(invalidDraftConfig.conflictingFlags == ["draft_model_id"])
+        #expect(invalidDraftConfig.disabledReason == "draft_model_not_allowed")
+
+        var unsupportedModePolicy = Melix_Worker_V1_AccelerationPolicy()
+        unsupportedModePolicy.mode = .acceleratedPrefill
+        unsupportedModePolicy.profileID = "balanced"
+        let unsupportedModeValidation = ModelCapabilityReceipts.validateAcceleration(
+            model: ModelCatalog.devTextModel(),
+            requestedMode: .acceleratedPrefill,
+            draftModelID: "",
+            requestedProfileID: "balanced"
+        )
+        let unsupportedModeConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: unsupportedModePolicy,
+            executionMetadata: [:],
+            validation: unsupportedModeValidation
+        )
+        #expect(unsupportedModeConfig.method == "baseline")
+        #expect(unsupportedModeConfig.requestedMethod == "accelerated_prefill")
+        #expect(unsupportedModeConfig.conflictingFlags == ["acceleration_mode"])
+        #expect(unsupportedModeConfig.disabledReason == "unsupported_mode")
+
+        var unverifiedProfileModel = admittedModel
+        unverifiedProfileModel.settings.ext["melix.acceleration.profile.proof_matrix_id"] = ""
+        unverifiedProfileModel.settings.ext["melix.acceleration.profile.verification_status"] = ""
+        let unverifiedProfileValidation = ModelCapabilityReceipts.validateAcceleration(
+            model: unverifiedProfileModel,
+            requestedMode: .speculativeDecode,
+            draftModelID: "melix-dev-draft",
+            requestedProfileID: "throughput"
+        )
+        speculativePolicy.draftModelID = "melix-dev-draft"
+        let unverifiedProfileConfig = ModelCapabilityReceipts.resolvedAccelerationConfig(
+            for: speculativePolicy,
+            executionMetadata: [:],
+            validation: unverifiedProfileValidation
+        )
+        #expect(unverifiedProfileConfig.method == "baseline")
+        #expect(unverifiedProfileConfig.requestedMethod == "speculative_decode")
+        #expect(unverifiedProfileConfig.profile == "throughput")
+        #expect(unverifiedProfileConfig.conflictingFlags == ["acceleration_profile"])
+        #expect(unverifiedProfileConfig.disabledReason == "experimental_unverified")
+    }
+
     @Test("capability receipt validation refuses invalid drafts and inconsistent speculative metadata")
     func capabilityReceiptValidationRefusesInvalidDraftsAndInconsistentSpeculativeMetadata() async throws {
         var model = ModelCatalog.devTextModel()

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/RequestCoordinatorTests.swift
@@ -4603,6 +4603,15 @@ struct RequestCoordinatorTests {
         #expect(prefillRequest.execution.ext["melix.serving.capability.unsupported_reason"] == "none")
         #expect(prefillRequest.execution.ext["melix.serving.capability.ignored_flags"] == "")
         #expect(prefillRequest.execution.ext["melix.serving.capability.fallback_policy"] == "observable_fallback")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.schema_version"] == "melix.resolved_acceleration_config.v1")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.method"] == "speculative_decode")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.requested_method"] == "speculative_decode")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.sidecar_model"] == "melix-dev-text")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.num_speculative_tokens"] == "7")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.profile"] == "throughput")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.conflicting_flags"] == "")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.controller_scope"] == "request")
+        #expect(prefillRequest.execution.ext["melix.serving.acceleration_config.disabled_reason"] == "none")
 
         await workerClient.emitDecodeStarted(
             requestID: "req-gateway-speculative-defaults",

--- a/services/mlx-worker-python/tests/test_serving_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_serving_diagnostics.py
@@ -550,6 +550,80 @@ def test_serving_diagnostics_effective_config_materializes_control_plane_capabil
     }
 
 
+def test_serving_diagnostics_effective_config_derives_acceleration_config_receipt_from_metadata(
+    tmp_path: Path,
+) -> None:
+    paths = write_serving_diagnostics_bundle(
+        output_root=tmp_path,
+        bundle_id="diag-control-plane-acceleration-config",
+        invocation={},
+        effective_config={
+            "execution_ext": {
+                "melix.serving.acceleration_config.schema_version": (
+                    "melix.resolved_acceleration_config.v1"
+                ),
+                "melix.serving.acceleration_config.method": "speculative_decode",
+                "melix.serving.acceleration_config.requested_method": (
+                    "speculative_decode"
+                ),
+                "melix.serving.acceleration_config.sidecar_model": (
+                    "melix-dev-draft"
+                ),
+                "melix.serving.acceleration_config.num_speculative_tokens": "6",
+                "melix.serving.acceleration_config.profile": "throughput",
+                "melix.serving.acceleration_config.conflicting_flags": (
+                    "draft_model_id, acceleration_profile"
+                ),
+                "melix.serving.acceleration_config.controller_scope": "request",
+                "melix.serving.acceleration_config.disabled_reason": "none",
+            }
+        },
+        model_refs={"model_id": "melix-dev-text"},
+        request_summary=profile_proof_request_summary(),
+        events=(),
+        diagnostics_mode="debug",
+    )
+
+    effective_config = json.loads(paths["effective_config"].read_text(encoding="utf-8"))
+    assert effective_config["serving_acceleration_config"] == {
+        "schema_version": "melix.resolved_acceleration_config.v1",
+        "method": "speculative_decode",
+        "requested_method": "speculative_decode",
+        "sidecar_model": "melix-dev-draft",
+        "num_speculative_tokens": 6,
+        "profile": "throughput",
+        "conflicting_flags": ["draft_model_id", "acceleration_profile"],
+        "controller_scope": "request",
+        "disabled_reason": "none",
+    }
+
+
+def test_serving_diagnostics_acceleration_config_skips_invalid_token_count() -> None:
+    receipt = (
+        serving_diagnostics_module._serving_acceleration_config_receipt_from_audit_metadata(
+            {
+                "melix.serving.acceleration_config.schema_version": (
+                    "melix.resolved_acceleration_config.v1"
+                ),
+                "melix.serving.acceleration_config.method": "baseline",
+                "melix.serving.acceleration_config.requested_method": (
+                    "speculative_decode"
+                ),
+                "melix.serving.acceleration_config.sidecar_model": "",
+                "melix.serving.acceleration_config.num_speculative_tokens": "six",
+                "melix.serving.acceleration_config.profile": "balanced",
+                "melix.serving.acceleration_config.conflicting_flags": "",
+                "melix.serving.acceleration_config.controller_scope": "none",
+                "melix.serving.acceleration_config.disabled_reason": (
+                    "invalid_token_count"
+                ),
+            }
+        )
+    )
+
+    assert receipt == {}
+
+
 def test_serving_diagnostics_capability_receipt_normalizes_sequence_metadata() -> None:
     receipt = (
         serving_diagnostics_module._serving_capability_receipt_from_audit_metadata(

--- a/services/mlx-worker-python/worker/productization/serving_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/serving_diagnostics.py
@@ -67,6 +67,24 @@ _CAPABILITY_RECEIPT_REQUIRED_FIELDS = frozenset(
 _CAPABILITY_RECEIPT_LIST_FIELDS = frozenset(
     ("capabilities", "input_modalities", "output_modalities", "ignored_flags")
 )
+_ACCELERATION_CONFIG_AUDIT_TO_RECEIPT_FIELDS = {
+    "melix.serving.acceleration_config.schema_version": "schema_version",
+    "melix.serving.acceleration_config.method": "method",
+    "melix.serving.acceleration_config.requested_method": "requested_method",
+    "melix.serving.acceleration_config.sidecar_model": "sidecar_model",
+    "melix.serving.acceleration_config.num_speculative_tokens": (
+        "num_speculative_tokens"
+    ),
+    "melix.serving.acceleration_config.profile": "profile",
+    "melix.serving.acceleration_config.conflicting_flags": "conflicting_flags",
+    "melix.serving.acceleration_config.controller_scope": "controller_scope",
+    "melix.serving.acceleration_config.disabled_reason": "disabled_reason",
+}
+_ACCELERATION_CONFIG_RECEIPT_REQUIRED_FIELDS = frozenset(
+    _ACCELERATION_CONFIG_AUDIT_TO_RECEIPT_FIELDS.values()
+)
+_ACCELERATION_CONFIG_RECEIPT_LIST_FIELDS = frozenset(("conflicting_flags",))
+_ACCELERATION_CONFIG_RECEIPT_INT_FIELDS = frozenset(("num_speculative_tokens",))
 _EMPTY_EVENT_ATTRIBUTES: Mapping[str, object] = MappingProxyType({})
 _JSON_COMPACT_SEPARATORS = (",", ":")
 _JSONL_ENCODER = json.JSONEncoder(sort_keys=True, separators=_JSON_COMPACT_SEPARATORS)
@@ -623,6 +641,14 @@ def _effective_config_with_profile_receipt(
             if receipt:
                 enriched_config["serving_capability"] = receipt
                 break
+    if "serving_acceleration_config" not in enriched_config:
+        for metadata in metadata_sources:
+            receipt = _serving_acceleration_config_receipt_from_audit_metadata(
+                metadata
+            )
+            if receipt:
+                enriched_config["serving_acceleration_config"] = receipt
+                break
     if "network_fetch_policy" not in enriched_config:
         for metadata in metadata_sources:
             receipt = network_fetch_policy_receipt_from_metadata(metadata)
@@ -717,6 +743,28 @@ def _serving_capability_receipt_from_audit_metadata(
     return {}
 
 
+def _serving_acceleration_config_receipt_from_audit_metadata(
+    metadata: Mapping[str, object],
+) -> dict[str, object]:
+    receipt: dict[str, object] = {}
+    for audit_key, receipt_key in _ACCELERATION_CONFIG_AUDIT_TO_RECEIPT_FIELDS.items():
+        value = metadata.get(audit_key)
+        if value is None:
+            continue
+        if receipt_key in _ACCELERATION_CONFIG_RECEIPT_LIST_FIELDS:
+            receipt[receipt_key] = _metadata_list(value)
+        elif receipt_key in _ACCELERATION_CONFIG_RECEIPT_INT_FIELDS:
+            try:
+                receipt[receipt_key] = int(str(value).strip())
+            except ValueError:
+                return {}
+        else:
+            receipt[receipt_key] = str(value)
+    if _ACCELERATION_CONFIG_RECEIPT_REQUIRED_FIELDS.issubset(receipt):
+        return receipt
+    return {}
+
+
 def _metadata_list(value: object) -> list[str]:
     if isinstance(value, (list, tuple)):
         raw_items = value
@@ -765,12 +813,16 @@ def _write_jsonl(path: Path, rows: Any) -> None:
     append_line = payload.extend
     newline = b"\n"
     request_id_literals: dict[str, bytes] = {}
+    decode_completed_duration_prefixes: dict[float, bytes] = {}
+    decode_completed_request_suffixes: dict[str, bytes] = {}
     for row in rows:
         if isinstance(row, event_type):
             if extend_empty_attribute_event(
                 append_line,
                 row,
                 request_id_literals,
+                decode_completed_duration_prefixes,
+                decode_completed_request_suffixes,
             ):
                 continue
             row = row.to_dict()
@@ -793,6 +845,8 @@ def _extend_empty_attribute_event_json_line_bytes(
     append_line: Any,
     event: ServingDiagnosticsEvent,
     request_id_literals: dict[str, bytes],
+    decode_completed_duration_prefixes: dict[float, bytes] | None = None,
+    decode_completed_request_suffixes: dict[str, bytes] | None = None,
 ) -> bool:
     if event._attributes is not _EMPTY_EVENT_ATTRIBUTES:
         return False
@@ -805,21 +859,45 @@ def _extend_empty_attribute_event_json_line_bytes(
     phase = event._phase
     request_id = event._request_id
     status = event._status
+    duration_literal = _ascii_float_literal(duration_ms)
+    event_index_literal = _ascii_int_literal(event_index)
+    if phase == "decode" and status == "completed":
+        if decode_completed_duration_prefixes is None:
+            decode_completed_duration_prefixes = {}
+        if decode_completed_request_suffixes is None:
+            decode_completed_request_suffixes = {}
+        duration_prefix = decode_completed_duration_prefixes.get(duration_ms)
+        if duration_prefix is None:
+            duration_prefix = b"".join(
+                (
+                    _EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX,
+                    duration_literal,
+                    _EMPTY_EVENT_JSON_DECODE_COMPLETED_MID,
+                )
+            )
+            decode_completed_duration_prefixes[duration_ms] = duration_prefix
+        request_suffix = decode_completed_request_suffixes.get(request_id)
+        if request_suffix is None:
+            encoded_request_id = request_id_literals.get(request_id)
+            if encoded_request_id is None:
+                encoded_request_id = _json_string_literal_bytes(request_id)
+                request_id_literals[request_id] = encoded_request_id
+            request_suffix = b"".join(
+                (
+                    _EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX,
+                    encoded_request_id,
+                    _EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX_LINE,
+                )
+            )
+            decode_completed_request_suffixes[request_id] = request_suffix
+        append_line(duration_prefix)
+        append_line(event_index_literal)
+        append_line(request_suffix)
+        return True
     encoded_request_id = request_id_literals.get(request_id)
     if encoded_request_id is None:
         encoded_request_id = _json_string_literal_bytes(request_id)
         request_id_literals[request_id] = encoded_request_id
-    duration_literal = _ascii_float_literal(duration_ms)
-    event_index_literal = _ascii_int_literal(event_index)
-    if phase == "decode" and status == "completed":
-        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_PREFIX)
-        append_line(duration_literal)
-        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_MID)
-        append_line(event_index_literal)
-        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_REQUEST_PREFIX)
-        append_line(encoded_request_id)
-        append_line(_EMPTY_EVENT_JSON_DECODE_COMPLETED_SUFFIX_LINE)
-        return True
     append_line(b'{"attributes":{},"duration_ms":')
     append_line(duration_literal)
     append_line(b',"event_index":')


### PR DESCRIPTION
## Summary
- Adds a diagnostics-only `ResolvedAccelerationConfig` receipt that normalizes low-level acceleration policy, capability validation, profile admission, suppressed overrides, and disabled reasons into one operator-facing shape.
- Threads the resolved acceleration audit metadata through the Swift request coordinator and teaches Python serving diagnostics to materialize `serving_acceleration_config` receipts from control-plane metadata.
- Includes a scoped serving-diagnostics JSONL serialization cache optimization to keep the additional receipt materialization neutral in the gated performance probe.
- Documents the passive receipt contract and fixes a menu bar install-state test so it no longer reads the operator's real `~/.melix` manifest.

Refs #350.

## Plan or Spec
- Governing plan: `docs/plans/2026-07-06-issue-350-resolved-acceleration-config.md`
- Runbook updated: `docs/runbooks/serving-diagnostics-evidence.md`

## Commands Run
```text
git diff --check && git diff --cached --check
# pass

.githooks/pre-commit
# pass on 256 GiB macOS host
# make swift-test: pass, elapsed 138.3s
# make py-test: 4719 passed, 14 skipped, 2 warnings in 161.44s
# make integration-test: 123 passed, 1 skipped in 419.24s
# scoped performance: status ok, report .runtime/pre-commit-performance/20260706-103155-276ce50b/report/report.md

git fetch origin main
git merge origin/main
# pass, merged origin/main at 5f22d888 with no conflicts

git diff --check && xcrun swift test --no-parallel --package-path services/control-plane-swift --filter ModelCatalogTests/resolvedAccelerationConfigReceiptNormalizesLowLevelAccelerationFields && xcrun swift test --no-parallel --package-path services/control-plane-swift --filter RequestCoordinatorTests/gatewaySpeculativeDefaultsPopulateWorkerAccelerationWhenModelDefaultsAreUnspecified && env HOME="$PWD/.swift-home/macos-menubar" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex/macos-menubar" xcrun swift test --package-path apps/macos-menubar --no-parallel -Xswiftc -gnone --filter 'ProductInstallStateTests/returnsNilWithoutResolvableManifest'
# pass

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_serving_diagnostics.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_serving_diagnostics_queue_probe_script_emits_metrics
# 63 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python - <<'PY'
import subprocess
from scripts.pre_commit_gate import repo_root, run_performance_report
root = repo_root()
changed_files = subprocess.check_output(
    ["git", "diff", "--name-only", "origin/main...HEAD"], cwd=root, text=True
).splitlines()
outcome = run_performance_report(root, changed_files, base_ref="origin/main")
print(f"[post-merge-performance] status={outcome.status} report_dir={outcome.report_dir} selected={outcome.selected_probe_count}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
# pass, status ok, report .runtime/pre-commit-performance/20260706-103810-fb1a49b3/report/report.md
```

## Coverage and Metrics
- Python changed-line coverage from post-merge PR scoped report: 100.00% for `serving_diagnostics.py` and `test_serving_diagnostics.py` changed lines, aggregate 58/58.
- Swift changed-line coverage measured for the changed control-plane scope: 98.02% aggregate, with `ModelCapabilityReceipts.swift` at 97.67% and `RequestCoordinator.swift` at 100.00%.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260706-103155-276ce50b/report/report.md`, status ok, 0 regressions.
- Post-merge scoped performance report: `.runtime/pre-commit-performance/20260706-103810-fb1a49b3/report/report.md`, status ok, 0 regressions.
- Serving diagnostics debug queue bounds in post-merge report: `serialization_elapsed_ms_mean` base 0.804 ms, head 0.769 ms, -4.35%, neutral; serialized bytes and checksum unchanged.
- GitHub PR scoped performance report rerun: status ok, 0 regressions, 0 context regressions, 0 verification failures.
- Observability mode: debug diagnostics only. The receipt is passive metadata in diagnostics artifacts and does not alter runtime acceleration behavior.

## Known Gaps
- Runtime behavior changes and UI/operator controls are intentionally deferred to later #350 slices.
- Protocol and dependency changes: N/A, no schema or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A is stated explicitly.
- [x] Dependency changes include updated lockfiles, or N/A is stated explicitly.
- [x] Relevant tests were run.
- [x] A metrics report is included, or N/A is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
