### PR TITLE
perf: branch full-list tool config fast path

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -131,6 +131,22 @@ Expected effect:
 - leave registry selection, schema serialization, protobuf config handling, and
   tool definitions unchanged.
 
+## Follow-up Slice: Full List Template Branch
+
+The 2026-07-06 follow-up keeps `built_in_tool_config(list(BUILTIN_AGENTIC_TOOL_NAMES))`
+behavior unchanged, but checks the full-list template case inside the list branch
+instead of first comparing the caller's list to the canonical tuple. The hot path
+still returns a fresh mutable protobuf copy from the built-in template, while the
+registered selector probe's full-list workload avoids an unnecessary cross-type
+sequence comparison before taking the existing template fast path.
+
+Expected effect:
+
+- reduce `tool-registry-select-name-index-cache` `full_config_template_elapsed_ms_mean`;
+- preserve mutation isolation for returned `ToolConfig` messages;
+- leave partial selections, tuple full selections, registry selection, and tool
+  definitions unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -195,11 +195,29 @@ def test_tool_registry_worker_config_reuses_isolated_template_copy() -> None:
 
 
 def test_built_in_tool_config_full_tuple_selection_returns_full_template_copy() -> None:
-    selected_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+    selected_config = built_in_tool_config(tuple(list(BUILTIN_AGENTIC_TOOL_NAMES)))
     selected_config.tools.pop()
     selected_config.schema_version = "mutated"
 
-    next_selected_config = built_in_tool_config(BUILTIN_AGENTIC_TOOL_NAMES)
+    next_selected_config = built_in_tool_config(tuple(list(BUILTIN_AGENTIC_TOOL_NAMES)))
+
+    assert [tool.name for tool in next_selected_config.tools] == list(BUILTIN_AGENTIC_TOOL_NAMES)
+    assert next_selected_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION
+
+
+def test_built_in_tool_config_full_list_selection_returns_full_template_copy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_select(self: ToolRegistry, names: tuple[str, ...]) -> object:  # pragma: no cover
+        raise AssertionError("full list selection should reuse the built-in template")
+
+    monkeypatch.setattr(ToolRegistry, "select", fail_select)
+
+    selected_config = built_in_tool_config(list(BUILTIN_AGENTIC_TOOL_NAMES))
+    selected_config.tools.pop()
+    selected_config.schema_version = "mutated"
+
+    next_selected_config = built_in_tool_config(list(BUILTIN_AGENTIC_TOOL_NAMES))
 
     assert [tool.name for tool in next_selected_config.tools] == list(BUILTIN_AGENTIC_TOOL_NAMES)
     assert next_selected_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -512,9 +512,11 @@ def agentic_tool_index_metadata() -> dict[str, ToolIndexMetadata]:
 
 def built_in_tool_config(names: list[str] | tuple[str, ...] | None = None) -> common_pb2.ToolConfig:
     copy_tool_config = _copy_tool_config
-    if names is None or names is BUILTIN_AGENTIC_TOOL_NAMES or names == BUILTIN_AGENTIC_TOOL_NAMES:
+    if names is None or names is BUILTIN_AGENTIC_TOOL_NAMES:
         return copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
     if isinstance(names, tuple):
+        if names == BUILTIN_AGENTIC_TOOL_NAMES:
+            return copy_tool_config(_BUILTIN_TOOL_CONFIG_TEMPLATE)
         cached_config = _BUILTIN_TOOL_CONFIG_SELECTION_TEMPLATES.get(names)
         if cached_config is not None:
             return copy_tool_config(cached_config)


### PR DESCRIPTION
## Summary
- Route full-list `built_in_tool_config(...)` calls through the list-specific template fast path instead of first comparing a list against the canonical tuple.
- Add regression coverage that full list selections return isolated template copies without entering registry selection.
- Update the tool registry schema-payload plan with the registered full-list template branch slice.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 102 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# 102 passed in 0.80s; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /tmp/melix-perf-tool-registry-full-list-2835434/base --head-repo /tmp/melix-perf-tool-registry-full-list-2835434/head --output /tmp/melix-perf-tool-registry-full-list-2835434/tool_registry_select_report.json
# head verification ok; base/head probes ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered local probe: `tool-registry-select-name-index-cache`.
- Local registered probe metrics (lower is better unless informational):
  - `full_config_template_elapsed_ms_mean`: base `26.108913`, head `21.988626` (`-4.120287 ms`, ~`15.78%` faster).
  - `elapsed_ms_mean`: base `23.206018`, head `22.288361` (`-0.917658 ms`, ~`3.95%` faster).
  - `selector_planning_elapsed_ms_mean`: base `31.370858`, head `30.707198` (`-0.663660 ms`, ~`2.12%` faster; adjacent selector segment).
  - `full_config_template_hits_mean`: base/head `16000.0` (unchanged).
  - `select_calls_mean`: base/head `80000.0` (unchanged).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux-local Python behavior and synthetic probe metrics were validated. No Swift runtime effect is claimed.
- The slice targets only full-list built-in tool config calls; partial selection behavior is intentionally unchanged.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
