### PR TITLE
perf: reuse report run-kind value set

### DIFF
--- a/docs/plans/2026-07-01-report-evidence-single-evidence-id-sort-elision.md
+++ b/docs/plans/2026-07-01-report-evidence-single-evidence-id-sort-elision.md
@@ -34,6 +34,15 @@ precomputed report run-kind set instead of dispatching through the general
 `_run_kind_rule_matches` helper on every role. Multi-value, non-tuple, and
 non-string run-kind rules continue to use the existing general matching behavior.
 
+## 2026-07-06 follow-up: mutable run-kind value set
+
+This Python-only follow-up keeps the same registered probe and narrows to
+`_report_matrix_roles`. The role scanner only needs transient membership checks
+for the run kinds observed in a report, so `_report_run_kind_values` can return
+the populated `set[str]` directly instead of wrapping it in a `frozenset`. The
+set is not exposed outside the scan and remains equivalent for membership and
+`isdisjoint` checks while avoiding an extra container allocation.
+
 ## Verification plan
 
 Run the registered focused test command, changed-scope coverage command, and the

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -311,6 +311,12 @@ def test_report_evidence_gate_matrix_roles_keep_non_string_run_kind_match() -> N
 
 def test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules() -> None:
     report_evidence_gate_module._string_frozenset_from_tuple.cache_clear()
+    run_kind_values = report_evidence_gate_module._report_run_kind_values(
+        [{"run_kind": "serving_benchmark"}, {"run_kind": "evaluation"}]
+    )
+    assert type(run_kind_values) is set
+    assert run_kind_values == {"serving_benchmark", "evaluation"}
+
     roles = report_evidence_gate_module._report_matrix_roles(
         {"runs": [{"run_kind": "serving_benchmark"}, {"run_kind": "evaluation"}]},
         {

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -301,7 +301,7 @@ def _report_matrix_roles(
     runs = _dict_list(report.get("runs"))
     targets = _dict_list(report.get("targets"))
     metrics = _dict_list(report.get("metrics"))
-    run_kind_values: frozenset[str] | None = None
+    run_kind_values: set[str] | None = None
     probe_phases: set[str] | None = None
     run_kind_only_rule = _run_kind_only_rule
     run_kind_rule_matches = _run_kind_rule_matches
@@ -340,7 +340,7 @@ def _run_kind_only_rule(rule: dict[str, object]) -> bool:
     )
 
 
-def _run_kind_rule_matches(run_kinds: object, run_kind_values: frozenset[str]) -> bool:
+def _run_kind_rule_matches(run_kinds: object, run_kind_values: AbstractSet[str]) -> bool:
     if isinstance(run_kinds, tuple):
         if len(run_kinds) == 1:
             run_kind = run_kinds[0]
@@ -356,7 +356,7 @@ def _run_kind_rule_matches(run_kinds: object, run_kind_values: frozenset[str]) -
     return not _string_frozenset(run_kinds).isdisjoint(run_kind_values)
 
 
-def _report_run_kind_values(runs: list[dict[str, object]]) -> frozenset[str]:
+def _report_run_kind_values(runs: list[dict[str, object]]) -> set[str]:
     run_kind_key = "run_kind"
     values: set[str] = set()
     values_add = values.add
@@ -367,7 +367,7 @@ def _report_run_kind_values(runs: list[dict[str, object]]) -> frozenset[str]:
             values_add(run_kind)
         else:
             values_add(to_string(run_kind))
-    return frozenset(values)
+    return values
 
 
 def _rule_matches_report(


### PR DESCRIPTION
## Summary
- Reuse the transient report run-kind `set` directly in `_report_matrix_roles` instead of wrapping it in a `frozenset`.
- Extend the focused report-evidence gate test to pin the mutable set snapshot contract.
- Document the 2026-07-06 follow-up slice in the governing report-evidence performance plan.

## Plan or Spec
- `docs/plans/2026-07-01-report-evidence-single-evidence-id-sort-elision.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` via the registered `test_command` for `report-evidence-gate-run-kind-set-membership` — 29 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...` via the registered `coverage_command` — TOTAL 7/7 changed lines covered, 100%.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c ... scripts/report_evidence_gate_run_kind_probe.py` — see metrics below.
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=7`, `aggregate_covered_changed_lines=7`).
- Local registered probe (Linux, candidate): `elapsed_ms_mean=972.8414425946539`, `run_kind_elapsed_ms_mean=207.5009115942521`, `matrix_roles_elapsed_ms_mean=3.233529403223656`.
- Local comparison spot-check at 30k iterations / 3 samples: base `elapsed_ms_mean=1011.4947329915594`, `matrix_roles_elapsed_ms_mean=3.488223801832646`; candidate `elapsed_ms_mean=990.3250122093596`, `matrix_roles_elapsed_ms_mean=3.3024732023477554`.
- Registered PR-scoped performance CI is required as the merge gate.

## Known Gaps
- Linux local probe validates the Python path only; CI remains the source of truth for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Registered probe covers the changed path and includes focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run and metrics are included.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
