### PR TITLE
perf: bind changed-scope sparse membership helper

### DIFF
--- a/docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md
+++ b/docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md
@@ -17,6 +17,14 @@ implementation can use C-level `set.intersection(...)` against the executed and
 missing line lists. The fallback path still supports generic `Set[int]`
 implementations, and coverage classification remains identical.
 
+## 2026-07 sparse measured-line membership binding slice
+
+This follow-up slice is limited to the sparse measured-line fallback in
+`_measurable_changed_lines(...)`. It keeps the bisect-based membership helper but
+binds it once per measured-file path before the changed-line list comprehension,
+reducing repeated global lookups while preserving the dense `set.intersection`
+path and all coverage classification semantics.
+
 ## Registered performance probe
 
 The affected path is already covered by the registered PR-scoped probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`, including focused `test_command`, `coverage_command`, and `probe_command` entries. The probe builds a deterministic synthetic multi-file diff and reports:

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -275,6 +275,7 @@ def _measurable_changed_lines(
             missing_lookup = missing_lines
         if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
             measured_line_count = len(executed_lookup) + len(missing_lookup)
+            sorted_line_list_contains = _sorted_line_list_contains
             if (
                 measured_line_count
                 and len(changed) >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
@@ -292,8 +293,8 @@ def _measurable_changed_lines(
                 measured_changed = [
                     line_no
                     for line_no in changed
-                    if _sorted_line_list_contains(executed_lookup, line_no)
-                    or _sorted_line_list_contains(missing_lookup, line_no)
+                    if sorted_line_list_contains(executed_lookup, line_no)
+                    or sorted_line_list_contains(missing_lookup, line_no)
                 ]
         else:
             measured_changed = [


### PR DESCRIPTION
## Summary
- Bind the sparse changed-scope measured-line membership helper once before the fallback list comprehension.
- Keep the existing dense `set.intersection` path and coverage classification semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-05-changed-scope-coverage-line-dispatch.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py::test_measurable_changed_lines_handles_large_measured_sets_without_union tests/test_changed_scope_coverage.py::test_measurable_changed_lines_dense_filter_keeps_generic_set_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 4 passed in 0.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-measured-set-filter --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/changed_scope_membership_probe.json
# head verification passed; coverage command reported TOTAL 1 0 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage from the registered probe coverage command: `TOTAL 1 0 100%`.
- Registered local probe `changed-scope-coverage-measured-set-filter`:
  - `elapsed_ms_mean`: base `0.2807261397330357`, head `0.24266785476356745` (delta `-0.03805828496946825` ms, ~13.56% faster).
  - `allowlist_parse_elapsed_ms_mean`: base `3.3759474255410686`, head `3.2986838528553823`.
  - `source_read_calls_mean`: base `0.0`, head `0.0`.
- GitHub Actions PR-scoped performance is required as the merge gate for the registered CI probe report.

## Known Gaps
- None for the Linux-verifiable Python slice. CI remains the final registered probe validation source.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode or debug changes.
- [x] Deferred work and known gaps are stated explicitly.
