### PR TITLE
perf(dataset): bind source size stat helpers

### DIFF
--- a/docs/plans/2026-07-07-dataset-source-size-stat-local-bind.md
+++ b/docs/plans/2026-07-07-dataset-source-size-stat-local-bind.md
@@ -1,0 +1,21 @@
+# Dataset source size stat local binding
+
+## Scope
+
+This Python-only performance slice is limited to `services/mlx-worker-python/worker/productization/dataset_preparation.py` and the dataset ingest source-size accounting path that runs after source file discovery.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for `dataset_preparation.py`, `test_dataset_preparation_ingest.py`, `test_pr_scoped_performance.py`, and `scripts/dataset_source_records_probe.py`.
+
+## Optimization
+
+`_source_size_entries(...)` previously performed an `entries.append` lookup and a bound `path.stat` lookup for every discovered source path. This slice binds `entries.append` and `Path.stat` once per helper invocation, preserving the existing ordered `(Path, size)` output, test monkeypatch seam, and missing-file fallback while reducing repeated Python attribute lookups in large source trees.
+
+## Validation Plan
+
+1. Keep the regression coverage for ordered source-size accounting, including a missing file fallback.
+2. Run the registered focused test command for `dataset-source-records-scandir` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered local probe on Linux and compare against the synced `origin/main` baseline.
+5. Use the PR-scoped performance GitHub Actions report as the merge gate.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -20,6 +20,7 @@ from worker.productization.dataset_preparation import (
     _normalize_line_endings,
     _record,
     _read_source_text,
+    _source_size_entries,
     _source_kind,
     _source_kind_for_name,
     _workspace_privacy_detection_evidence,
@@ -57,6 +58,20 @@ def test_dataset_ingest_source_file_paths_use_scandir_without_rglob(
         "a/a.txt",
         "b/b.txt",
         "z.txt",
+    ]
+
+
+def test_dataset_ingest_source_size_entries_preserve_order_and_missing_files(tmp_path: Path) -> None:
+    first = tmp_path / "first.txt"
+    missing = tmp_path / "missing.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("alpha", encoding="utf-8")
+    second.write_text("bravo-charlie", encoding="utf-8")
+
+    assert _source_size_entries([first, missing, second]) == [
+        (first, 5),
+        (missing, 0),
+        (second, 13),
     ]
 
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -831,11 +831,13 @@ def _input_source_paths(input_path: Path) -> list[Path]:
 
 def _source_size_entries(paths: list[Path]) -> list[tuple[Path, int]]:
     entries: list[tuple[Path, int]] = []
+    entries_append = entries.append
+    path_stat = Path.stat
     for path in paths:
         try:
-            entries.append((path, path.stat().st_size))
+            entries_append((path, path_stat(path).st_size))
         except OSError:
-            entries.append((path, 0))
+            entries_append((path, 0))
     return entries
 
 


### PR DESCRIPTION
## Summary
- Bind `entries.append` and `Path.stat` once in dataset ingest source-size accounting.
- Add focused regression coverage for ordered source-size entries and missing-file fallback.
- Document the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-07-07-dataset-source-size-stat-local-bind.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_source_size_entries_preserve_order_and_missing_files
# 1 passed in 0.19s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 46 passed in 1.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 46 passed; changed-scope coverage TOTAL 11 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# {"elapsed_ms_mean": 11.484284998997198, "record_elapsed_ms_mean": 20.42139935921031, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /tmp/melix-dataset-source-size-stat-base-135258 --head-repo "$PWD" --output /tmp/dataset_source_size_stat_probe.json
# base elapsed_ms_mean=12.714165363418447; head elapsed_ms_mean=11.169174273329025
# base record_elapsed_ms_mean=21.625040368896656; head record_elapsed_ms_mean=20.872552815655414

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 11 0 100%`).
- Registered probe: `dataset-source-records-scandir`.
- Local base-vs-head probe: `elapsed_ms_mean` 12.714165363418447 ms -> 11.169174273329025 ms (delta -1.5449910900894217 ms, 12.15173034114149% faster).
- `record_elapsed_ms_mean` 21.625040368896656 ms -> 20.872552815655414 ms (delta -0.7524875532412416 ms, 3.479704733053568% faster).
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux local validation only; this slice touches Python code and does not validate Swift runtime effects.
- PR-scoped GitHub Actions performance report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped evidence probe; probe overhead is covered by the existing registered probe workflow.
- [x] Deferred work and known gaps are stated explicitly.
