### PR TITLE
perf(evaluation): use copy sort for latency stats

### DIFF
--- a/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
+++ b/docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md
@@ -26,11 +26,12 @@ The probe must be base-compatible so `origin/main` still runs successfully durin
 
 ## Success Metrics
 
-- `_latency_stats()` performs one sort per invocation instead of two.
+- `_latency_stats()` performs one ordering pass per invocation instead of two.
 - A 2026-05-28 follow-up micro-slice keeps the same behavior and one-sort invariant while inlining the two fixed percentile calculations inside `_latency_stats()`. The previous class-attribute binding step is already present on `main`, so this slice removes the remaining two `_ordered_percentile(...)` helper calls from the hot return path instead of rebinding them again.
+- A 2026-07-07 follow-up micro-slice preserves caller input order while replacing `sorted(values)` with `values.copy(); sorted_values.sort()` so the hot path avoids the `builtins.sorted` call wrapper and keeps a single copied vector for `p50`, `p95`, and `max`.
 - Latency summary outputs (`mean`, `p50`, `p95`, `max`) remain unchanged.
 - Focused changed-scope coverage for touched executable files is at least 95%.
-- The registered local probe must show stable or lower `elapsed_ms_mean` versus `origin/main`; `sorted_calls_mean` must remain `1.0`.
+- The registered local probe must show stable or lower `elapsed_ms_mean` versus `origin/main`; `sorted_calls_mean` may drop below `1.0` when the implementation uses `list.sort()` on a defensive copy instead of `builtins.sorted`.
 
 ## Verification Commands
 

--- a/services/mlx-worker-python/tests/test_evaluation_core.py
+++ b/services/mlx-worker-python/tests/test_evaluation_core.py
@@ -737,12 +737,14 @@ def test_latency_stats_reuse_single_sorted_vector(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(builtins, "sorted", counting_sorted)
     monkeypatch.setattr(EvaluationCore, "_ordered_percentile", fail_ordered_percentile)
 
-    stats = EvaluationCore._latency_stats([40.0, 10.0, 30.0, 20.0])
+    original = [40.0, 10.0, 30.0, 20.0]
+    stats = EvaluationCore._latency_stats(original)
 
+    assert original == [40.0, 10.0, 30.0, 20.0]
     assert stats == {"mean": 25.0, "p50": 25.0, "p95": 38.5, "max": 40.0}
     assert EvaluationCore._latency_stats([10.0, 30.0, 20.0]) == {"mean": 20.0, "p50": 20.0, "p95": 29.0, "max": 30.0}
     assert EvaluationCore._latency_stats([42.0]) == {"mean": 42.0, "p50": 42.0, "p95": 42.0, "max": 42.0}
-    assert sorted_call_count == 3
+    assert sorted_call_count == 0
 
 
 def test_run_local_suite_executes_packaged_dataset_and_persists_result(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -6459,7 +6459,7 @@ def test_evaluation_latency_percentile_probe_command_emits_metrics() -> None:
     metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
 
     assert metrics["elapsed_ms_mean"] > 0
-    assert metrics["sorted_calls_mean"] == 1.0
+    assert metrics["sorted_calls_mean"] == 0.0
     assert metrics["sample_count"] == 12000.0
     assert metrics["iteration_count"] == 160.0
     assert metrics["p95"] >= metrics["p50"]

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -1926,7 +1926,8 @@ class EvaluationCore:
         if not values:
             return {"mean": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
         total = sum(values)
-        sorted_values = sorted(values)
+        sorted_values = values.copy()
+        sorted_values.sort()
         value_count = len(sorted_values)
         round_ms = cls._round_ms
         if value_count == 1:


### PR DESCRIPTION
## Summary
- Replace `sorted(values)` in `EvaluationCore._latency_stats()` with a defensive `values.copy()` plus in-place `list.sort()`.
- Preserve caller input order and existing `mean`/`p50`/`p95`/`max` semantics.
- Update the focused regression test, PR-scoped probe assertion, and governing latency percentile plan for the new zero-`builtins.sorted` invariant.

## Plan or Spec
- `docs/plans/2026-05-03-evaluation-latency-percentile-vector-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_percentile_preserves_interpolated_results services/mlx-worker-python/tests/test_evaluation_core.py::test_latency_stats_reuse_single_sorted_vector services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_latency_percentile_probe_command_emits_metrics services/mlx-worker-python/tests/test_event_extraction.py::test_event_extraction_dialogue_diagnostics_uses_top_k_for_slowest_dialogues services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring
# 17 passed in 2.90s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id evaluation-latency-percentile-vector-reuse --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/evaluation_latency_perf.json
# head verification passed; base probe elapsed_ms_mean=241.530164, sorted_calls_mean=1.0; head probe elapsed_ms_mean=234.648888, sorted_calls_mean=0.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered local probe (`evaluation-latency-percentile-vector-reuse`):
  - `elapsed_ms_mean`: base `241.530164` ms, head `234.648888` ms, delta `-6.881276` ms (`~2.85%` faster)
  - `sorted_calls_mean`: base `1.0`, head `0.0`
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository test suite not run locally; focused registered Python tests, changed-scope coverage, and the registered probe were run on Linux.
- Swift/macOS runtime effects are not applicable for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance evidence; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
