### PR TITLE
perf(model-load): bind config stat helpers

### DIFF
--- a/docs/plans/2026-07-07-model-load-config-os-binding.md
+++ b/docs/plans/2026-07-07-model-load-config-os-binding.md
@@ -1,0 +1,30 @@
+# Model Load Config OS Binding Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to `services/mlx-worker-python/worker/model_load_trust.py` and the repeated model-load trust policy path that probes `config.json` for custom loader metadata.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for `model_load_trust.py`, `test_model_load_trust.py`, `test_pr_scoped_performance.py`, and `scripts/model_load_config_json_bytes_probe.py`.
+
+## Optimization
+
+Bind the hot OS and stat helpers used by the repeated config probe path at module import time:
+
+- `os.stat` -> `_OS_STAT`
+- `os.scandir` -> `_OS_SCANDIR`
+- `stat.S_ISREG` -> `_STAT_ISREG`
+
+This keeps trust-policy semantics unchanged while avoiding repeated global attribute resolution in the hot config stat and executable-file fallback paths.
+
+## Verification Plan
+
+Run locally on Linux before PR:
+
+1. Focused model-load trust tests and PR-scoped performance probe dispatch tests.
+2. Changed-scope coverage using the registered coverage command for `model-load-config-json-bytes`.
+3. Registered probe locally with `scripts/model_load_config_json_bytes_probe.py`.
+4. `git diff --check`.
+
+GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -23,6 +23,9 @@ CONFIG_JSON_DETECTION = (False, CONFIG_JSON_SOURCE)
 CONFIG_JSON_ABSENT_DETECTION = (False, CONFIG_JSON_ABSENT_SOURCE)
 CONFIG_JSON_AUTO_MAP_DETECTION = (True, CONFIG_JSON_AUTO_MAP_SOURCE)
 _JSON_LOADS = json.loads
+_OS_STAT = os.stat
+_OS_SCANDIR = os.scandir
+_STAT_ISREG = stat.S_ISREG
 EXECUTABLE_MODEL_FILE_PREFIXES = (
     "configuration",
     "feature_extraction",
@@ -258,10 +261,10 @@ def _detect_custom_loader_requirement(model_spec: common_pb2.ModelSpec) -> tuple
     if config_path is not None:
         config_path_text, stat_path = config_path
         try:
-            config_stat = os.stat(stat_path)
+            config_stat = _OS_STAT(stat_path)
         except OSError:
             config_stat = None
-        if config_stat is not None and stat.S_ISREG(config_stat.st_mode):
+        if config_stat is not None and _STAT_ISREG(config_stat.st_mode):
             config_detection = _detect_custom_loader_requirement_for_stat(
                 config_path_text,
                 config_stat.st_mtime_ns,
@@ -285,7 +288,7 @@ def _detect_executable_model_files(model_spec: common_pb2.ModelSpec) -> tuple[st
         scan_path = model_path
     is_executable_model_file_entry = _is_executable_model_file_entry
     try:
-        with os.scandir(scan_path) as entries:
+        with _OS_SCANDIR(scan_path) as entries:
             return tuple(
                 sorted(
                     entry.name
@@ -331,8 +334,8 @@ def _read_model_config(model_spec: common_pb2.ModelSpec) -> dict[str, Any] | Non
         return None
     config_path_text, stat_path = config_path
     try:
-        config_stat = os.stat(stat_path)
-        if not stat.S_ISREG(config_stat.st_mode):
+        config_stat = _OS_STAT(stat_path)
+        if not _STAT_ISREG(config_stat.st_mode):
             return None
     except OSError:
         return None


### PR DESCRIPTION
## Summary
- Bind hot `os.stat`, `os.scandir`, and `stat.S_ISREG` helpers in `model_load_trust.py` for the repeated config trust-policy probe path.
- Keep custom-loader detection semantics unchanged while reducing repeated global attribute lookup overhead.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-07-model-load-config-os-binding.md`
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_bytes_with_direct_open services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_reads_config_json_with_bound_json_loads services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_config_json_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_caches_auto_map_detection_by_file_stat services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_auto_map_detection_does_not_scan_model_files services/mlx-worker-python/tests/test_model_load_trust.py::test_read_model_config_reuses_cached_config_path_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_load_config_json_bytes_probe_script_emits_metrics` → 7 passed
- Registered `model-load-config-json-bytes` `test_command` → 29 passed
- Registered `model-load-config-json-bytes` `coverage_command` → TOTAL 8 0 100%
- Registered `model-load-config-json-bytes` `probe_command` locally → `elapsed_ms_mean=5.540019566459315`, `peak_bytes_mean=3187.4285714285716`, `rejections_mean=300.0`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`aggregate_measurable_changed_lines=8`, `aggregate_covered_changed_lines=8`).
- Local Linux probe baseline on `origin/main` (5 runs): `old_mean=5.897717285967831ms`.
- Local Linux probe after change (5 runs): `new_mean=5.610333857060011ms`.
- Delta: `-0.28738342890781965ms` mean, `speedup=1.0512239442838465x` (`4.872790860823016%`).
- PR-scoped performance CI is required as the merge gate for the registered probe report.

## Known Gaps
- This is a Python-only slice verified locally on Linux; no Swift runtime effect is claimed.
- The change intentionally does not alter trust-policy cache keys or file freshness semantics.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage was measured locally.
- [x] Registered probe was run locally and showed an improvement.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
