### PR TITLE
perf: fast path auto-map loader strings

### DIFF
--- a/docs/plans/2026-07-07-model-load-auto-map-leading-ascii.md
+++ b/docs/plans/2026-07-07-model-load-auto-map-leading-ascii.md
@@ -1,0 +1,45 @@
+# Model Load Auto-Map Leading ASCII Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `_auto_map_has_custom_loader(...)` in `services/mlx-worker-python/worker/model_load_trust.py`. It preserves custom-loader detection semantics for empty strings, ASCII whitespace-only strings, Unicode whitespace-only strings, non-string fallback values, and common non-empty `auto_map` strings.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `Model load config JSON bytes` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and selects this probe when `services/mlx-worker-python/worker/model_load_trust.py`, related tests, or `scripts/model_load_config_json_bytes_probe.py` changes.
+
+## Optimization
+
+The hot probe payload uses `auto_map` values like `"custom.Loader"`. Instead of calling `value[0].isspace()` for the common leading printable ASCII case, check `value[0] > " "` first and return immediately. Values whose first character is not printable ASCII still fall through to the existing whitespace-preserving checks, including Unicode whitespace.
+
+## Verification Plan
+
+1. Add focused regression coverage for Unicode whitespace-only `auto_map` strings so the printable-ASCII fast path cannot change blank-string semantics.
+2. Run the registered focused test command locally on Linux.
+3. Run changed-scope coverage for the registered model-load probe scope and require at least 95% coverage for touched executable scope.
+4. Run the registered probe locally on Linux before and after the change and compare repeated `elapsed_ms_mean` samples.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Baseline
+
+Local Linux baseline on `origin/main`, `scripts/model_load_config_json_bytes_probe.py` repeated three times:
+
+- `elapsed_ms_mean=6.085972717430975`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`
+- `elapsed_ms_mean=5.696465859987906`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`
+- `elapsed_ms_mean=5.9100692867234885`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`
+
+Mean baseline `elapsed_ms_mean=5.89750262138079` ms.
+
+## Candidate Metrics
+
+Local Linux candidate on this branch, `scripts/model_load_config_json_bytes_probe.py` repeated three times:
+
+- `elapsed_ms_mean=5.782281855187778`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`
+- `elapsed_ms_mean=5.56336300048445`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`
+- `elapsed_ms_mean=5.701765139487439`, `peak_bytes_mean=3194.285714285714`, `rejections_mean=300.0`
+
+Mean candidate `elapsed_ms_mean=5.682469998386556` ms. Delta vs baseline: `-0.21503262299423387` ms (`~3.6462%` lower). `rejections_mean` remained `300.0` and `peak_bytes_mean` remained `3194.285714285714`.
+
+## Linux Validation Boundary
+
+This slice only changes Python worker code and is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_model_load_trust.py
+++ b/services/mlx-worker-python/tests/test_model_load_trust.py
@@ -508,6 +508,7 @@ def test_trust_policy_auto_map_common_string_uses_leading_character_fast_path() 
 def test_trust_policy_auto_map_custom_loader_scan_preserves_blank_string_behavior() -> None:
     assert model_load_trust_module._auto_map_has_custom_loader({"AutoModel": ""}) is False
     assert model_load_trust_module._auto_map_has_custom_loader({"AutoModel": " \t\n"}) is False
+    assert model_load_trust_module._auto_map_has_custom_loader({"AutoModel": "\u2003\u2003"}) is False
     assert model_load_trust_module._auto_map_has_custom_loader({"AutoModel": "custom.Loader"}) is True
 
 

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -318,7 +318,8 @@ def _auto_map_has_custom_loader(auto_map: dict[Any, Any]) -> bool:
         if isinstance(value, str):
             if not value:
                 continue
-            if not value[0].isspace() or not value.isspace():
+            first = value[0]
+            if " " < first <= "~" or not first.isspace() or not value.isspace():
                 return True
         elif value is not None and str(value).strip():
             return True


### PR DESCRIPTION
## Summary
- Fast-path common printable ASCII `auto_map` loader strings in `_auto_map_has_custom_loader(...)` before falling back to full whitespace checks.
- Add regression coverage for Unicode whitespace-only `auto_map` strings so blank-string semantics stay unchanged.
- Document the Python-only performance slice and local Linux probe evidence.

## Plan or Spec
- `docs/plans/2026-07-07-model-load-auto-map-leading-ascii.md`
- Registered PR-scoped probe: `Model load config JSON bytes` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_custom_loader_scan_preserves_blank_string_behavior
.                                                                        [100%]
1 passed in 0.43s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered Model load config JSON bytes test_command>
.............................                                            [100%]
29 passed in 1.52s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered Model load config JSON bytes test_command tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py
.............................                                            [100%]
29 passed in 1.07s
TOTAL 3 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py  # baseline x3 on origin/main
elapsed_ms_mean: 6.085972717430975, 5.696465859987906, 5.9100692867234885

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py  # candidate x3
elapsed_ms_mean: 5.782281855187778, 5.56336300048445, 5.701765139487439

$ git diff --check
(no output)
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Baseline local Linux mean: `elapsed_ms_mean=5.89750262138079` ms.
- Candidate local Linux mean: `elapsed_ms_mean=5.682469998386556` ms.
- Delta: `-0.21503262299423387` ms (`~3.6462%` lower).
- `rejections_mean` remained `300.0`; `peak_bytes_mean` remained `3194.285714285714`.
- CI PR-scoped performance is still required as the registered merge-gate validation.

## Known Gaps
- Linux-only local validation for this Python worker slice; no Swift runtime effect is claimed.
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this focused scheduled slice; GitHub Actions is the broader gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
