### PR TITLE
perf(dataset): dispatch source kind by final character

### DIFF
--- a/docs/plans/2026-07-07-dataset-source-kind-last-char-dispatch.md
+++ b/docs/plans/2026-07-07-dataset-source-kind-last-char-dispatch.md
@@ -1,0 +1,35 @@
+# Dataset Source Kind Last-Character Dispatch
+
+## Scope
+
+This Python-only performance slice is limited to dataset ingest source-kind
+classification in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+The hot helper `_classify_source_kind_name()` now dispatches common lowercase
+suffix checks by the final filename character before evaluating suffix-specific
+slices. This preserves the existing fallback path for uppercase or uncommon
+suffix spellings while avoiding most repeated slice comparisons on the common
+lowercase dataset source names used by ingest scans.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+The probe reports source-tree traversal timing plus source-kind classification
+metrics (`source_kind_elapsed_ms_mean`, `source_kind_elapsed_ms_min`, and
+`source_kind_elapsed_ms_p95`).
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, `git diff --check`,
+and the registered `dataset-source-records-scandir` probe locally on Linux before
+opening the PR. GitHub Actions PR-scoped performance remains the merge gate for
+the registered probe report.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1274,24 +1274,33 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
 
 
 def _classify_source_kind_name(name: str) -> str | None:
-    if name[-4:] == ".txt":
-        if len(name) >= 8 and name[-8] == "." and name[-7:-4].lower() == "pdf":
-            return "pdf"
-        if len(name) >= 9 and name[-9] == "." and name[-8:-4].lower() == "docx":
-            return "docx"
-        return "text"
-    if name[-5:] == ".text":
-        return "text"
-    if name[-3:] == ".md":
-        return "markdown"
-    if name[-3:] == ".py":
-        return "code"
-    if name[-6:] == ".jsonl":
-        return "structured_data"
-    if name[-5:] == ".json":
-        return "structured_data"
-    if name[-4:] in (".csv", ".tsv"):
-        return "structured_data"
+    if not name:
+        return None
+    last_char = name[-1]
+    if last_char == "t":
+        if name[-4:] == ".txt":
+            if len(name) >= 8 and name[-8] == "." and name[-7:-4].lower() == "pdf":
+                return "pdf"
+            if len(name) >= 9 and name[-9] == "." and name[-8:-4].lower() == "docx":
+                return "docx"
+            return "text"
+        if name[-5:] == ".text":
+            return "text"
+    elif last_char == "d":
+        if name[-3:] == ".md":
+            return "markdown"
+    elif last_char == "y":
+        if name[-3:] == ".py":
+            return "code"
+    elif last_char == "l":
+        if name[-6:] == ".jsonl":
+            return "structured_data"
+    elif last_char == "n":
+        if name[-5:] == ".json":
+            return "structured_data"
+    elif last_char == "v":
+        if name[-4:] in (".csv", ".tsv"):
+            return "structured_data"
 
     dot_index = name.rfind(".")
     if dot_index < 0:


### PR DESCRIPTION
## Summary
- Dispatch dataset source-kind classification by the final filename character before common lowercase suffix checks.
- Preserve the existing uppercase/uncommon suffix fallback path and source-kind behavior.
- Document the Python-only performance slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-07-07-dataset-source-kind-last-char-dispatch.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 46 passed in 1.91s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 46 passed in 1.13s; changed_line_coverage=96.30%; TOTAL 27 1 96%

git diff --check
# exit 0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# {"directory_count": 250.0, "elapsed_ms_mean": 11.35247272693298, "elapsed_ms_min": 10.934620979242027, "elapsed_ms_p95": 11.414081003749743, "file_count_mean": 7000.0, "files_per_directory": 28.0, "record_elapsed_ms_mean": 21.517317636277188, "record_elapsed_ms_min": 20.370532001834363, "record_elapsed_ms_p95": 22.733244026312605, "sample_count": 11.0, "source_kind_elapsed_ms_mean": 18.58311936534433, "source_kind_elapsed_ms_min": 17.383208993123844, "source_kind_elapsed_ms_p95": 18.441663996782154, "source_kind_variant_count": 7.0}
```

## Coverage and Metrics
- Registered probe: `dataset-source-records-scandir`.
- Local Linux changed-scope coverage: `96.30%` (`TOTAL 27 1 96%`).
- Local baseline (`origin/main`) vs head probe:
  - `source_kind_elapsed_ms_mean`: `19.475835` ms -> `18.583119` ms (`delta=-0.892715` ms, `speedup=1.0480x`).
  - `source_kind_elapsed_ms_min`: `18.473514` ms -> `17.383209` ms (`delta=-1.090305` ms, `speedup=1.0627x`).
  - `source_kind_elapsed_ms_p95`: `20.361244` ms -> `18.441664` ms (`delta=-1.919580` ms, `speedup=1.1041x`).
  - Overall source path scan `elapsed_ms_mean`: `11.733976` ms -> `11.352473` ms (`delta=-0.381503` ms, `speedup=1.0336x`).
- PR-scoped performance CI is required for the registered probe merge gate.

## Known Gaps
- Local validation is Linux-only. The changed path is Python-only; no Swift runtime effect is claimed.
- `record_elapsed_ms_mean` is an adjacent probe metric and moved from `20.980560` ms to `21.517318` ms in the local head run; this slice does not touch record construction, so CI registered-probe reporting remains the gate for final noise/regression assessment.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A (no runtime observability change); probe overhead: existing PR-scoped synthetic probe only.
- [x] Deferred work and known gaps are stated explicitly.
