### PR TITLE
perf(runtime-export): fast path clean diagnostic paths

### DIFF
--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -36,6 +36,8 @@ from worker.productization.export_target_diagnostics import (
     _has_named_secret_marker,
     _has_private_text_line_marker,
     _has_secret_redaction_marker,
+    _redact_absolute_path,
+    _RedactionSummary,
     _split_source_lines,
     _target_relative_text,
 )
@@ -92,6 +94,37 @@ def test_export_target_diagnostics_source_line_extension_matches_split_helper() 
 
 def test_export_target_diagnostics_target_relative_text_handles_root_slash_boundary() -> None:
     assert _target_relative_text("/tmp/melix-target/", "/tmp/melix-target") is None
+
+
+def test_export_target_diagnostics_absolute_path_redaction_preserves_suffix_contract(
+    tmp_path: Path,
+) -> None:
+    summary = _RedactionSummary()
+    target_root = tmp_path / "target"
+    target_root.mkdir()
+    target_file = target_root / "artifacts" / "model.gguf"
+
+    assert (
+        _redact_absolute_path(
+            str(target_file),
+            target_root,
+            str(target_root),
+            summary,
+        )
+        == "<target>/artifacts/model.gguf"
+    )
+    assert summary.redacted_absolute_path_count == 1
+
+    assert (
+        _redact_absolute_path(
+            f"{target_file}.)",
+            target_root,
+            str(target_root),
+            summary,
+        )
+        == "<target>/artifacts/model.gguf.)"
+    )
+    assert summary.redacted_absolute_path_count == 2
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -782,8 +782,12 @@ def _redact_absolute_path(
     resolved_target_root_text: str,
     summary: _RedactionSummary,
 ) -> str:
-    trimmed_path = raw_path.rstrip(".,)")
-    suffix = raw_path[len(trimmed_path):]
+    if raw_path[-1] in ".,)":
+        trimmed_path = raw_path.rstrip(".,)")
+        suffix = raw_path[len(trimmed_path):]
+    else:
+        trimmed_path = raw_path
+        suffix = ""
     relative_text = _target_relative_text(trimmed_path, resolved_target_root_text)
     if relative_text is not None:
         summary.redacted_absolute_path_count += 1


### PR DESCRIPTION
## Summary
- Adds a clean-path fast path in runtime export diagnostic absolute-path redaction so common paths skip suffix trimming/allocation.
- Adds regression coverage for both clean absolute paths and punctuation-suffixed paths.

## Plan or Spec
- Governing plan: `docs/plans/2026-05-08-evidence-telemetry-roadmap.md` (evidence/report diagnostics and PR-scoped probe evidence).
- Behavior contract unchanged: path redaction output and suffix preservation remain the same.

## Commands Run
```text
# Baseline on origin/main (1097a940) for comparison:
MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=80 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; path_redaction_elapsed_ms_mean=48.32875642958762; diagnosis_matching_elapsed_ms_mean=0.9716738589174513; diagnostic_latency_ms=7.380844966974109; elapsed_ms_mean=6943.272871859205

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 82 passed in 1.40s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; elapsed_ms_mean=2576.5192144026514; path_redaction_elapsed_ms_mean=19.787053391337395; diagnostic_latency_ms=7.190281990915537

MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=80 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=7 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; path_redaction_elapsed_ms_mean=44.94498100081858; diagnosis_matching_elapsed_ms_mean=0.8640318535201784; diagnostic_latency_ms=7.272819988429546; elapsed_ms_mean=7004.330087715061

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 14 0 100%`).
- Registered probe: `runtime-export-diagnostic-parser` is already registered in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe comparison at 80 iterations / 7 samples:
  - `path_redaction_elapsed_ms_mean`: 48.32875642958762 ms -> 44.94498100081858 ms (delta -3.38377542876904 ms, ~7.00% faster)
  - `diagnostic_latency_ms`: 7.380844966974109 ms -> 7.272819988429546 ms (delta -0.1080249785445633 ms, ~1.46% faster)
  - `diagnosis_matching_elapsed_ms_mean`: 0.9716738589174513 ms -> 0.8640318535201784 ms (delta -0.10764200539727286 ms, ~11.08% faster; unchanged code path, recorded as probe variance/secondary signal)
  - `elapsed_ms_mean`: 6943.272871859205 ms -> 7004.330087715061 ms (delta +61.057215855856 ms, ~0.88% slower; dominated by temporary-directory report generation outside the redaction fast path)
- CI PR-scoped performance workflow is required for the authoritative registered probe validation before merge.

## Known Gaps
- No docs were changed because this preserves the runtime export diagnostics behavior contract and only changes the internal redaction fast path.
- Local validation was Linux-only; CI must provide final PR-scoped probe evidence.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or N/A is stated explicitly.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: existing PR-scoped evidence probe, no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
