### PR TITLE
perf(local-job): use suffix helper in follow-up scan

### DIFF
--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -368,10 +368,7 @@ class LocalJobContinuationStore:
             json_suffix_length = len(json_suffix)
             for entry in os.scandir(root_fspath):
                 name = entry.name
-                if (
-                    len(name) < json_suffix_length
-                    or name[-json_suffix_length:] != json_suffix
-                ):
+                if not name.endswith(json_suffix):
                     continue
                 if entry.is_file(follow_symlinks=False):
                     # The scan has already filtered this to a .json file name.


### PR DESCRIPTION
## Summary
- Replaces the manual `.json` suffix length/slice check in local-job follow-up scans with `str.endswith`.
- Keeps the existing `os.scandir` scan, symlink-safe file check, and direct job-id slicing behavior unchanged.

## Plan or Spec
- Governed by `docs/unified-agentic-tool-runtime-contract.md` and `docs/plans/2026-06-15-local-job-followup-loop-bindings.md`.
- Registered probe: `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` (baseline before change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` (after change)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_reads_json_bytes services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_uses_direct_binary_open services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_avoids_path_join_wrapper services/mlx-worker-python/tests/test_local_job_continuation.py::test_load_record_tolerates_record_deleted_between_path_resolution_and_read services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_uses_narrow_receipt_copies services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_copy_preserves_json_scalars_by_value services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_copy_preserves_container_subclasses services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 16 passed.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Baseline probe: `elapsed_ms_mean=20.861049`, `projection_elapsed_ms_mean=133.101467`, `scalar_copy_optimized_elapsed_ms_mean=1814.325674`, `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`.
- Updated probe: `elapsed_ms_mean=19.15142`, `projection_elapsed_ms_mean=125.818108`, `scalar_copy_optimized_elapsed_ms_mean=1787.644059`, `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`.
- Local scan delta: `-1.709629 ms` (`~8.20%` lower elapsed mean).
- CI is required to validate the registered PR-scoped performance workflow on GitHub.

## Known Gaps
- Local verification was Linux/Python only; no Swift runtime path is touched.
- Probe timings are local microbenchmarks and may vary; merge should wait for the registered CI probe.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and reported metrics.
- [ ] GitHub Actions / registered PR-scoped performance report completed successfully.
