### PR TITLE
perf(report-evidence): bind release matrix membership check

### DIFF
--- a/docs/plans/2026-07-03-report-evidence-single-run-kind-membership-performance.md
+++ b/docs/plans/2026-07-03-report-evidence-single-run-kind-membership-performance.md
@@ -54,3 +54,31 @@ registered probe replay kept the targeted matrix-role metric positive at about
 0.247 ms faster than baseline (~6.58%) while unrelated submetrics showed normal
 noise. A focused single-rule microprobe over 1,000,000 iterations and seven
 samples measured old_mean=193.395 ms, new_mean=189.821 ms, speedup=1.019x.
+
+## 2026-07-07 follow-up slice: release-matrix membership binding
+
+This follow-up keeps the same registered probe,
+`report-evidence-gate-run-kind-set-membership`, and stays limited to
+`_release_matrix_rows()`. The release-matrix row builder now binds the matrix
+membership check once before scanning report roles, reducing repeated attribute
+lookup overhead while preserving the existing invalid-role skip behavior and row
+ordering semantics.
+
+Local Linux pre-change probe from `origin/main`:
+
+- `elapsed_ms_mean=1001.6281351912767`
+- `release_matrix_elapsed_ms_mean=29.859048197977245`
+- `matrix_roles_elapsed_ms_mean=3.3346045936923474`
+
+Local Linux candidate probe replays:
+
+- first replay: `elapsed_ms_mean=946.8983010097872`,
+  `release_matrix_elapsed_ms_mean=29.390572203556076`,
+  `matrix_roles_elapsed_ms_mean=3.2762992021162063`
+- second replay: `elapsed_ms_mean=946.6942346014548`,
+  `release_matrix_elapsed_ms_mean=28.76191778923385`,
+  `matrix_roles_elapsed_ms_mean=3.227511403383687`
+
+The targeted release-matrix metric improved by 0.468 ms (~1.57%) on the first
+replay and 1.097 ms (~3.67%) on the second replay, with overall probe mean also
+lower in both candidate runs.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -244,6 +244,7 @@ def _release_matrix_rows(
     evidence_by_role: dict[str, set[str]] = {}
     to_string = str
     evidence_by_role_get = evidence_by_role.get
+    matrix_contains = matrix.__contains__
     for report in reports:
         roles = report.get("release_matrix_roles")
         source_evidence_ids = report.get("source_evidence_ids", [])
@@ -255,7 +256,7 @@ def _release_matrix_rows(
             continue
         if len(roles) == 1:
             role = roles[0]
-            if role in matrix:
+            if matrix_contains(role):
                 evidence_ids_for_role = evidence_by_role_get(role)
                 if evidence_ids_for_role is None:
                     evidence_ids_for_role = set()
@@ -265,7 +266,7 @@ def _release_matrix_rows(
             continue
         evidence_ids = tuple(to_string(item) for item in source_evidence_ids)
         for role in roles:
-            if role not in matrix:
+            if not matrix_contains(role):
                 continue
             evidence_ids_for_role = evidence_by_role_get(role)
             if evidence_ids_for_role is None:


### PR DESCRIPTION
## Summary
- Bind the release evidence matrix membership check once inside `_release_matrix_rows()`.
- Keep invalid role filtering, evidence-id de-duplication, and output row ordering unchanged.

## Plan or Spec
- Governed by `docs/plans/2026-07-03-report-evidence-single-run-kind-membership-performance.md`.
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py` (baseline on `origin/main` before change)
- Registered `test_command` from `infra/perf/pr_scoped_probes.json` for `report-evidence-gate-run-kind-set-membership`
- Registered `coverage_command` from `infra/perf/pr_scoped_probes.json` for `report-evidence-gate-run-kind-set-membership`
- Registered `probe_command` from `infra/perf/pr_scoped_probes.json` for `report-evidence-gate-run-kind-set-membership`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `29 passed in 1.31s`
- Changed-scope coverage: `TOTAL 3 0 100%`
- Baseline local probe: `elapsed_ms_mean=1001.6281351912767`, `release_matrix_elapsed_ms_mean=29.859048197977245`, `matrix_roles_elapsed_ms_mean=3.3346045936923474`
- Candidate local probe replay 1: `elapsed_ms_mean=946.8983010097872`, `release_matrix_elapsed_ms_mean=29.390572203556076`, `matrix_roles_elapsed_ms_mean=3.2762992021162063`
- Candidate local probe replay 2: `elapsed_ms_mean=946.6942346014548`, `release_matrix_elapsed_ms_mean=28.76191778923385`, `matrix_roles_elapsed_ms_mean=3.227511403383687`
- Registered probe replay after coverage: `elapsed_ms_mean=959.5059575862251`, `release_matrix_elapsed_ms_mean=29.765685205347836`, `matrix_roles_elapsed_ms_mean=3.3292344014625996`
- Targeted release-matrix metric delta vs baseline: `-0.468 ms` / `-1.57%` on replay 1, `-1.097 ms` / `-3.67%` on replay 2, `-0.093 ms` / `-0.31%` on final registered replay.

## Known Gaps
- Local validation is Linux/Python-only. GitHub Actions PR-scoped performance is still required as the registered CI validation and merge gate.

## Evidence Checklist
- [x] Registered PR-scoped probe exists with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run and recorded.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
