### PR TITLE
perf: bind embedding sum-square helper

### DIFF
--- a/docs/plans/2026-07-06-embedding-project-sum-squares-binding.md
+++ b/docs/plans/2026-07-06-embedding-project-sum-squares-binding.md
@@ -1,0 +1,37 @@
+# Deterministic embedding sum-squares binding
+
+## Scope
+
+This Python-only performance slice targets deterministic embedding projection in
+`services/mlx-worker-python/worker/runtime/embedding_backends.py`.
+
+The affected path is covered by the registered PR-scoped performance probe
+`deterministic-embedding-project-digest-allocation` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already provides focused
+`test_command`, `coverage_command`, and `probe_command` entries for the embedding
+runtime tests, changed-scope coverage, and digest projection probe.
+
+## Optimization
+
+`DeterministicEmbeddingBackend._project_digest(...)` already binds common runtime
+helpers such as `sha256`, `sqrt`, and `round` through default arguments. This
+slice extends that pattern to `_sum_squares_8`, avoiding a global lookup for each
+projection while preserving the existing default-dimension normalization loop and
+expanded-dimension behavior.
+
+No embedding vector values, dimensions, checksums, or zero-norm fallback behavior
+change.
+
+## Verification plan
+
+1. Run the registered focused test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered `deterministic-embedding-project-digest-allocation` probe
+   locally against `origin/main` and this branch.
+4. Use GitHub Actions PR-scoped performance as the final registered probe merge
+   gate.
+
+## Verification boundary
+
+This is a Python-only slice and is locally verifiable on Linux. The PR-scoped CI
+probe report remains the required merge gate before merging.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -69,13 +69,14 @@ class DeterministicEmbeddingBackend:
         _sha256=_SHA256,
         _sqrt=_SQRT,
         _round=_ROUND,
+        _sum_squares=_sum_squares_8,
     ) -> list[float]:
         base_values = [
             raw * _DIGEST_UINT32_SCALE - 1.0
             for raw in _UNPACK_DIGEST_UINT32(_sha256(seed_text.encode("utf-8")).digest())
         ]
         if dimensions == 8:
-            l2_norm = _sqrt(_sum_squares_8(base_values))
+            l2_norm = _sqrt(_sum_squares(base_values))
             if l2_norm == 0.0:
                 return [0.0] * 8
             inverse_l2_norm = 1.0 / l2_norm


### PR DESCRIPTION
## Summary
- Bind the deterministic embedding `_sum_squares_8` helper through `_project_digest(...)` default arguments, matching the existing local bindings for `sha256`, `sqrt`, and `round`.
- Keep vector values, dimensions, checksums, and zero-norm fallback behavior unchanged.

## Plan or Spec
- `docs/plans/2026-07-06-embedding-project-sum-squares-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# 21 passed in 16.71s

git diff --check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id deterministic-embedding-project-digest-allocation --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-embedding-default-dim-list-literal-20260706 --head-repo "$PWD" --output /tmp/embedding_sum_squares_bind_probe.json
# Head verification: 21 passed in 49.94s; changed-scope coverage TOTAL 1 0 100%; base/head probe completed ok.
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`aggregate_measurable_changed_lines=1`, `aggregate_covered_changed_lines=1`, `aggregate_missed_changed_lines=0`).
- Registered probe: `deterministic-embedding-project-digest-allocation`.
- Local Linux probe metrics (`base -> head`):
  - `elapsed_ms_mean`: `15.650493 -> 15.054881` (`-0.595612 ms`, `-3.81%`).
  - `default_dimension_elapsed_ms_mean`: `105.732113 -> 105.374463` (`-0.357650 ms`, `-0.34%`).
  - `peak_bytes_mean`: `74840.888889 -> 74840.888889` (no change).
  - `default_dimension_peak_bytes_mean`: `989.333333 -> 989.333333` (no change).
- Checksums unchanged: `checksum=8.325108`, `default_dimension_checksum=213.60249` on both base and head.
- PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally; this slice used the registered focused Python test, coverage, and probe commands.
- No Swift runtime behavior changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability or probe overhead added.
- [x] Deferred work and known gaps are stated explicitly.
