### PR TITLE
perf: accumulate dataset quality output length total

### DIFF
--- a/docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md
+++ b/docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md
@@ -10,6 +10,8 @@ The affected path is covered by the registered PR-scoped probe `dataset-quality-
 
 `_append_sample_output_lengths()` previously iterated over a temporary `(train_rows, validation_rows)` tuple and kept the per-row extraction loop nested under that outer loop. This slice keeps output semantics unchanged while moving the row loop into `_append_rows_output_lengths()` and calling it once for train rows and once for validation rows. The goal is to remove the outer tuple iteration from the hot path and keep local `append`/`str` bindings scoped to the direct row pass.
 
+A 2026-07-06 follow-up keeps the same row helper and returns the accumulated output-length total while appending each length. `_sample_output_length_stats()` uses that inline total instead of rescanning the collected lengths with `sum()` before sorting for p95, preserving output semantics while removing one full pass over the hot length list. The registered probe default sample count also increases from 7 to 25 so the short dataset-quality timing path is less sensitive to single-sample scheduler noise in CI and local comparisons.
+
 ## Verification Plan
 
 1. Run the registered local probe on `origin/main` before the change and on `HEAD` after the change.

--- a/scripts/dataset_quality_lengths_probe.py
+++ b/scripts/dataset_quality_lengths_probe.py
@@ -146,7 +146,7 @@ def measure_failed_partition(*, segment_count: int, failed_modulus: int, samples
 def main() -> int:
     train_count = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_TRAIN_ROWS", "12000"))
     validation_count = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_VALIDATION_ROWS", "3000"))
-    samples = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_SAMPLES", "7"))
+    samples = int(os.environ.get("MELIX_DATASET_QUALITY_LENGTHS_SAMPLES", "25"))
     segment_count = int(os.environ.get("MELIX_DATASET_FAILED_PARTITION_SEGMENTS", "15000"))
     failed_modulus = int(os.environ.get("MELIX_DATASET_FAILED_PARTITION_MODULUS", "5"))
     metrics = measure(train_count=train_count, validation_count=validation_count, samples=samples)

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -7,6 +7,7 @@ import sys
 import pytest
 
 from dataset_ingest_limit_contract import exercise_dataset_ingest_limit_contract
+from worker.productization import dataset_preparation as dataset_preparation_module
 from worker.productization.dataset_preparation import (
     DatasetIngestRequest,
     DatasetRetryFailedRequest,
@@ -212,6 +213,20 @@ def test_dataset_quality_message_rows_skip_completion_key_lookup() -> None:
     row = MessageRow({"messages": [{"content": "hello"}, {"content": 678}, "skip-me"]})
 
     assert _sample_output_lengths([], [row]) == [8]
+
+
+def test_dataset_quality_length_stats_accumulates_total_inline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_sum(*args: object, **kwargs: object) -> int:  # pragma: no cover - regression tripwire
+        raise AssertionError("output-length stats should not rescan lengths with sum()")
+
+    monkeypatch.setattr(dataset_preparation_module, "sum", fail_sum, raising=False)
+
+    assert _sample_output_length_stats(
+        [{"completion": "abc"}, {"completion": 12345}],
+        [{"messages": [{"content": "hello"}, {"content": "world"}]}],
+    ) == (3, 18, 10)
 
 
 def test_dataset_quality_summary_reuses_train_validation_counts() -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1802,11 +1802,10 @@ def _sample_output_length_stats(
     validation_rows: list[dict[str, Any]],
 ) -> tuple[int, int, int]:
     lengths: list[int] = []
-    _append_sample_output_lengths(lengths, train_rows, validation_rows)
+    output_length_total = _append_sample_output_lengths(lengths, train_rows, validation_rows)
     length_count = len(lengths)
     if not length_count:
         return 0, 0, 0
-    output_length_total = sum(lengths)
     lengths.sort()
     index = min(length_count - 1, int(round((length_count - 1) * 0.95)))
     return length_count, output_length_total, lengths[index]
@@ -1816,19 +1815,22 @@ def _append_sample_output_lengths(
     lengths: list[int],
     train_rows: list[dict[str, Any]],
     validation_rows: list[dict[str, Any]],
-) -> None:
-    _append_rows_output_lengths(lengths, train_rows)
-    _append_rows_output_lengths(lengths, validation_rows)
+) -> int:
+    return _append_rows_output_lengths(lengths, train_rows) + _append_rows_output_lengths(
+        lengths,
+        validation_rows,
+    )
 
 
 def _append_rows_output_lengths(
     lengths: list[int],
     rows: list[dict[str, Any]],
-) -> None:
+) -> int:
     append = lengths.append
     len_ = len
     str_ = str
     missing = _MISSING
+    output_length_total = 0
     for row in rows:
         completion = row.get("completion", missing)
         if completion is missing:
@@ -1847,11 +1849,15 @@ def _append_rows_output_lengths(
                 else:
                     total += len_(str_(content))
             append(total)
+            output_length_total += total
         else:
             if type(completion) is str:
-                append(len_(completion))
+                length = len_(completion)
             else:
-                append(len_(str_(completion)))
+                length = len_(str_(completion))
+            append(length)
+            output_length_total += length
+    return output_length_total
 
 
 def _p95(values: list[int]) -> int:


### PR DESCRIPTION
## Summary
- Accumulate dataset quality output-length totals while appending per-row lengths, removing the extra `sum(lengths)` pass before p95 sorting.
- Add a regression test that fails if `_sample_output_length_stats()` rescans the collected length list with `sum()`.
- Increase the registered dataset-quality probe default sample count from 7 to 25 to reduce scheduler-noise sensitivity for the short timing path.

## Plan or Spec
- `docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics
# 55 passed in 0.73s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# 55 passed in 1.48s; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-quality-lengths-chain --base-repo /tmp/melix-perf-real-dataset-quality-final-2513315/base --head-repo /tmp/melix-perf-real-dataset-quality-final-2513315/head --output /tmp/dataset_quality_lengths_inline_total_probe_final.json
# head verification ok; base/head probes ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Registered local probe: `dataset-quality-lengths-chain`.
- Local probe metrics (25 samples, lower is better unless informational):
  - `elapsed_ms_mean`: base `2.605413`, head `2.547673` (`-0.057740 ms`, ~`2.22%` faster).
  - `elapsed_ms_p95`: base `2.812890`, head `2.674239` (`-0.138651 ms`, ~`4.93%` faster).
  - `mean_output_length`: base/head `51.999` (unchanged).
  - `p95_output_length`: base/head `100.0` (unchanged).
  - `failed_partition_elapsed_ms_mean`: base `1.119787`, head `1.098471` (unrelated probe segment, ~`1.90%` faster).
  - `failed_partition_elapsed_ms_p95`: base `1.164217`, head `1.260326` (unrelated probe segment, noisy local p95; PR-scoped CI remains the merge gate).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux-local Python behavior and synthetic probe metrics were validated. No Swift runtime effect is claimed.
- The short failed-partition submetric is unrelated to the touched output-length code and can be noisy locally; CI registered probe report is the final gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
