### PR TITLE
perf: bind code eval payload prefix checks

### DIFF
--- a/docs/plans/2026-07-06-code-eval-payload-startswith-local-bindings.md
+++ b/docs/plans/2026-07-06-code-eval-payload-startswith-local-bindings.md
@@ -1,0 +1,35 @@
+# Code eval payload startswith local bindings
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation payload fast
+path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The change keeps the existing byte-oriented JSON payload extraction behavior and
+only binds `payload_bytes.startswith` once in the hot helper scopes that perform
+multiple prefix checks.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped registered probe
+`code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. The probe
+has focused `test_command`, `coverage_command`, and `probe_command` entries and
+watches:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_payload_json_probe.py`
+
+## Validation plan
+
+1. Run the focused payload fast-path regression tests.
+2. Run the registered probe coverage command and changed-scope coverage gate.
+3. Run the registered probe locally on Linux before and after the change.
+4. Use the PR-scoped performance workflow as the CI validation source.
+
+## Success metrics
+
+Accept the slice only if behavior tests pass and the registered probe does not
+show a regression. Local Linux probe evidence should show stable or improved
+`elapsed_ms_mean` while preserving `peak_bytes_mean`.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -464,7 +464,8 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
     if bounds is None:
         return None
 
-    if payload_bytes.startswith(_CODE_EVAL_PAYLOAD_RUNNER_PREFIX, bounds[0]):
+    payload_startswith = payload_bytes.startswith
+    if payload_startswith(_CODE_EVAL_PAYLOAD_RUNNER_PREFIX, bounds[0]):
         failure_index = payload_bytes.find(_CODE_EVAL_PAYLOAD_KEY_TOKENS["failure_detail"])
         runtime_index = payload_bytes.find(_CODE_EVAL_PAYLOAD_KEY_TOKENS["runtime_status"])
         if 0 <= failure_index < runtime_index:
@@ -509,12 +510,13 @@ def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, 
     payload: dict[str, object] = {}
     field_value_start = _json_field_value_start_for_token
     extract_int_and_end = _extract_json_int_field_value_and_end
+    payload_startswith = payload_bytes.startswith
 
     failure_start = field_value_start(
         payload_bytes,
         _CODE_EVAL_PAYLOAD_KEY_TOKENS["failure_detail"],
     )
-    if failure_start is None or not payload_bytes.startswith(b'""', failure_start):
+    if failure_start is None or not payload_startswith(b'""', failure_start):
         return None
     payload["failure_detail"] = ""
 
@@ -523,7 +525,7 @@ def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, 
         _CODE_EVAL_PAYLOAD_KEY_TOKENS["runtime_status"],
         start=failure_start + 2,
     )
-    if runtime_start is None or not payload_bytes.startswith(b'"ok"', runtime_start):
+    if runtime_start is None or not payload_startswith(b'"ok"', runtime_start):
         return None
     payload["runtime_status"] = "ok"
 
@@ -532,7 +534,7 @@ def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, 
         _CODE_EVAL_PAYLOAD_KEY_TOKENS["test_status"],
         start=runtime_start + 4,
     )
-    if test_start is None or not payload_bytes.startswith(b'"passed"', test_start):
+    if test_start is None or not payload_startswith(b'"passed"', test_start):
         return None
     payload["test_status"] = "passed"
 
@@ -563,7 +565,7 @@ def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, 
         _CODE_EVAL_PAYLOAD_KEY_TOKENS["timeout_status"],
         start=total_end,
     )
-    if timeout_start is None or not payload_bytes.startswith(b'"ok"', timeout_start):
+    if timeout_start is None or not payload_startswith(b'"ok"', timeout_start):
         return None
     payload["timeout_status"] = "ok"
 
@@ -640,26 +642,27 @@ def _known_code_eval_payload_string_value(
     value_end: int,
 ) -> str | None:
     value_length = value_end - value_start
+    payload_startswith = payload_bytes.startswith
     if value_length == 0:
         return ""
     if value_length == 2:
-        return "ok" if payload_bytes.startswith(b"ok", value_start) else None
+        return "ok" if payload_startswith(b"ok", value_start) else None
     if value_length == 5:
-        return "error" if payload_bytes.startswith(b"error", value_start) else None
+        return "error" if payload_startswith(b"error", value_start) else None
     if value_length == 6:
-        if payload_bytes.startswith(b"failed", value_start):
+        if payload_startswith(b"failed", value_start):
             return "failed"
-        return "passed" if payload_bytes.startswith(b"passed", value_start) else None
+        return "passed" if payload_startswith(b"passed", value_start) else None
     if value_length == 7:
-        if payload_bytes.startswith(b"not_run", value_start):
+        if payload_startswith(b"not_run", value_start):
             return "not_run"
-        return "timeout" if payload_bytes.startswith(b"timeout", value_start) else None
+        return "timeout" if payload_startswith(b"timeout", value_start) else None
     if value_length == 8:
-        return "compiled" if payload_bytes.startswith(b"compiled", value_start) else None
+        return "compiled" if payload_startswith(b"compiled", value_start) else None
     if value_length == 9:
-        return "timed_out" if payload_bytes.startswith(b"timed_out", value_start) else None
+        return "timed_out" if payload_startswith(b"timed_out", value_start) else None
     if value_length == 12:
-        return "syntax_error" if payload_bytes.startswith(b"syntax_error", value_start) else None
+        return "syntax_error" if payload_startswith(b"syntax_error", value_start) else None
     return None
 
 


### PR DESCRIPTION
## Summary
- Bind `payload_bytes.startswith` inside the code-eval payload fast-path helpers to avoid repeated bound-method lookups while parsing runner JSON payload bytes.
- Add a focused plan for the slice and its registered PR-scoped performance probe.

## Plan or Spec
- `docs/plans/2026-07-06-code-eval-payload-startswith-local-bindings.md`
- Registered probe: `code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json` (already has focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline focused tests before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_fast_path_decodes_known_status_values services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges
# 3 passed in 0.20s

# Baseline registered probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# {"elapsed_ms_mean": 81.46120742769979, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60292.0, "sample_count": 7.0}

# Focused tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_fast_path_decodes_known_status_values services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges
# 3 passed in 0.07s

# Registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_returns_none_for_missing_or_malformed_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_fast_path_decodes_known_status_values services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_missing_required_field_falls_back_to_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# 13 passed in 1.78s

# Registered coverage command + changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_returns_none_for_missing_or_malformed_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_fast_path_decodes_known_status_values services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_missing_required_field_falls_back_to_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# 13 passed in 4.04s; TOTAL 17 0 100%

# Registered probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_payload_json_probe.py
# {"elapsed_ms_mean": 77.60274900231578, "iteration_count": 1200.0, "payload_bytes": 55474.0, "peak_bytes_mean": 60292.0, "sample_count": 7.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Local registered probe delta: old_mean=`81.46120742769979` ms, new_mean=`77.60274900231578` ms, delta=`-3.858458` ms, improvement=`4.7366%`, speedup=`4.9721%`.
- Peak bytes stayed flat at `60292.0`.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- Linux local validation covers the Python slice only; repository-wide CI and the PR-scoped performance workflow must complete before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new probe overhead introduced.
- [x] Deferred work and known gaps are stated explicitly.
