### PR TITLE
perf: inline runtime export failure check collection

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -218,6 +218,13 @@ fails. Paths with empty relative text or `..` segments continue through the same
 safe fallback behavior, but ordinary bounded runtime excerpts skip the unused
 fallback assignment and the extra parent-segment boundary checks.
 
+A follow-up 2026-07-07 failure-check source collection slice keeps mapping and
+attribute-style smoke check semantics unchanged while extracting failure check
+fields inline in `_collect_source_lines()`. The hot diagnostic parser probe uses
+small mapping rows for synthetic smoke failures, so this avoids repeated helper
+calls and repeated `Mapping` dispatch for every check row while preserving the
+same source-path fallback and failed/blocked status filter.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -792,6 +793,59 @@ def test_export_target_diagnostics_source_collection_skips_duplicates_and_missin
 
     assert [line.source_path for line in lines].count(log_path) == 1
     assert all(line.source_path != "logs/missing-runtime.log" for line in lines)
+
+
+def test_export_target_diagnostics_collects_mapping_and_object_failure_checks(
+    tmp_path: Path,
+) -> None:
+    _target_root, manifest = _materialized_manifest(
+        tmp_path,
+        FIXTURE_ROOT / "melix_managed/export-target-manifest.json",
+    )
+    layout = build_export_target_layout(tmp_path, manifest)
+
+    lines = _collect_source_lines(
+        layout,
+        manifest,
+        failure_checks=(
+            {
+                "check": "load_check",
+                "status": "passed",
+                "failure_code": "runtime_load_failed",
+                "failure_message": "should be skipped",
+                "evidence_path": "smoke/skipped.json",
+            },
+            {
+                "name": "metadata_check",
+                "status": "failed",
+                "failure_code": "missing_blob",
+                "failure_message": "missing blob sha256-777777",
+                "evidence_path": "smoke/metadata.json",
+            },
+            SimpleNamespace(
+                check="generation_check",
+                status="blocked",
+                failure_code="runtime_timeout",
+                failure_message="generation smoke timed out",
+                evidence_path="smoke/generation.json",
+            ),
+        ),
+        bounded_bytes=1024,
+    )
+
+    collected = [(line.source_path, line.text) for line in lines]
+    assert (
+        "smoke/skipped.json",
+        "load_check: runtime_load_failed: should be skipped",
+    ) not in collected
+    assert (
+        "smoke/metadata.json",
+        "metadata_check: missing_blob: missing blob sha256-777777",
+    ) in collected
+    assert (
+        "smoke/generation.json",
+        "generation_check: runtime_timeout: generation smoke timed out",
+    ) in collected
 
 
 def test_export_target_diagnostics_falls_back_when_path_resolution_raises_oserror(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -502,17 +502,36 @@ def _collect_source_lines(
             _extend_source_lines(lines, row.path, text)
 
     for check in failure_checks:
-        failure_message = _check_value(check, "failure_message")
-        failure_code = _check_value(check, "failure_code")
-        status = _check_value(check, "status")
+        if isinstance(check, Mapping):
+            check_get = check.get
+            raw_failure_message = check_get("failure_message", "")
+            raw_failure_code = check_get("failure_code", "")
+            raw_status = check_get("status", "")
+            raw_check_name = check_get("check", "") or check_get("name", "")
+            raw_evidence_path = check_get("evidence_path", "")
+        else:
+            raw_failure_message = getattr(check, "failure_message", "")
+            raw_failure_code = getattr(check, "failure_code", "")
+            raw_status = getattr(check, "status", "")
+            raw_check_name = getattr(check, "check", "") or getattr(check, "name", "")
+            raw_evidence_path = getattr(check, "evidence_path", "")
+        failure_message = str(raw_failure_message) if raw_failure_message is not None else ""
+        failure_code = str(raw_failure_code) if raw_failure_code is not None else ""
+        status = str(raw_status) if raw_status is not None else ""
         if not failure_message and not failure_code:
             continue
         if status and status not in _FAILING_CHECK_STATUSES:
             continue
-        check_name = _check_value(check, "check") or _check_value(check, "name") or "smoke_failure"
-        evidence_path = _check_value(check, "evidence_path") or manifest.evidence.smoke_receipt_path
-        text = f"{check_name}: {failure_code}: {failure_message}".strip()
-        _extend_source_lines(lines, evidence_path or "smoke/smoke-receipt.json", text)
+        check_name = str(raw_check_name) if raw_check_name is not None else ""
+        evidence_path = str(raw_evidence_path) if raw_evidence_path is not None else ""
+        text = f"{check_name or 'smoke_failure'}: {failure_code}: {failure_message}".strip()
+        _extend_source_lines(
+            lines,
+            evidence_path
+            or manifest.evidence.smoke_receipt_path
+            or "smoke/smoke-receipt.json",
+            text,
+        )
 
     return lines
 
@@ -539,13 +558,6 @@ def _split_source_lines(source_path: str, text: str) -> list[_SourceLine]:
     _extend_source_lines(lines, source_path, text)
     return lines
 
-
-def _check_value(check: object, name: str) -> str:
-    if isinstance(check, Mapping):
-        value = check.get(name, "")
-    else:
-        value = getattr(check, name, "")
-    return str(value) if value is not None else ""
 
 
 def _build_redacted_excerpt(


### PR DESCRIPTION
## Summary
- Inline runtime export failure-check field extraction in `_collect_source_lines()` to avoid repeated helper calls and repeated `Mapping` dispatch in the diagnostic parser hot path.
- Preserve mapping and attribute-style smoke failure semantics with a regression test covering failed/blocked collection and passed-check skipping.
- Update the runtime export diagnostic parser plan with this 2026-07-07 slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# baseline registered probe on origin/main branch worktree (3 runs), exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
elapsed_ms_mean: 2592.5140266073868 / 2591.9248647987843 / 2616.444559197407
diagnostic_latency_ms: 8.678011014126241 / 7.178325991844758 / 6.998060009209439

# focused new regression test, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_collects_mapping_and_object_failure_checks
1 passed in 0.20s

# registered focused test command, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
81 passed in 0.62s

# registered changed-scope coverage command, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
81 passed in 1.47s
TOTAL 28 0 100%

# registered probe after change (3-run comparison set plus final sanity run), exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
comparison elapsed_ms_mean: 2642.9208032030147 / 2551.933804404689 / 2580.023369390983
comparison diagnostic_latency_ms: 7.083491014782339 / 7.1588750288356096 / 6.985541025642306
final sanity elapsed_ms_mean: 2595.5696641933173
final sanity diagnostic_latency_ms: 7.0914580137468874

# whitespace guard, exit 0
git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 28 0 100%`.
- Registered probe metrics (3-run means):
  - `elapsed_ms_mean`: old_mean=2600.294483534526 ms, new_mean=2591.6259923328957 ms, delta=-8.668491201630331 ms, speedup=1.0033448079419158x.
  - `diagnostic_latency_ms`: old_mean=7.61813233839348 ms, new_mean=7.075969023086752 ms, delta=-0.5421633153067278 ms, speedup=1.0766203630255888x.
- CI is still required to run the registered PR-scoped performance workflow and publish the official probe report before merge.

## Known Gaps
- No Swift runtime validation is involved; this is a Python-only runtime export diagnostics slice verified locally on Linux.
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; the registered focused gate and changed-scope coverage were run for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new probe overhead introduced.
- [x] Deferred work and known gaps are stated explicitly.
