### PR TITLE
perf(runtime-export): add exact diagnostic phrase lookup

### DIFF
--- a/docs/plans/2026-07-06-export-diagnostic-common-phrase-fastpath.md
+++ b/docs/plans/2026-07-06-export-diagnostic-common-phrase-fastpath.md
@@ -15,12 +15,18 @@ entries and reports both aggregate diagnostic report latency and
 ## Optimization
 
 `_diagnoses_from_excerpt()` already lowercases each candidate log line and gates
-unrelated text with diagnosis markers. This slice adds a narrow fast phrase table
-for the most common literal runtime failure phrases emitted by fixtures and
+unrelated text with diagnosis markers. The first slice added a narrow fast phrase
+table for the most common literal runtime failure phrases emitted by fixtures and
 runtime smoke checks. When a phrase maps directly to a known diagnosis pattern,
 the parser emits the same diagnosis payload without walking the regex expression
 table for that line. Lines that do not hit the phrase table keep the existing
 marker and regex behavior unchanged.
+
+This follow-up slice adds an exact lowered-text lookup for those canonical
+runtime smoke failure lines before the phrase scan. Exact matches still dedupe
+previously emitted diagnosis codes and then emit the same diagnosis payload, but
+avoid the repeated ordered phrase checks on the common fixture/runtime messages.
+Non-exact log text continues through the existing phrase and regex paths.
 
 ## Verification
 

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -60,12 +60,16 @@ def test_export_target_diagnostics_common_phrase_fast_path_skips_regex_table(
         _SourceLine(
             source_path="logs/ollama-create.log",
             text="runtime load failed while opening model",
-        )
+        ),
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text="runtime load failed while opening model",
+        ),
     ]
 
     diagnoses = _diagnoses_from_excerpt(
         source_lines,
-        {0: 1},
+        {0: 1, 1: 2},
         "diagnostics/redacted-log-excerpt.txt",
     )
 

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -294,6 +294,17 @@ _DIAGNOSIS_FAST_PHRASE_PATTERNS = (
     ("runtime load failed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED]),
     ("model load failed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED]),
 )
+_DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS = {
+    "runtime load failed while opening model": _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED],
+    "unsupported architecture arm64 required": _DIAGNOSIS_PATTERN_BY_CODE[CODE_UNSUPPORTED_ARCHITECTURE],
+    "duplicate tensor name decoder.layers.0": _DIAGNOSIS_PATTERN_BY_CODE[CODE_DUPLICATE_TENSOR_NAME],
+    "missing blob sha256-777777 not found": _DIAGNOSIS_PATTERN_BY_CODE[CODE_MISSING_BLOB],
+    "runtime binary not installed: ollama": _DIAGNOSIS_PATTERN_BY_CODE[CODE_MISSING_BINARY],
+    "invalid runtime path /tmp/melix/bad-target": _DIAGNOSIS_PATTERN_BY_CODE[CODE_INVALID_RUNTIME_PATH],
+    "generation smoke timed out after deadline exceeded": _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_TIMEOUT],
+    "permission denied opening model weights": _DIAGNOSIS_PATTERN_BY_CODE[CODE_PERMISSION_DENIED],
+    "metal out of memory during load": _DIAGNOSIS_PATTERN_BY_CODE[CODE_INSUFFICIENT_MEMORY],
+}
 
 
 def write_export_diagnostics_receipt(
@@ -831,6 +842,7 @@ def _diagnoses_from_excerpt(
     seen_codes_add = seen_codes.add
     patterns = _DIAGNOSIS_PATTERNS
     fast_phrase_patterns = _DIAGNOSIS_FAST_PHRASE_PATTERNS
+    exact_fast_text_patterns = _DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS
     source_lines_local = source_lines
     has_diagnosis_marker = _has_diagnosis_marker
     remaining_known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
@@ -840,6 +852,24 @@ def _diagnoses_from_excerpt(
         text = source_lines_local[index].text
         lowered_text = text.lower()
         if not has_diagnosis_marker(lowered_text):
+            continue
+        fast_pattern = exact_fast_text_patterns.get(lowered_text)
+        if fast_pattern is not None:
+            pattern_code = fast_pattern.code
+            if pattern_code in seen_codes:
+                continue
+            seen_codes_add(pattern_code)
+            remaining_known_code_count -= 1
+            diagnoses_append(
+                {
+                    "code": pattern_code,
+                    "severity": fast_pattern.severity,
+                    "matched_pattern_id": fast_pattern.pattern_id,
+                    "operator_message": fast_pattern.operator_message,
+                    "remediation": fast_pattern.remediation,
+                    "evidence_path": f"{excerpt_path}#line-{line_number}",
+                }
+            )
             continue
         fast_pattern = None
         for phrase, pattern in fast_phrase_patterns:


### PR DESCRIPTION
## Summary
- Add an exact lowered-text lookup for canonical runtime export diagnostic failure lines before the ordered phrase scan.
- Preserve existing diagnosis payloads and duplicate-code suppression while reducing repeated phrase checks for common smoke/runtime messages.
- Extend the existing fast-path regression test to cover duplicate exact matches.

## Plan or Spec
- `docs/plans/2026-07-06-export-diagnostic-common-phrase-fastpath.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 81 passed in 1.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 81 passed in 1.65s; TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-diagnostic-exact-fastpath-20260707 --head-repo "$PWD" --output /tmp/runtime_diagnostic_exact_fastpath_probe.json
# ok; base/head probe completed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-diagnostic-exact-fastpath-20260707 --head-repo "$PWD" --output /tmp/runtime_diagnostic_exact_fastpath_probe_2.json
# ok; base/head probe completed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered local probe (`runtime-export-diagnostic-parser`, latest repeat):
  - `diagnosis_matching_elapsed_ms_mean`: base `0.40590259595774114`, head `0.34133599256165326` (`-15.91%`, lower is better).
  - `elapsed_ms_mean`: base `2640.558430197416`, head `2638.4135750005953` (`-0.08%`, lower is better).
  - `diagnostic_parser_coverage`: base `1.0`, head `1.0`.
  - `diagnosis_code_count`: base `9.0`, head `9.0`.
- Earlier local repeat also showed `diagnosis_matching_elapsed_ms_mean` base `0.4116215917747468`, head `0.3335608053021133` (`-18.96%`).
- GitHub Actions PR-scoped performance is still the final registered probe validation and merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the focused registered Python probe commands on Linux.
- No Swift/macOS runtime effect is claimed for this Python-only change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
