### PR TITLE
perf(runtime-export): check exact diagnoses before markers

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -225,6 +225,13 @@ small mapping rows for synthetic smoke failures, so this avoids repeated helper
 calls and repeated `Mapping` dispatch for every check row while preserving the
 same source-path fallback and failed/blocked status filter.
 
+A follow-up 2026-07-07 exact diagnosis text slice keeps diagnosis semantics and
+matched pattern ids unchanged while checking the exact lowercased diagnosis-text
+table before the broader marker prefilter. Fixture-like common lines already
+covered by the exact table now skip the union marker scan and phrase loop,
+whereas non-exact lines continue through the same marker, phrase, and regex
+fallbacks.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -619,6 +619,32 @@ def test_export_target_diagnostics_runtime_load_fast_phrase_skips_regexes(
     assert [expression.search.call_count for expression in expressions] == [0, 0, 0, 0, 0]
 
 
+def test_export_target_diagnostics_exact_text_fast_path_skips_marker_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_marker_scan(_lowered_text: str) -> bool:  # pragma: no cover - regression guard
+        raise AssertionError("exact diagnosis text should skip marker scanning")
+
+    monkeypatch.setattr(
+        export_target_diagnostics_module,
+        "_has_diagnosis_marker",
+        fail_marker_scan,
+    )
+
+    diagnoses = _diagnoses_from_excerpt(
+        [
+            _SourceLine(
+                source_path="logs/ollama-create.log",
+                text="runtime load failed while opening model",
+            ),
+        ],
+        {0: 1},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert [diagnosis["code"] for diagnosis in diagnoses] == [CODE_RUNTIME_LOAD_FAILED]
+
+
 def test_export_target_diagnostics_skips_secret_regexes_for_plain_path_lines(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -851,8 +851,6 @@ def _diagnoses_from_excerpt(
             break
         text = source_lines_local[index].text
         lowered_text = text.lower()
-        if not has_diagnosis_marker(lowered_text):
-            continue
         fast_pattern = exact_fast_text_patterns.get(lowered_text)
         if fast_pattern is not None:
             pattern_code = fast_pattern.code
@@ -872,6 +870,8 @@ def _diagnoses_from_excerpt(
             )
             continue
         fast_pattern = None
+        if not has_diagnosis_marker(lowered_text):
+            continue
         for phrase, pattern in fast_phrase_patterns:
             if phrase in lowered_text:
                 pattern_code = pattern.code


### PR DESCRIPTION
## Summary
- Move exact runtime-export diagnosis text lookup ahead of the broader diagnosis marker prefilter.
- Add a regression test proving exact known lines skip marker scanning while preserving matched diagnosis output.
- Update the runtime export diagnostic parser plan with this follow-up performance slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
# Red test before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_exact_text_fast_path_skips_marker_scan
# exit 1; failed as expected before moving exact lookup before marker scan

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 82 passed in 1.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; 82 passed in 1.46s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# before: diagnosis_matching_elapsed_ms_mean=0.336409208830446; elapsed_ms_mean=2600.0220868038014
# after:  diagnosis_matching_elapsed_ms_mean=0.19218880333937705; elapsed_ms_mean=2578.6581691994797

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-runtime-export-diagnostic-prefix-check-20260707 --head-repo "$PWD" --output /tmp/runtime_export_diagnostic_prefix_probe.json
# exit 0; head verification ok; first run diagnosis_matching_elapsed_ms_mean base=0.33341500093229115, head=0.18706039991229773
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 6 0 100%`).
- Registered probe: `runtime-export-diagnostic-parser` is already registered with focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Direct same-worktree probe: `diagnosis_matching_elapsed_ms_mean` improved from `0.336409208830446` ms to `0.19218880333937705` ms (about 42.9% lower); `elapsed_ms_mean` improved from `2600.0220868038014` ms to `2578.6581691994797` ms.
- Registered base/head run: first run reported `diagnosis_matching_elapsed_ms_mean` base `0.33341500093229115` ms vs head `0.18706039991229773` ms (about 43.9% lower), with parser coverage unchanged at `1.0`.
- CI PR-scoped performance is required as the final registered probe validation and merge gate.

## Known Gaps
- Local validation was Linux/Python only. No Swift runtime behavior is touched.
- The registered probe's sub-millisecond matching metric is noisy across reruns, so CI PR-scoped performance remains the authoritative final gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
