### PR TITLE
perf(hub): cache repeated direct size hints

### DIFF
--- a/docs/plans/2026-07-07-hub-size-hint-direct-cache.md
+++ b/docs/plans/2026-07-07-hub-size-hint-direct-cache.md
@@ -1,0 +1,25 @@
+# Hub catalog repeated direct size-hint cache
+
+## Goal
+
+Reduce repeated direct model-size hint parsing overhead in the Hub catalog path by caching the pure direct-card and direct-explicit text parsers for repeated Hub metadata strings.
+
+## Scope
+
+This Python-only slice is limited to `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and focused Hub catalog tests. It does not change accepted size-hint syntax or Hub API behavior.
+
+## Registered probe
+
+The affected path is already covered by the PR-scoped `hub-catalog-size-hint-regex-precompile` probe in `infra/perf/pr_scoped_probes.json`. The probe watches the Hub catalog module, focused tests, PR-scoped performance tests, and `scripts/hub_catalog_size_hint_probe.py`, and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Validation plan
+
+- Run the registered focused Hub catalog test command.
+- Run the registered changed-scope coverage command.
+- Run `scripts/hub_catalog_size_hint_probe.py` before and after the change on Linux and compare `elapsed_ms_mean`.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above 95% for the touched scope.
+- The registered probe shows lower `elapsed_ms_mean` without changing the parsed hint count or compatibility count.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -546,6 +546,30 @@ def test_direct_explicit_size_hint_handles_common_readme_lines() -> None:
     assert hub_catalog_module._direct_explicit_size_hint_from_text("mOdel size: 12 GB") == 0
 
 
+def test_direct_size_hint_fast_paths_cache_repeated_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    hub_catalog_module._direct_card_size_hint_from_text.cache_clear()
+    hub_catalog_module._direct_explicit_size_hint_from_text.cache_clear()
+    original = hub_catalog_module._direct_size_hint_from_text
+    direct_calls: list[str] = []
+
+    def counting_direct_size_hint(text: str) -> int:
+        direct_calls.append(text)
+        return original(text)
+
+    monkeypatch.setattr(hub_catalog_module, "_direct_size_hint_from_text", counting_direct_size_hint)
+
+    for _ in range(3):
+        assert hub_catalog_module._direct_card_size_hint_from_text("Model size: 12 MB") == 12 * MB
+        assert (
+            hub_catalog_module._direct_explicit_size_hint_from_text(
+                "README\nModel size: 12 MB\nother metadata"
+            )
+            == 12 * MB
+        )
+
+    assert direct_calls == ["12 MB", "12 MB"]
+
+
 def test_weight_or_config_file_preserves_case_insensitive_matches() -> None:
     assert hub_catalog_module._is_weight_or_config_file("config.json") is True
     assert hub_catalog_module._is_weight_or_config_file("model.safetensors") is True

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -4,6 +4,7 @@ import json
 import math
 import re
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
 from urllib.parse import unquote_plus, urlencode
@@ -958,6 +959,7 @@ def _direct_size_hint_from_text(text: str) -> int:
         return 0
 
 
+@lru_cache(maxsize=4096)
 def _direct_card_size_hint_from_text(text: str) -> int:
     stripped_text = _strip_model_size_label(text)
     if stripped_text:
@@ -979,6 +981,7 @@ def _direct_size_hint_from_line(text: str, value_start: int) -> int:
     return _direct_size_hint_from_text(text[value_start:value_end])
 
 
+@lru_cache(maxsize=4096)
 def _direct_explicit_size_hint_from_text(text: str) -> int:
     marker_index = text.find("MODEL SIZE | ")
     if marker_index >= 0:


### PR DESCRIPTION
## Summary
- Cache the pure direct Hub catalog size-hint parsers for repeated `cardData.model_size` and marked README/description text.
- Add a focused regression test proving repeated direct parser inputs reuse cached results.

## Plan or Spec
- `docs/plans/2026-07-07-hub-size-hint-direct-cache.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main before the code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 93 passed in 1.36s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; elapsed_ms_mean=1718.127529002959; payload_compatibility_elapsed_ms_mean=193.67499160580337; size_hint_calls_mean=0.0

# After the code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# exit 0; 94 passed in 0.51s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# exit 0; TOTAL 16 0 100%
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# exit 0; elapsed_ms_mean=1295.8132938016206; payload_compatibility_elapsed_ms_mean=192.99844239722006; size_hint_calls_mean=0.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered local probe (`hub_catalog_size_hint_probe.py`):
  - `elapsed_ms_mean`: 1718.127529002959 ms -> 1295.8132938016206 ms (`-422.31423520133846 ms`, ~24.58% faster).
  - `payload_compatibility_elapsed_ms_mean`: 193.67499160580337 ms -> 192.99844239722006 ms.
  - `size_hint_calls_mean`: unchanged at 0.0.
  - `matched_hint_count`: unchanged at 120000.0.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local validation covers the Python path only; GitHub Actions PR-scoped performance report is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes.
- [x] Deferred work and known gaps are stated explicitly.
