### PR TITLE
perf(code-eval): defer whitespace scan for code blocks

### DIFF
--- a/docs/plans/2026-07-08-code-eval-code-block-whitespace-deferral.md
+++ b/docs/plans/2026-07-08-code-eval-code-block-whitespace-deferral.md
@@ -1,0 +1,36 @@
+# Code Eval Code-Block Whitespace Deferral Slice
+
+## Scope
+
+This Python-only performance slice is limited to `extract_candidate_code` in
+`services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+The code-block extractor already scans from the tail to select the final fenced
+code block. This slice keeps that behavior unchanged while deferring the
+full-response whitespace scan until after the no-fence plaintext fallback is
+known to be needed. The common code-block path can then avoid an up-front
+`str.isspace()` pass over large model responses without changing fence pairing,
+fallback, stripping, or language-tag handling.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`code-eval-code-block-last-match-streaming` in
+`infra/perf/pr_scoped_probes.json`. The probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `elapsed_ms_mean` for extraction latency on a synthetic multi-block response.
+- `peak_bytes_mean` for allocation guardrails.
+
+## Verification plan
+
+Run the registered probe locally on Linux against `origin/main` and this branch
+through `scripts/pr_scoped_performance_run.py`. The CI PR-scoped performance
+workflow remains the merge gate after the PR is opened.
+
+## Acceptance criteria
+
+- Focused code-eval extraction tests and registered probe tests pass.
+- Changed-scope coverage for touched lines is at least 95%.
+- Registered probe preserves `peak_bytes_mean` and shows no behavior checksum drift.
+- GitHub Actions, including the PR-scoped performance report, completes green.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -51,7 +51,7 @@ class CodeEvaluationResult:
 
 
 def extract_candidate_code(raw_response: str) -> tuple[str, str]:
-    if not raw_response or raw_response.isspace():
+    if not raw_response:
         return "", "empty_prediction"
 
     fence = "```"
@@ -71,6 +71,8 @@ def extract_candidate_code(raw_response: str) -> tuple[str, str]:
                 content_start = _code_block_content_start(raw_response, opening + 3)
                 return _stripped_slice(raw_response, content_start, closing), "parsed_code_block"
 
+    if raw_response.isspace():
+        return "", "empty_prediction"
     return raw_response.strip(), "parsed_code"
 
 


### PR DESCRIPTION
## Summary
- Defer the code-eval extractor's full-response whitespace scan until after the no-fence plaintext fallback is known to be needed.
- Keep final fenced-block selection, empty block handling, language-tag handling, and plaintext fallback behavior unchanged.
- Add a governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-08-code-eval-code-block-whitespace-deferral.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# 4 passed in 0.16s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_extract_candidate_code_handles_empty_plaintext_and_code_blocks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_code_block_extract_probe_script_emits_metrics
# 4 passed in 0.27s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_code_block_extract_probe.py
# TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-code-block-last-match-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-code-eval-rfind-bind-20260708 --output /tmp/code_eval_whitespace_probe.json
# head verification ok; base/head probe ok
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%` for `services/mlx-worker-python/worker/engine/code_eval_runner.py` and registered probe/test paths.
- Registered local probe `code-eval-code-block-last-match-streaming`:
  - base `elapsed_ms_mean=0.03448342821294708`, head `elapsed_ms_mean=0.03241086129232177`, delta `-0.00207256692062531 ms` (~6.01% faster; informational metric)
  - base `peak_bytes_mean=198.0`, head `peak_bytes_mean=198.0`, delta `0.0`
- Observability mode: evidence (registered PR-scoped performance probe). Probe overhead is limited to CI/local synthetic probe execution; runtime code adds no new logging or telemetry.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local verification is Linux/Python-only. No Swift runtime effect is involved.
- The latency metric for this probe is informational; merge gating relies on behavior checks, changed-scope coverage, peak allocation guardrail, and the CI PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
