### PR TITLE
perf: bind deterministic rerank score loop helpers

### DIFF
--- a/docs/plans/2026-07-06-rerank-score-loop-bindings.md
+++ b/docs/plans/2026-07-06-rerank-score-loop-bindings.md
@@ -1,0 +1,30 @@
+# Deterministic rerank score loop bindings
+
+This Python-only performance slice is limited to `DeterministicRerankRuntime.score_documents(...)` in `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`.
+
+## Scope
+
+The deterministic rerank runtime already builds query tokens, a query-token set, and the family query context once per request, then reuses cached scores for duplicate document strings. This follow-up keeps those semantics unchanged and narrows the per-document scoring loop by binding repeated cache lookup, score append, and family scoring callables once before iterating documents.
+
+No rerank model metadata, backend selection, query-context construction, duplicate-document cache behavior, score ordering, or response schema changes in this slice.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py`
+- `services/mlx-worker-python/worker/runtime/rerank_backends.py`
+- `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`
+- `services/mlx-worker-python/tests/test_rerank_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Verification plan
+
+1. Run the registered focused rerank tests locally on Linux.
+2. Run the registered changed-scope coverage command locally and require at least 95% changed-line coverage.
+3. Run the registered `deterministic-rerank-query-context-reuse` probe locally against `origin/main` and this branch.
+4. Use GitHub Actions PR-scoped performance as the final registered probe validation and merge gate.
+
+## Linux validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime behavior changes are included.

--- a/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py
@@ -41,11 +41,14 @@ class DeterministicRerankRuntime:
             query_token_set=query_token_set,
         )
         document_score_cache: dict[str, float] = {}
+        document_score_cache_get = document_score_cache.get
         scores: list[float] = []
+        scores_append = scores.append
+        family_score = family.score
         for document in documents:
-            score = document_score_cache.get(document)
+            score = document_score_cache_get(document)
             if score is None:
-                score = family.score(
+                score = family_score(
                     backend,
                     query,
                     document,
@@ -54,5 +57,5 @@ class DeterministicRerankRuntime:
                     query_token_set=query_token_set,
                 )
                 document_score_cache[document] = score
-            scores.append(score)
+            scores_append(score)
         return scores


### PR DESCRIPTION
## Summary
- Bind repeated deterministic rerank score-loop helpers (`dict.get`, `list.append`, and `family.score`) before iterating documents.
- Preserve query-context reuse, duplicate-document score caching, score ordering, and response semantics.

## Plan or Spec
- `docs/plans/2026-07-06-rerank-score-loop-bindings.md`
- Registered probe: `deterministic-rerank-query-context-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe
# 43 passed in 15.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_rerank_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_deterministic_rerank_probe && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_rerank_runtime.py services/mlx-worker-python/worker/runtime/rerank_backends.py services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_rerank_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 43 passed in 49.40s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-rerank-query-context-reuse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-rerank-score-loop-binds-20260706 --head-repo "$PWD" --output /tmp/rerank-score-loop-perf.json
# head verification passed; base/head probe completed successfully
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%` for `deterministic_rerank_runtime.py` changed lines.
- Local registered probe (`deterministic-rerank-query-context-reuse`, Linux):
  - `elapsed_ms_mean`: base `4.425352` ms → head `3.839474` ms (`-0.585878` ms, ~`13.24%` faster).
  - `query_context_builds_mean`: base `1.0` → head `1.0`.
  - `score_calls_mean`: base `64.0` → head `64.0`.
  - `tokenize_calls_mean`: base `65.0` → head `65.0`.
  - `unique_document_count`: base/head `64.0`.
- GitHub Actions PR-scoped performance is required as final registered probe validation before merge.

## Known Gaps
- None for the Python slice. No Swift runtime behavior changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
