### PR TITLE
perf: use list copy descriptor for trajectory scalars

### DIFF
--- a/docs/plans/2026-07-06-trajectory-scalar-list-copy-exact.md
+++ b/docs/plans/2026-07-06-trajectory-scalar-list-copy-exact.md
@@ -1,0 +1,30 @@
+# Trajectory scalar list exact-copy performance slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.trajectory_provenance._copy_json_list()` for exact `list` instances that contain only JSON-immutable scalar values.
+
+## Registered probe
+
+The affected file is covered by the registered PR-scoped performance probe `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`. The probe watches:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/trajectory_provenance_copy_elision_probe.py`
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` fields. Local Linux verification uses those commands before PR creation; GitHub Actions PR-scoped performance remains the merge gate.
+
+## Implementation plan
+
+1. Preserve the recursive-copy and custom-list-subclass behavior already covered by tests.
+2. Use the unbound built-in `list.copy(value)` path after the immutable scan instead of a list display copy.
+3. Keep list subclasses safe by calling the built-in descriptor directly, so overridden `copy()` methods are not invoked and the result remains an exact `list`.
+4. Run the registered focused tests, changed-scope coverage command, and local probe.
+5. Create and merge a focused PR only after CI and the registered PR-scoped performance report pass.
+
+## Success criteria
+
+- Focused trajectory provenance tests pass.
+- Changed-scope coverage for `worker.trajectory_provenance` remains above the repository threshold.
+- `trajectory-provenance-copy-elision` reports lower or equivalent scalar-list elapsed time and no in-scope regression.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -13,6 +13,7 @@ _PATH_READ_BYTES = Path.read_bytes
 _OPEN = _builtin_open
 _STR = str
 _TYPE = type
+_LIST_COPY = list.copy
 
 
 def _strip_manifest_text(value: Any) -> str:
@@ -60,7 +61,7 @@ def _copy_json_list(value: list[Any]) -> list[Any]:
     for item in value:
         if value_type(item) not in immutable_types:
             return [_copy_trajectory_provenance_value(item) for item in value]
-    return [*value]
+    return _LIST_COPY(value)
 
 
 def _copy_json_tuple(value: tuple[Any, ...]) -> tuple[Any, ...]:


### PR DESCRIPTION
## Summary
- Use the unbound `list.copy` descriptor for scalar-only trajectory provenance list copies after the immutable scan.
- Preserve custom list subclass behavior by bypassing overridden `copy()` methods and still returning an exact `list`.
- Add the governing performance-slice plan for this registered probe path.

## Plan or Spec
- `docs/plans/2026-07-06-trajectory-scalar-list-copy-exact.md`

## Commands Run
```text
# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
Result: 19 passed in 0.50s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
Result: 16 passed in 0.82s; changed_line_coverage=100.00%; TOTAL 2 0 100%

# local registered probe, base-vs-head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id trajectory-provenance-copy-elision --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-trajectory-scalar-list-copy-exact-20260706 --head-repo "$PWD" --output /tmp/trajectory_scalar_list_probe.json
Result: ok; head verification test_ok=True coverage_ok=True; base probe ok=True; head probe ok=True
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` = 100.00% (`TOTAL 2 0 100%`).
- Registered probe: `trajectory-provenance-copy-elision`.
- Local base-vs-head probe metrics:
  - `optimized_elapsed_ms_mean`: base `289.7756420017686 ms` -> head `284.1870137985097 ms` (delta `-5.5886282032589 ms`, ~1.93% faster)
  - `scalar_list_elapsed_ms_mean`: base `0.7524385990109295 ms` -> head `0.6870280019938946 ms` (delta `-0.0654105970170349 ms`, ~8.69% faster)
  - `scalar_list_speedup`: base `1.1875100542116517x` -> head `1.2674563421363452x`
  - `peak_bytes_mean`: unchanged at `11795.2 bytes`
- CI PR-scoped performance is required as the merge-gate validation source.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused test/coverage/probe commands on Linux.
- Observability mode: N/A, no runtime observability behavior changed. Probe overhead: N/A, no new probe was added.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
