### PR TITLE
perf(dataset): reuse source hashing constructor

### DIFF
--- a/docs/plans/2026-07-07-dataset-source-sha256-binding.md
+++ b/docs/plans/2026-07-07-dataset-source-sha256-binding.md
@@ -1,0 +1,40 @@
+# Dataset source SHA-256 binding slice
+
+## Scope
+
+This Python-only performance slice is limited to dataset preparation hashing in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+The common ingest path repeatedly hashes normalized source text, source paths,
+and deterministic validation split IDs. This slice reuses a module-level SHA-256
+constructor binding instead of resolving `hashlib.sha256` or rebinding it per
+record call.
+
+No dataset ingest, segmentation, privacy, validation split, or receipt semantics
+change.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for dataset preparation ingest behavior,
+`scripts/dataset_source_records_probe.py`, and PR-scoped performance registry
+coverage.
+
+## Validation plan
+
+Run locally on Linux before pushing:
+
+1. Focused registered test command for `dataset-source-records-scandir`.
+2. Registered changed-scope coverage command for the same probe.
+3. Registered local PR-scoped performance runner comparing `origin/main` to this
+   branch for `dataset-source-records-scandir`.
+
+GitHub Actions PR-scoped performance remains the merge gate after opening the PR.
+
+## Acceptance criteria
+
+- Focused tests pass.
+- Changed-scope coverage for touched files is at least 95%.
+- The registered probe shows a clear improvement or non-regression for
+  `record_elapsed_ms_mean` and no behavior guard failures.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -35,6 +35,7 @@ _CODE_SOURCE_SUFFIXES = frozenset(
     (".py", ".swift", ".js", ".ts", ".java", ".go", ".rs", ".cpp", ".c", ".h")
 )
 _STRUCTURED_DATA_SOURCE_SUFFIXES = frozenset((".jsonl", ".json", ".csv", ".tsv"))
+_SHA256 = hashlib.sha256
 _CODE_SOURCE_LANGUAGE_BY_SUFFIX = {
     ".py": "python",
     ".swift": "swift",
@@ -326,7 +327,7 @@ def prepare_dataset_ingest(request: DatasetIngestRequest) -> dict[str, Any]:
             text, record_pii_mask_count = _mask_pii(text)
         normalized = _normalize_text(text)
         if request.exact_dedup:
-            exact_key = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+            exact_key = _SHA256(normalized.encode("utf-8")).hexdigest()
             if exact_key in exact_seen:
                 exact_dedup_count += 1
                 continue
@@ -1482,14 +1483,13 @@ def _record(
     normalized_text = text if normalized else _normalize_line_endings(text)
     normalized_bytes = normalized_text.encode("utf-8")
     record_metadata = dict(metadata) if metadata else {}
-    sha256 = hashlib.sha256
     path_name = path.name
     path_key = str(path).encode("utf-8")
     return {
-        "source_id": sha256(path_key).hexdigest()[:16],
+        "source_id": _SHA256(path_key).hexdigest()[:16],
         "source_uri": path_name,
         "source_kind": source_kind,
-        "content_sha256": sha256(normalized_bytes).hexdigest(),
+        "content_sha256": _SHA256(normalized_bytes).hexdigest(),
         "byte_size": len(normalized_bytes),
         "record_count": 1,
         "text": normalized_text,
@@ -1684,7 +1684,12 @@ def _split_dataset_version_validation(
     validation_count = min(max(validation_count, 1), len(rows) - 1)
     validation_segment_ids = {
         row["source_segment_id"]
-        for row in sorted(rows, key=lambda item: hashlib.sha256(str(item["source_segment_id"]).encode("utf-8")).hexdigest())[:validation_count]
+        for row in sorted(
+            rows,
+            key=lambda item: _SHA256(
+                str(item["source_segment_id"]).encode("utf-8")
+            ).hexdigest(),
+        )[:validation_count]
     }
     train_rows: list[dict[str, Any]] = []
     validation_rows: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- Reuses a module-level SHA-256 constructor binding in dataset preparation hashing paths.
- Keeps dataset ingest, source record, and validation split semantics unchanged.

## Plan or Spec
- `docs/plans/2026-07-07-dataset-source-sha256-binding.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 45 passed in 1.71s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 45 passed in 1.10s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix-base --head-repo "$PWD" --output /tmp/dataset-source-sha256-binding-probe.json
# rc=0; head verification test_ok=True coverage_ok=True; base/head probes ok=True

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics
# 35 passed in 0.50s

git diff --check
# rc=0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe `dataset-source-records-scandir` (`/tmp/dataset-source-sha256-binding-probe.json`):
  - `elapsed_ms_mean`: base `11.2903 ms`, head `11.2576 ms` (delta `-0.0328 ms`, `0.29%` faster).
  - `record_elapsed_ms_mean`: base `20.8371 ms`, head `20.4148 ms` (delta `-0.4223 ms`, `2.03%` faster).
  - `record_elapsed_ms_p95`: base `22.1864 ms`, head `21.2118 ms` (delta `-0.9747 ms`, `4.39%` faster).
  - Guard metrics: `file_count_mean=7000.0`, `source_kind_variant_count=7.0`, probes ok for both base and head.
- CI PR-scoped performance is required as final registered probe validation before merge.

## Known Gaps
- Linux local validation only; this is a Python-only slice.
- No protocol, dependency, generated artifact, or Swift runtime changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
