### PR TITLE
perf: bind trajectory provenance value type lookup

### DIFF
--- a/docs/plans/2026-06-25-trajectory-copy-list-literal.md
+++ b/docs/plans/2026-06-25-trajectory-copy-list-literal.md
@@ -45,3 +45,13 @@ guards now reuse a module-level `type` binding inside the per-item scan instead
 of resolving the builtin on every iteration. Container isolation and recursive
 copy behavior stay unchanged; the slice only targets the exact-scalar list/tuple
 hot loops measured by the registered probe.
+
+## 2026-07-06 follow-up: normalize value type binding
+
+This follow-up remains limited to `normalize_trajectory_provenance(...)` in the
+same Python-only trajectory provenance path. The normalizer now reuses the
+module-level `_TYPE` binding for each provenance field type check instead of
+resolving the builtin `type` during every field iteration. Copy isolation,
+empty-value filtering, and scalar forwarding semantics stay unchanged. The
+registered `trajectory-provenance-copy-elision` probe remains the local Linux and
+CI validation gate for the affected path.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -101,11 +101,12 @@ def normalize_trajectory_provenance(
     normalized: dict[str, Any] = {}
     provenance_get = provenance.get
     copy_value = _copy_trajectory_provenance_value
+    value_type_of = _TYPE
     for field in TRAJECTORY_PROVENANCE_FIELDS:
         value = provenance_get(field)
         if value is None:
             continue
-        value_type = type(value)
+        value_type = value_type_of(value)
         if value_type is str:
             if value == "":
                 continue


### PR DESCRIPTION
## Summary
- Bind the trajectory provenance normalizer's per-field type lookup to the existing module-level `_TYPE` helper.
- Keep provenance copy isolation, empty-value filtering, and scalar forwarding behavior unchanged.
- Update the trajectory provenance performance plan with the 2026-07-06 normalize value type binding slice.

## Plan or Spec
- `docs/plans/2026-06-25-trajectory-copy-list-literal.md`
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ git fetch origin --prune
# origin/main synced before creating isolated worktree.

$ git -C /root/.hermes/profiles/coder/workspace/melix.git worktree add -b perf/cron-python-slice-20260706191814 /root/.hermes/profiles/coder/workspace/worktrees/melix-cron-python-slice-20260706191814 origin/main
# HEAD: 4114d43c perf: bind embedding sum-square helper (#2622)

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 19 passed in 2.24s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 16 passed in 0.78s; changed_line_coverage=100.00%; TOTAL 2 0 100%

$ python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id trajectory-provenance-copy-elision --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-trajectory-typebind-20260706191814 --head-repo "$PWD" --output /tmp/trajectory_typebind_probe.json
# ok; head verification coverage 100%; base/head probe completed successfully.

$ git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines 104 and 109 covered; `TOTAL 2 0 100%`.
- Registered local probe: `trajectory-provenance-copy-elision`.
  - `optimized_elapsed_ms_mean`: base `352.4400794005487 ms`, head `349.10033880150877 ms`, delta `-3.339740599039925 ms` (~0.95% lower).
  - `speedup`: base `5.702062400545865x`, head `5.883385234327227x`.
  - `peak_bytes_mean`: base `12112.0`, head `12112.0`.
  - `scalar_list_elapsed_ms_mean`: base `0.6718416028888896 ms`, head `0.6559139990713447 ms`.
- CI PR-scoped performance is required as the registered probe merge gate.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this narrow Python-only slice.
- Swift runtime effects are not applicable; this change is locally verified on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
