### PR TITLE
perf(dataset): use itemgetter for version listing sort

### DIFF
--- a/docs/plans/2026-07-07-dataset-version-list-string-sort-key.md
+++ b/docs/plans/2026-07-07-dataset-version-list-string-sort-key.md
@@ -1,0 +1,39 @@
+# Dataset Version Listing String Sort Key Slice
+
+## Scope
+
+This Python-only performance slice is limited to `list_dataset_versions()` in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+The common dataset-version listing path reads generated `dataset-version.json`
+files whose `created_at` and `version_id` fields are strings. The existing sort
+key preserved malformed/non-string compatibility by calling a Python helper for
+every row, even on this common string-only path.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+fields, and watches the production module, focused tests, and
+`scripts/dataset_version_listing_probe.py`.
+
+## Plan
+
+1. Add a regression test proving non-string sort keys still use the historical
+   string-coercion fallback ordering.
+2. Keep the existing fallback helper for malformed manifests, but detect the
+   common string-key path while building the listing.
+3. Use a bound `operator.itemgetter("created_at", "version_id")` sort key for
+   the common string-key path to avoid per-row Python helper calls.
+4. Run focused pytest, changed-scope coverage, and the registered local probe on
+   Linux before opening the PR. GitHub Actions PR-scoped performance remains the
+   merge gate.
+
+## Verification targets
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_skips_missing_or_directory_manifests services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_preserves_non_string_sort_key_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_skips_missing_or_directory_manifests services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_preserves_non_string_sort_key_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo <baseline-worktree> --head-repo "$PWD" --output /tmp/dataset_version_listing_probe.json
+```

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -458,6 +458,46 @@ def test_dataset_version_listing_handles_missing_versions_root(tmp_path: Path) -
     assert listing["metrics"]["dataset_version_count"] == 0
 
 
+def test_dataset_version_listing_preserves_non_string_sort_key_fallback(tmp_path: Path) -> None:
+    versions_root = tmp_path / "datasets" / "support-chat" / "versions"
+    for version_id, created_at in [
+        ("support-chat-v2", 2),
+        ("support-chat-v10", 10),
+        ("support-chat-v1", "2026-05-24T01:00:00Z"),
+    ]:
+        version_dir = versions_root / version_id
+        version_dir.mkdir(parents=True)
+        payload = {
+            "dataset_id": "support-chat",
+            "version_id": version_id,
+            "created_at": created_at,
+            "status": "ready",
+            "train_count": 0,
+            "validation_count": 0,
+            "failed_count": 0,
+            "quality_summary_path": "",
+        }
+        if version_id == "support-chat-v1":
+            payload.pop("status")
+            payload["created_at"] = 1
+        (version_dir / "dataset-version.json").write_text(
+            json.dumps(payload),
+            encoding="utf-8",
+        )
+
+    listing = list_dataset_versions(
+        workspace_manifest_path=tmp_path / "workspace-manifest.json",
+        output_root=tmp_path / "datasets",
+        dataset_id="support-chat",
+    )
+
+    assert [item["version_id"] for item in listing["versions"]] == [
+        "support-chat-v1",
+        "support-chat-v10",
+        "support-chat-v2",
+    ]
+
+
 def test_failed_only_retry_copies_successful_samples_without_rewriting(
     tmp_path: Path,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 import hashlib
 import io
 import json
+from operator import itemgetter
 import os
 import re
 import time
@@ -1084,6 +1085,7 @@ def list_dataset_versions(
     versions_append = versions.append
     json_loads = json.loads
     open_file = open
+    common_string_sort_keys = True
     for manifest_path in _iter_dataset_version_manifest_paths(versions_root):
         try:
             with open_file(manifest_path, "rb") as handle:
@@ -1091,11 +1093,15 @@ def list_dataset_versions(
         except (FileNotFoundError, IsADirectoryError, NotADirectoryError):
             continue
         try:
+            created_at = version["created_at"]
+            version_id = version["version_id"]
+            if type(created_at) is not str or type(version_id) is not str:
+                common_string_sort_keys = False
             versions_append(
                 {
                     "dataset_id": version["dataset_id"],
-                    "version_id": version["version_id"],
-                    "created_at": version["created_at"],
+                    "version_id": version_id,
+                    "created_at": created_at,
                     "status": version["status"],
                     "train_count": version["train_count"],
                     "validation_count": version["validation_count"],
@@ -1106,11 +1112,15 @@ def list_dataset_versions(
             )
         except KeyError:
             version_get = version.get
+            created_at = version_get("created_at", "")
+            version_id = version_get("version_id", "")
+            if type(created_at) is not str or type(version_id) is not str:
+                common_string_sort_keys = False
             versions_append(
                 {
                     "dataset_id": version_get("dataset_id", ""),
-                    "version_id": version_get("version_id", ""),
-                    "created_at": version_get("created_at", ""),
+                    "version_id": version_id,
+                    "created_at": created_at,
                     "status": version_get("status", ""),
                     "train_count": version_get("train_count", 0),
                     "validation_count": version_get("validation_count", 0),
@@ -1119,7 +1129,11 @@ def list_dataset_versions(
                     "dataset_version_path": manifest_path,
                 }
             )
-    versions.sort(key=_dataset_version_list_sort_key)
+    versions.sort(
+        key=_DATASET_VERSION_LIST_STRING_SORT_KEY
+        if common_string_sort_keys
+        else _dataset_version_list_sort_key
+    )
     return {
         "schema_version": DATASET_VERSION_LIST_SCHEMA_VERSION,
         "workspace_manifest_path": manifest_path_string,
@@ -1139,6 +1153,9 @@ def _dataset_version_list_sort_key(item: dict[str, Any]) -> tuple[str, str]:
         created_at if type(created_at) is str else str(created_at),
         version_id if type(version_id) is str else str(version_id),
     )
+
+
+_DATASET_VERSION_LIST_STRING_SORT_KEY = itemgetter("created_at", "version_id")
 
 
 def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:


### PR DESCRIPTION
## Summary
- Optimizes `list_dataset_versions()` by using a bound `operator.itemgetter("created_at", "version_id")` sort key on the common string-key path.
- Preserves the historical string-coercion fallback for malformed/non-string sort keys.
- Adds a focused regression test and records the slice plan.

## Plan or Spec
- `docs/plans/2026-07-07-dataset-version-list-string-sort-key.md`
- Registered PR-scoped probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_skips_missing_or_directory_manifests services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_preserves_non_string_sort_key_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 7 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_skips_missing_or_directory_manifests services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_handles_missing_versions_root services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_version_listing_preserves_non_string_sort_key_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# 7 passed in 0.53s; TOTAL 24 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_version_listing_probe.json
# head verification: 57 passed in 1.75s; changed-scope coverage TOTAL 24 0 100%; base/head probes ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 24 0 100%`.
- Local registered probe `dataset-version-listing-scandir`:
  - base `elapsed_ms_mean=38.441975`, head `elapsed_ms_mean=34.848857`, delta `-3.593118 ms` (~9.35% faster).
  - base `elapsed_ms_min=33.400135`, head `elapsed_ms_min=32.612018`, delta `-0.788117 ms`.
  - base `elapsed_ms_p95=38.261236`, head `elapsed_ms_p95=34.905417`, delta `-3.355819 ms`.
  - `version_count=2500`.
- GitHub Actions PR-scoped performance is still required as the merge gate.

## Known Gaps
- Linux local validation covers the Python slice. No Swift runtime path is changed.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes; registered probe overhead is unchanged.
- [x] Deferred work and known gaps are stated explicitly.
