### PR TITLE
perf: fast path empty OpenAI tool schemas

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -147,6 +147,23 @@ Expected effect:
 - leave partial selections, tuple full selections, registry selection, and tool
   definitions unchanged.
 
+## Follow-up Slice: Empty OpenAI Tool Selection Fast Path
+
+The 2026-07-08 follow-up keeps `ToolRegistry.as_openai_tools()` copy-on-return
+behavior unchanged, but returns a fresh empty list before binding copy helpers or
+entering the template-cloning comprehension when a selected registry has no
+OpenAI tool templates. Empty selected registries are already cached by
+`ToolRegistry.select(())`; this slice narrows the zero-tool OpenAI schema path
+without changing full or partial registry payloads.
+
+Expected effect:
+
+- reduce `tool-registry-openai-tools-template-cache` `empty_elapsed_ms_mean` for
+  empty selected registries;
+- preserve fresh-list mutation isolation for `as_openai_tools()` callers;
+- leave non-empty OpenAI tool payload construction, registry selection,
+  schema serialization, and protobuf config handling unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5159,6 +5159,12 @@
         "warn_pct": 5.0
       },
       {
+        "key": "empty_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "key": "descriptor_as_openai_tool_calls_mean",
         "unit": "calls",
         "direction": "lower_is_better",

--- a/scripts/tool_registry_openai_tools_probe.py
+++ b/scripts/tool_registry_openai_tools_probe.py
@@ -18,11 +18,14 @@ from worker.runtime.tool_registry import BUILTIN_AGENTIC_TOOL_NAMES, built_in_to
 
 def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     registry = built_in_tool_registry()
+    empty_registry = registry.select(())
     expected_names = BUILTIN_AGENTIC_TOOL_NAMES
     elapsed_samples: list[float] = []
+    empty_elapsed_samples: list[float] = []
     descriptor_calls_samples: list[float] = []
     isolated_payload_samples: list[float] = []
     checksum = 0
+    empty_checksum = 0
 
     original_as_openai_tool = tool_registry_module.ToolDescriptor.as_openai_tool
     try:
@@ -52,14 +55,23 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
             elapsed_samples.append((time.perf_counter() - started) * 1000.0)
             descriptor_calls_samples.append(float(call_count))
             isolated_payload_samples.append(float(isolated_payload_count))
+            started = time.perf_counter()
+            for _index in range(iterations):
+                tools = empty_registry.as_openai_tools()
+                if tools:  # pragma: no cover - defensive probe invariant
+                    raise RuntimeError(f"unexpected empty selection tools: {tools!r}")
+                empty_checksum += len(tools)
+            empty_elapsed_samples.append((time.perf_counter() - started) * 1000.0)
     finally:
         tool_registry_module.ToolDescriptor.as_openai_tool = original_as_openai_tool
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "empty_elapsed_ms_mean": statistics.fmean(empty_elapsed_samples),
         "descriptor_as_openai_tool_calls_mean": statistics.fmean(descriptor_calls_samples),
         "isolated_payload_calls_mean": statistics.fmean(isolated_payload_samples),
         "checksum": float(checksum),
+        "empty_checksum": float(empty_checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),
     }

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1067,6 +1067,8 @@ def test_tool_registry_openai_tools_probe_script_emits_metrics(
 
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["empty_elapsed_ms_mean"] >= 0.0
+    assert metrics["empty_checksum"] == 0.0
     assert metrics["descriptor_as_openai_tool_calls_mean"] == 0.0
     assert metrics["isolated_payload_calls_mean"] == 20.0
 

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -320,6 +320,16 @@ def test_tool_registry_empty_selection_reuses_cached_registry() -> None:
     assert registry.select([]) is selected
 
 
+def test_tool_registry_empty_selection_openai_tools_returns_fresh_empty_list() -> None:
+    registry = built_in_tool_registry().select([])
+
+    tools = registry.as_openai_tools()
+    tools.append({"mutated": True})
+
+    assert registry.as_openai_tools() == []
+    assert registry.as_openai_tools() is not tools
+
+
 def test_tool_registry_names_reuses_registry_snapshot() -> None:
     registry = ToolRegistry(built_in_tool_registry().tools)
     expected_names = registry.names()

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -435,6 +435,9 @@ class ToolRegistry:
         return selection
 
     def as_openai_tools(self) -> list[dict[str, Any]]:
+        openai_tool_templates = self._openai_tool_templates
+        if not openai_tool_templates:
+            return []
         copy_dict = _COPY_DICT
         copy_list = _COPY_LIST
         return [
@@ -463,7 +466,7 @@ class ToolRegistry:
                 observation_kind,
                 schema_properties,
                 required_arguments,
-            ) in self._openai_tool_templates
+            ) in openai_tool_templates
         ]
 
     def as_worker_tool_config(self) -> common_pb2.ToolConfig:


### PR DESCRIPTION
## Summary
- Add an empty-selection fast path in `ToolRegistry.as_openai_tools()` so zero-tool selected registries return a fresh empty list before copy-helper binding and template cloning.
- Extend the registered OpenAI-tools PR-scoped probe with `empty_elapsed_ms_mean` for the zero-tool path.
- Add regression coverage for empty-selection mutation isolation and update the governing tool-registry performance plan.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` (new "Empty OpenAI Tool Selection Fast Path" follow-up slice).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_empty_selection_reuses_cached_registry services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_empty_selection_openai_tools_returns_fresh_empty_list services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_openai_tools_reuses_cached_templates services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics
# 4 passed in 1.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 103 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_openai_tools_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_openai_tools_probe.py && rm -f coverage.json
# 103 passed in 0.52s; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_OPENAI_TOOLS_ITERATIONS=50000 MELIX_TOOL_REGISTRY_OPENAI_TOOLS_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_openai_tools_probe.py
# {"checksum": 1500000.0, "descriptor_as_openai_tool_calls_mean": 0.0, "elapsed_ms_mean": 444.70170920249075, "empty_checksum": 0.0, "empty_elapsed_ms_mean": 5.4942350019700825, "isolated_payload_calls_mean": 50000.0, "iterations": 50000.0, "sample_count": 5.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered local probe: `tool-registry-openai-tools-template-cache`.
  - `elapsed_ms_mean=444.70170920249075 ms`
  - `empty_elapsed_ms_mean=5.4942350019700825 ms`
  - `descriptor_as_openai_tool_calls_mean=0.0`
  - `isolated_payload_calls_mean=50000.0`
- Local differential micro-check for empty selected registry (300,000 calls, 7 samples): old mean `48.63277457271969 ms`, new mean `37.406027001062675 ms`, delta `-11.226747571657014 ms` (~23.09% faster).
- CI PR-scoped performance workflow is required as the merge gate for registered probe validation.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused test, coverage, and probe commands on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
