### PR TITLE
Add native MTP capability registry

### DIFF
--- a/docs/plans/2026-07-08-issue-2602-native-mtp-capability-registry.md
+++ b/docs/plans/2026-07-08-issue-2602-native-mtp-capability-registry.md
@@ -132,7 +132,7 @@ make integration-test
   `ModuleNotFoundError: No module named 'worker.runtime.native_mtp.capability'`.
 - Focused tests:
   `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights`
-  passed with 14 tests.
+  passed with 15 tests.
 - Native MTP regression tests:
   `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q ...`
   passed with 22 tests across the new registry coverage, VLM preload fixture,

--- a/docs/plans/2026-07-08-issue-2602-native-mtp-capability-registry.md
+++ b/docs/plans/2026-07-08-issue-2602-native-mtp-capability-registry.md
@@ -1,0 +1,157 @@
+# Issue 2602 Native MTP Capability Registry
+
+## Goal
+
+Generalize Melix native MTP admission from the current embedded Qwen3.5/Qwen3.6
+checks into a declarative capability-registry boundary that can later support
+additional native heads, batched MTP, and hardware-aware activation without
+exposing assistant sidecar checkpoints as runnable serving targets.
+
+## Governing Issue
+
+- GitHub issue: `#2602`
+- First implementation slice: add the registry and receipt adapter, then route
+  the existing Qwen3.5/Qwen3.6 native-head path through that registry.
+
+## End-State Architecture
+
+The Python worker owns model-local acceleration truth. Native MTP activation
+should be decided by a pure, testable registry before MLX or mlx-vlm loading:
+
+- config parsing resolves a registered native-MTP family and head source
+- weight-map inspection records whether native-head tensors are present
+- assistant-sidecar or draft-only checkpoints fail closed before patching
+- runtime patching consumes only the registry decision
+- load receipts expose the same acceleration contract shape used by speculative
+  draft-model paths, even when the first implementation still runs only the
+  singleton Qwen native-head route
+
+Future slices should add batch-shape expansion and device-aware gating behind
+this decision object rather than adding more hard-coded checks in text or VLM
+runtime loaders.
+
+## Scope
+
+- Add a native MTP capability registry module under
+  `worker.runtime.native_mtp`.
+- Preserve the current Qwen3.5/Qwen3.6 native-head behavior as the first
+  registered capability.
+- Add stable receipt fields that describe method, source, family, head count,
+  batch shape, hardware gate state, resolution, and refusal reason.
+- Refuse assistant-sidecar-shaped MTP configs without applying native MTP
+  patches.
+- Route both text and VLM preload patch functions through the registry.
+- Keep the existing legacy `melix.native_mtp.*` fields for compatibility.
+
+## Non-Goals
+
+- No new public HTTP API or protobuf schema.
+- No broad model-family expansion beyond the existing Qwen native-head shape.
+- No batched MTP implementation in this slice; batch support remains reported
+  as `singleton_only`.
+- No Apple Silicon hardware policy enforcement in this slice; hardware gating
+  is reported as `not_evaluated`.
+- No assistant-sidecar speculative decode execution changes.
+
+## Performance Probes
+
+Measurement points:
+
+- preload decision latency for parsing `config.json` and the safetensors index
+- registry allocation shape on unsupported models and disabled legacy paths
+- native MTP patch calls only after registry acceptance
+- PR-scoped native-MTP loader probe remains the performance merge gate for
+  native-MTP loader-adjacent changes
+
+Success metrics:
+
+- Existing Qwen native-head fixtures still activate with
+  `melix.native_mtp.active=true`.
+- Sidecar-shaped assistant configs return a refused receipt and never call
+  `apply_native_mtp_patches()`.
+- Disabled legacy requests remain inactive with `melix.native_mtp.reason=disabled`.
+- Focused tests and changed-scope coverage are at or above 95 percent for the
+  changed Python scope.
+- Local and CI PR-scoped performance reports finish with status `ok`,
+  regressions `0`, and verification failures `0`.
+
+## Implementation Plan
+
+1. Add failing tests for a pure registry decision covering the Qwen native-head
+   fixture, an assistant-sidecar-shaped config, and the disabled legacy path.
+2. Add failing preload integration tests proving text and VLM loaders expose
+   the receipt fields and only apply native MTP patches for accepted native
+   heads.
+3. Implement the registry decision object and receipt adapter under
+   `worker.runtime.native_mtp`.
+4. Replace duplicate text and VLM config/weight helper logic with the registry.
+5. Run focused tests, changed-scope coverage, the native-MTP scoped performance
+   probe, and the repository pre-commit gate before opening the PR.
+
+## Verification Plan
+
+Focused tests:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q \
+  services/mlx-worker-python/tests/test_native_mtp_capability.py \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights
+```
+
+Changed-scope coverage:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_native_mtp_capability.py \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/runtime/native_mtp/capability.py \
+  services/mlx-worker-python/worker/runtime/mlx_text_runtime.py \
+  services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py \
+  services/mlx-worker-python/tests/test_native_mtp_capability.py \
+  services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+```
+
+Metrics and gates:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" \
+  uv run --project services/mlx-worker-python --extra mlx bash -c 'python3 scripts/native_mtp_loader_safetensor_scandir_probe.py'
+make swift-test
+make py-test
+make integration-test
+.githooks/pre-commit
+```
+
+## Verification Results
+
+- Red test:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py`
+  failed as expected before implementation with
+  `ModuleNotFoundError: No module named 'worker.runtime.native_mtp.capability'`.
+- Focused tests:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights`
+  passed with 14 tests.
+- Native MTP regression tests:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q ...`
+  passed with 22 tests across the new registry coverage, VLM preload fixture,
+  and existing native-MTP backend tests.
+- Changed-scope coverage:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q ... && coverage json ... && python3 scripts/changed_scope_coverage.py ...`
+  passed before commit staging with changed-scope aggregate coverage above the
+  required 95 percent. Follow-up module-scoped coverage for the extracted
+  native-MTP helpers passed with `capability.py` at 99 percent and `preload.py`
+  at 100 percent.
+- Native MTP loader performance probe:
+  `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python --extra mlx bash -c 'python3 scripts/native_mtp_loader_safetensor_scandir_probe.py'`
+  passed with direct-probe speedups `speedup=1.0144`,
+  `extra_speedup=6.9534`, `model_listing_speedup=2.2633`, and
+  `weight_load_speedup=1.2343`.
+- `make py-test` passed with `4769 passed, 14 skipped, 2 warnings in 172.18s`.
+- `make swift-test` passed; the macOS menubar stage completed with
+  `rc=0` and `834 tests` passing in that stage.
+- `make integration-test` passed with `123 passed, 1 skipped in 699.04s`.
+- `.githooks/pre-commit` must run after staging the exact commit content so the
+  hook can select the PR-scoped performance probes from staged files; record
+  the resulting report path in the pull request evidence.

--- a/services/mlx-worker-python/tests/test_native_mtp_capability.py
+++ b/services/mlx-worker-python/tests/test_native_mtp_capability.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from worker.runtime.mlx_text_runtime import maybe_apply_native_mtp_text_preload_patches
+from worker.runtime.mlx_vlm_runtime import maybe_apply_native_mtp_preload_patches
+from worker.runtime.native_mtp.capability import NativeMTPCapabilityDecision, resolve_native_mtp_capability
+
+
+def _write_model(
+    model_dir: Path,
+    *,
+    config: dict[str, object],
+    weight_map: dict[str, str] | None = None,
+) -> None:
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    if weight_map is not None:
+        (model_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": weight_map}),
+            encoding="utf-8",
+        )
+
+
+def _install_fake_native_mtp(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[tuple[str, bool]],
+    *,
+    patch_result: bool = True,
+) -> None:
+    class FakeNativeMTP:
+        @staticmethod
+        def set_mtp_active(active: bool) -> None:
+            calls.append(("active", active))
+
+        @staticmethod
+        def set_mtp_weight_attachment(active: bool) -> None:
+            calls.append(("attach", active))
+
+        @staticmethod
+        def apply_native_mtp_patches() -> bool:
+            calls.append(("patch", True))
+            return patch_result
+
+    import worker.runtime as worker_runtime_pkg
+
+    monkeypatch.setitem(sys.modules, "worker.runtime.native_mtp", FakeNativeMTP)
+    monkeypatch.setattr(worker_runtime_pkg, "native_mtp", FakeNativeMTP, raising=False)
+
+
+def test_registry_accepts_qwen_native_head_shape(tmp_path: Path) -> None:
+    model_dir = tmp_path / "qwen-native-head"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5",
+                "mtp_num_hidden_layers": 1,
+            },
+        },
+        weight_map={
+            "language_model.mtp.fc.weight": "mtp.safetensors",
+            "language_model.model.embed_tokens.weight": "model.safetensors",
+        },
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=True, active=True)
+
+    assert decision.patchable is True
+    assert decision.compatible is True
+    assert decision.resolution == "accepted"
+    assert decision.refusal_reason == ""
+    assert metadata["melix.native_mtp.enabled"] == "true"
+    assert metadata["melix.native_mtp.compatible"] == "true"
+    assert metadata["melix.native_mtp.weights_present"] == "true"
+    assert metadata["melix.native_mtp.weight_count"] == "1"
+    assert metadata["melix.native_mtp.reason"] == ""
+    assert metadata["melix.native_mtp.family"] == "qwen3_5"
+    assert metadata["melix.native_mtp.source"] == "native_head"
+    assert metadata["melix.native_mtp.head_count"] == "1"
+    assert metadata["melix.native_mtp.batch_shape"] == "singleton_only"
+    assert metadata["melix.native_mtp.hardware_gate"] == "not_evaluated"
+    assert metadata["melix.native_mtp.resolution"] == "accepted"
+    assert metadata["melix.native_mtp.refusal_reason"] == ""
+    assert metadata["melix.native_mtp.receipt.schema"] == "melix.native_mtp.capability.v1"
+    assert metadata["melix.native_mtp.receipt.status"] == "admitted"
+    assert metadata["melix.native_mtp.receipt.mode"] == "speculative_decode"
+    assert metadata["melix.native_mtp.receipt.draft_supported"] == "true"
+    assert metadata["melix.native_mtp.receipt.effective_depth"] == "1"
+    assert metadata["melix.native_mtp.receipt.depth_source"] == "native_head"
+    assert metadata["melix.native_mtp.receipt.runtime_scope"] == "text_only_singleton"
+
+
+def test_registry_refuses_assistant_sidecar_shape(tmp_path: Path) -> None:
+    model_dir = tmp_path / "assistant-sidecar"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "gemma4_assistant",
+            "mtp_num_hidden_layers": 1,
+        },
+        weight_map={"mtp.fc.weight": "assistant-mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.speculative.role": "assistant",
+            "melix.speculative.kind": "mtp",
+        },
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+
+    assert decision.patchable is False
+    assert decision.compatible is False
+    assert decision.resolution == "refused"
+    assert decision.refusal_reason == "assistant_sidecar"
+    assert metadata["melix.native_mtp.compatible"] == "false"
+    assert metadata["melix.native_mtp.source"] == "assistant_sidecar"
+    assert metadata["melix.native_mtp.resolution"] == "refused"
+    assert metadata["melix.native_mtp.reason"] == "assistant_sidecar"
+    assert metadata["melix.native_mtp.receipt.status"] == "refused"
+    assert metadata["melix.native_mtp.receipt.fallback_reason"] == "assistant_sidecar"
+    assert metadata["melix.native_mtp.receipt.draft_supported"] == "false"
+
+
+def test_registry_preserves_disabled_legacy_flag_path(tmp_path: Path) -> None:
+    model_dir = tmp_path / "qwen-disabled"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "qwen3_5_text",
+            "mtp_num_hidden_layers": 2,
+        },
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "false"},
+    )
+    metadata = decision.to_metadata(patch_applied=True, active=False)
+
+    assert decision.patchable is True
+    assert decision.compatible is True
+    assert decision.resolution == "legacy_only"
+    assert decision.refusal_reason == "disabled"
+    assert metadata["melix.native_mtp.enabled"] == "false"
+    assert metadata["melix.native_mtp.reason"] == "disabled"
+    assert metadata["melix.native_mtp.resolution"] == "legacy_only"
+    assert metadata["melix.native_mtp.receipt.status"] == "not_requested"
+    assert metadata["melix.native_mtp.receipt.mode"] == "disabled"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "operator_disabled"
+
+
+def test_registry_reports_missing_native_head_weights(tmp_path: Path) -> None:
+    model_dir = tmp_path / "qwen-missing-head"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "qwen3_5_text",
+            "mtp_num_hidden_layers": "bad",
+            "text_config": {
+                "model_type": "qwen3_5_text",
+                "mtp_num_hidden_layers": 1,
+            },
+        },
+        weight_map={"model.embed_tokens.weight": "model.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=True, active=False)
+
+    assert decision.patchable is True
+    assert decision.resolution == "refused"
+    assert decision.refusal_reason == "missing_mtp_weights"
+    assert metadata["melix.native_mtp.reason"] == "missing_mtp_weights"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "missing_native_head_weights"
+
+
+def test_registry_reports_unsupported_enabled_model(tmp_path: Path) -> None:
+    model_dir = tmp_path / "unsupported"
+    _write_model(
+        model_dir,
+        config={"model_type": "llama", "mtp_num_hidden_layers": 0},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+
+    assert decision.patchable is False
+    assert decision.resolution == "refused"
+    assert decision.refusal_reason == "unsupported_model"
+    assert metadata["melix.native_mtp.reason"] == "unsupported_model"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "unsupported_model"
+
+
+def test_registry_reports_patch_failure_for_native_head(tmp_path: Path) -> None:
+    model_dir = tmp_path / "qwen-patch-failed"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+
+    assert metadata["melix.native_mtp.reason"] == "patch_failed"
+    assert metadata["melix.native_mtp.resolution"] == "refused"
+    assert metadata["melix.native_mtp.receipt.status"] == "refused"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "patch_failed"
+
+
+def test_registry_detects_assistant_sidecar_from_role_or_model_type(tmp_path: Path) -> None:
+    role_model_dir = tmp_path / "role-sidecar"
+    _write_model(
+        role_model_dir,
+        config={"model_type": "unknown", "mtp_num_hidden_layers": 1},
+    )
+    model_type_dir = tmp_path / "model-type-sidecar"
+    _write_model(
+        model_type_dir,
+        config={"model_type": "gemma4_assistant", "architectures": ["GemmaMTPForCausalLM"]},
+    )
+
+    by_role = resolve_native_mtp_capability(
+        role_model_dir,
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.speculative.role": "assistant",
+            "melix.speculative.target_family": "gemma4-v1",
+        },
+    )
+    by_model_type = resolve_native_mtp_capability(
+        model_type_dir,
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.speculative.kind": "mtp",
+        },
+    )
+
+    assert by_role.source == "assistant_sidecar"
+    assert by_role.family == "gemma4-v1"
+    assert by_model_type.source == "assistant_sidecar"
+
+
+def test_registry_detects_architecture_only_assistant_sidecar(tmp_path: Path) -> None:
+    model_dir = tmp_path / "architecture-sidecar"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "gemma4_assistant",
+            "architectures": ["GemmaMTPForCausalLM"],
+            "mtp_num_hidden_layers": "not-a-number",
+        },
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert decision.source == "assistant_sidecar"
+    assert decision.refusal_reason == "assistant_sidecar"
+    assert decision.head_count == 0
+
+
+def test_registry_ignores_non_mtp_assistant_architecture(tmp_path: Path) -> None:
+    model_dir = tmp_path / "non-mtp-assistant"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "gemma4_assistant",
+            "architectures": ["GemmaForCausalLM"],
+            "text_config": {"mtp_num_hidden_layers": "bad"},
+            "mtp_num_hidden_layers": "also-bad",
+        },
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert decision.source == "none"
+    assert decision.refusal_reason == "unsupported_model"
+    assert decision.head_count == 0
+
+
+def test_registry_receipt_supports_empty_fallback_reason() -> None:
+    decision = NativeMTPCapabilityDecision(
+        enabled=True,
+        compatible=False,
+        patchable=False,
+        weights_present=False,
+        weight_count=0,
+        family="unknown",
+        source="none",
+        head_count=0,
+        batch_shape="unsupported",
+        hardware_gate="not_evaluated",
+        resolution="fallback",
+        refusal_reason="",
+    )
+
+    metadata = decision.to_metadata(patch_applied=False, active=False, reason="")
+
+    assert metadata["melix.native_mtp.reason"] == ""
+    assert metadata["melix.native_mtp.resolution"] == "fallback"
+    assert metadata["melix.native_mtp.receipt.status"] == "fallback"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "not_admitted"
+
+
+def test_text_preload_routes_through_registry_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "text-qwen-native-head"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+    calls: list[tuple[str, bool]] = []
+    _install_fake_native_mtp(monkeypatch, calls)
+
+    metadata = maybe_apply_native_mtp_text_preload_patches(
+        str(model_dir),
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert metadata["melix.native_mtp.active"] == "true"
+    assert metadata["melix.native_mtp.receipt.status"] == "admitted"
+    assert ("patch", True) in calls
+    assert calls[-1] == ("active", True)
+
+
+def test_text_preload_routes_through_registry_and_refuses_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "text-sidecar"
+    _write_model(
+        model_dir,
+        config={"model_type": "gemma4_assistant", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "assistant-mtp.safetensors"},
+    )
+    calls: list[tuple[str, bool]] = []
+    _install_fake_native_mtp(monkeypatch, calls)
+
+    metadata = maybe_apply_native_mtp_text_preload_patches(
+        str(model_dir),
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.speculative.role": "assistant",
+            "melix.speculative.kind": "mtp",
+        },
+    )
+
+    assert metadata["melix.native_mtp.resolution"] == "refused"
+    assert metadata["melix.native_mtp.reason"] == "assistant_sidecar"
+    assert ("patch", True) not in calls
+    assert calls[-1] == ("active", False)
+
+
+def test_vlm_preload_routes_through_registry_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "vlm-qwen-native-head"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "qwen3_5",
+            "text_config": {
+                "model_type": "qwen3_5",
+                "mtp_num_hidden_layers": 1,
+            },
+        },
+        weight_map={
+            "language_model.mtp.fc.weight": "mtp.safetensors",
+            "language_model.model.embed_tokens.weight": "model.safetensors",
+        },
+    )
+    calls: list[tuple[str, bool]] = []
+    _install_fake_native_mtp(monkeypatch, calls)
+
+    metadata = maybe_apply_native_mtp_preload_patches(
+        str(model_dir),
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert metadata["melix.native_mtp.active"] == "true"
+    assert metadata["melix.native_mtp.family"] == "qwen3_5"
+    assert metadata["melix.native_mtp.receipt.status"] == "admitted"
+    assert metadata["melix.native_mtp.receipt.mode"] == "speculative_decode"
+    assert ("patch", True) in calls
+    assert calls[-1] == ("active", True)

--- a/services/mlx-worker-python/tests/test_native_mtp_capability.py
+++ b/services/mlx-worker-python/tests/test_native_mtp_capability.py
@@ -211,6 +211,22 @@ def test_registry_reports_unsupported_enabled_model(tmp_path: Path) -> None:
     assert metadata["melix.native_mtp.receipt.request_gate"] == "unsupported_model"
 
 
+def test_registry_treats_invalid_utf8_json_payloads_as_empty(tmp_path: Path) -> None:
+    model_dir = tmp_path / "invalid-json-payloads"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_bytes(b"\xff")
+    (model_dir / "model.safetensors.index.json").write_bytes(b"\xff")
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert decision.source == "none"
+    assert decision.weights_present is False
+    assert decision.refusal_reason == "unsupported_model"
+
+
 def test_registry_reports_patch_failure_for_native_head(tmp_path: Path) -> None:
     model_dir = tmp_path / "qwen-patch-failed"
     _write_model(

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -14,6 +14,8 @@ import time
 from typing import Any
 
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
+from worker.runtime.native_mtp.capability import resolve_native_mtp_capability
+from worker.runtime.native_mtp.preload import apply_native_mtp_preload_decision
 from worker.runtime.prefix_block_store import (
     LCPResult as _LCPResult,
     clone_cache_snapshot as _clone_cache_snapshot,
@@ -195,7 +197,6 @@ _STREAM_STOP_KWARG_NAMES = ("stop", "stop_words", "stop_sequences")
 _SAMPLER_PENALTY_KWARG_NAMES = ("frequency_penalty", "presence_penalty")
 _STOP_CONTRACT_CACHE_FIELD = "_melix.resolved_text_stop_contract_cache"
 _STOP_KWARGS_CACHE_FIELD = "_melix.resolved_text_stop_kwargs_cache"
-_NATIVE_MTP_ENABLED_EXT_KEY = "melix.native_mtp.enabled"
 _NATIVE_MTP_TEXT_BATCH_PREFILL_STEP_SIZE_ENV = "MELIX_TEXT_NATIVE_MTP_PREFILL_STEP_SIZE"
 _NATIVE_MTP_TEXT_BATCH_DEFAULT_PREFILL_STEP_SIZE = 2048
 _NATIVE_MTP_TEXT_ACTIVE_FIELD = "_melix.native_mtp_text_active"
@@ -208,103 +209,13 @@ def _truthy_string(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
 
 
-def _load_json_payload(path: Path) -> dict[str, Any]:
-    try:
-        payload = json.loads(path.read_text())
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
-def _native_mtp_model_type(config_payload: dict[str, Any]) -> str:
-    text_config = config_payload.get("text_config")
-    if isinstance(text_config, dict):
-        value = text_config.get("model_type") or config_payload.get("model_type")
-    else:
-        value = config_payload.get("model_type")
-    return str(value or "").strip().lower()
-
-
-def _native_mtp_layer_count(config_payload: dict[str, Any]) -> int:
-    candidates: list[Any] = []
-    text_config = config_payload.get("text_config")
-    if isinstance(text_config, dict):
-        candidates.append(text_config.get("mtp_num_hidden_layers"))
-    candidates.append(config_payload.get("mtp_num_hidden_layers"))
-    for value in candidates:
-        try:
-            return max(0, int(value or 0))
-        except (TypeError, ValueError):
-            continue
-    return 0
-
-
-def _native_mtp_weight_presence(model_dir: Path) -> tuple[bool, int]:
-    index_payload = _load_json_payload(model_dir / "model.safetensors.index.json")
-    weight_map = index_payload.get("weight_map")
-    if not isinstance(weight_map, dict):
-        return False, 0
-    count = sum(
-        1
-        for key in weight_map
-        if str(key).startswith("language_model.mtp.") or str(key).startswith("mtp.")
-    )
-    return count > 0, count
-
-
 def maybe_apply_native_mtp_text_preload_patches(
     model_path: str,
     *,
     metadata: dict[str, str],
 ) -> dict[str, str]:
-    enabled = _truthy_string(metadata.get(_NATIVE_MTP_ENABLED_EXT_KEY, ""))
-    model_dir = Path(model_path)
-    config_payload = _load_json_payload(model_dir / "config.json")
-    model_type = _native_mtp_model_type(config_payload)
-    mtp_layers = _native_mtp_layer_count(config_payload)
-    compatible = model_type in {"qwen3_5", "qwen3_5_text"} and mtp_layers > 0
-    weights_present, weight_count = _native_mtp_weight_presence(model_dir)
-
-    active = False
-    patch_applied = False
-    reason = "disabled"
-    try:
-        from worker.runtime import native_mtp
-
-        native_mtp.set_mtp_active(False)
-        native_mtp.set_mtp_weight_attachment(False)
-        if compatible:
-            native_mtp.set_mtp_weight_attachment(weights_present)
-            patch_applied = native_mtp.apply_native_mtp_patches()
-            if not patch_applied:
-                reason = "patch_failed"
-            elif not enabled:
-                reason = "disabled"
-            elif not weights_present:
-                reason = "missing_mtp_weights"
-            else:
-                active = True
-                reason = ""
-        elif enabled:
-            reason = "unsupported_model"
-        native_mtp.set_mtp_active(active)
-    except Exception:
-        reason = "patch_error"
-        try:
-            native_mtp.set_mtp_active(False)
-            native_mtp.set_mtp_weight_attachment(False)
-        except Exception:
-            pass
-
-    return {
-        "melix.native_mtp.enabled": "true" if enabled else "false",
-        "melix.native_mtp.compatible": "true" if compatible else "false",
-        "melix.native_mtp.weights_present": "true" if weights_present else "false",
-        "melix.native_mtp.weight_count": str(weight_count),
-        "melix.native_mtp.patch_applied": "true" if patch_applied else "false",
-        "melix.native_mtp.active": "true" if active else "false",
-        "melix.native_mtp.reason": reason,
-    }
+    decision = resolve_native_mtp_capability(model_path, metadata=metadata)
+    return apply_native_mtp_preload_decision(decision, model_path=model_path)
 
 
 def _load_mlx_batch_generator_class():

--- a/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py
@@ -23,6 +23,8 @@ from worker.runtime.deterministic_vlm_runtime import (
     probe_receipt_fallback_reason,
 )
 from worker.runtime.mlx_executor import MLXRuntimeExecutor
+from worker.runtime.native_mtp.capability import resolve_native_mtp_capability
+from worker.runtime.native_mtp.preload import apply_native_mtp_preload_decision
 from worker.runtime.mlx_text_runtime import (
     NativeMTPBatchTimings,
     RuntimeTokenEvent,
@@ -105,7 +107,6 @@ _GEMMA_CHAT_TEMPLATE_MODEL_TYPES = frozenset(("gemma3", "gemma3n", "gemma4"))
 _TEXT_ONLY_BATCH_GENERATOR_EXT_KEY = "melix.vlm.text_only_batch_generator"
 _TEXT_ONLY_STEP_COOPERATIVE_EXT_KEY = "melix.vlm.text_only_step_cooperative"
 _IMAGE_BATCH1_STEP_EXT_KEY = "melix.vlm.image_batch1_step.enabled"
-_NATIVE_MTP_ENABLED_EXT_KEY = "melix.native_mtp.enabled"
 _TEXT_ONLY_BATCH_PREFILL_STEP_SIZE_ENV = "MELIX_VLM_TEXT_BATCH_PREFILL_STEP_SIZE"
 _TEXT_ONLY_BATCH_DEFAULT_PREFILL_STEP_SIZE = 512
 _TEXT_ONLY_BATCH_MAX_BATCH_SIZE_ENV = "MELIX_VLM_TEXT_BATCH_MAX_BATCH_SIZE"
@@ -227,99 +228,8 @@ def maybe_apply_native_mtp_preload_patches(
     *,
     metadata: dict[str, str],
 ) -> dict[str, str]:
-    enabled = _truthy_string(metadata.get(_NATIVE_MTP_ENABLED_EXT_KEY, ""))
-    model_dir = Path(model_path)
-    config_payload = _load_json_payload(model_dir / "config.json")
-    model_type = _native_mtp_model_type(config_payload)
-    mtp_layers = _native_mtp_layer_count(config_payload)
-    compatible = model_type in {"qwen3_5", "qwen3_5_text"} and mtp_layers > 0
-    weights_present, weight_count = _native_mtp_weight_presence(model_dir)
-
-    active = False
-    patch_applied = False
-    reason = "disabled"
-    try:
-        from worker.runtime import native_mtp
-
-        native_mtp.set_mtp_active(False)
-        native_mtp.set_mtp_weight_attachment(False)
-        if compatible:
-            native_mtp.set_mtp_weight_attachment(weights_present)
-            patch_applied = native_mtp.apply_native_mtp_patches()
-            if not patch_applied:
-                reason = "patch_failed"
-            elif not enabled:
-                reason = "disabled"
-            elif not weights_present:
-                reason = "missing_mtp_weights"
-            else:
-                active = True
-                reason = ""
-        elif enabled:
-            reason = "unsupported_model"
-        native_mtp.set_mtp_active(active)
-    except Exception as exc:  # pragma: no cover - defensive runtime guard.
-        logger.warning("Native MTP preload patch failed for %s: %s", model_path, exc)
-        reason = "patch_error"
-        try:
-            native_mtp.set_mtp_active(False)
-            native_mtp.set_mtp_weight_attachment(False)
-        except Exception:
-            pass
-
-    return {
-        "melix.native_mtp.enabled": "true" if enabled else "false",
-        "melix.native_mtp.compatible": "true" if compatible else "false",
-        "melix.native_mtp.weights_present": "true" if weights_present else "false",
-        "melix.native_mtp.weight_count": str(weight_count),
-        "melix.native_mtp.patch_applied": "true" if patch_applied else "false",
-        "melix.native_mtp.active": "true" if active else "false",
-        "melix.native_mtp.reason": reason,
-    }
-
-
-def _load_json_payload(path: Path) -> dict[str, Any]:
-    try:
-        payload = json.loads(path.read_text())
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
-def _native_mtp_model_type(config_payload: dict[str, Any]) -> str:
-    text_config = config_payload.get("text_config")
-    if isinstance(text_config, dict):
-        value = text_config.get("model_type") or config_payload.get("model_type")
-    else:
-        value = config_payload.get("model_type")
-    return str(value or "").strip().lower()
-
-
-def _native_mtp_layer_count(config_payload: dict[str, Any]) -> int:
-    candidates: list[Any] = []
-    text_config = config_payload.get("text_config")
-    if isinstance(text_config, dict):
-        candidates.append(text_config.get("mtp_num_hidden_layers"))
-    candidates.append(config_payload.get("mtp_num_hidden_layers"))
-    for value in candidates:
-        try:
-            return max(0, int(value or 0))
-        except (TypeError, ValueError):
-            continue
-    return 0
-
-
-def _native_mtp_weight_presence(model_dir: Path) -> tuple[bool, int]:
-    index_payload = _load_json_payload(model_dir / "model.safetensors.index.json")
-    weight_map = index_payload.get("weight_map")
-    if not isinstance(weight_map, dict):
-        return False, 0
-    count = sum(
-        1
-        for key in weight_map
-        if str(key).startswith("language_model.mtp.") or str(key).startswith("mtp.")
-    )
-    return count > 0, count
+    decision = resolve_native_mtp_capability(model_path, metadata=metadata)
+    return apply_native_mtp_preload_decision(decision, model_path=model_path, failure_logger=logger)
 
 
 def _truthy_string(value: str | None) -> bool:

--- a/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+NATIVE_MTP_ENABLED_EXT_KEY = "melix.native_mtp.enabled"
+NATIVE_MTP_RECEIPT_SCHEMA = "melix.native_mtp.capability.v1"
+_QWEN_NATIVE_MTP_MODEL_TYPES = frozenset(("qwen3_5", "qwen3_5_text"))
+_MTP_WEIGHT_PREFIXES = ("language_model.mtp.", "mtp.")
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPCapabilityDecision:
+    enabled: bool
+    compatible: bool
+    patchable: bool
+    weights_present: bool
+    weight_count: int
+    family: str
+    source: str
+    head_count: int
+    batch_shape: str
+    hardware_gate: str
+    resolution: str
+    refusal_reason: str
+
+    def to_metadata(
+        self,
+        *,
+        patch_applied: bool,
+        active: bool,
+        reason: str | None = None,
+    ) -> dict[str, str]:
+        final_reason = self._reason(patch_applied=patch_applied, active=active, override=reason)
+        receipt_status = self._receipt_status(active=active, reason=final_reason)
+        receipt_mode = "speculative_decode" if active else "disabled"
+        draft_supported = bool(self.compatible and self.source == "native_head")
+        return {
+            "melix.native_mtp.enabled": _bool_string(self.enabled),
+            "melix.native_mtp.compatible": _bool_string(self.compatible),
+            "melix.native_mtp.weights_present": _bool_string(self.weights_present),
+            "melix.native_mtp.weight_count": str(self.weight_count),
+            "melix.native_mtp.patch_applied": _bool_string(patch_applied),
+            "melix.native_mtp.active": _bool_string(active),
+            "melix.native_mtp.reason": final_reason,
+            "melix.native_mtp.family": self.family,
+            "melix.native_mtp.source": self.source,
+            "melix.native_mtp.head_count": str(self.head_count),
+            "melix.native_mtp.batch_shape": self.batch_shape,
+            "melix.native_mtp.hardware_gate": self.hardware_gate,
+            "melix.native_mtp.resolution": self._resolution(active=active, reason=final_reason),
+            "melix.native_mtp.refusal_reason": "" if active else final_reason,
+            "melix.native_mtp.receipt.schema": NATIVE_MTP_RECEIPT_SCHEMA,
+            "melix.native_mtp.receipt.enabled": _bool_string(self.enabled),
+            "melix.native_mtp.receipt.status": receipt_status,
+            "melix.native_mtp.receipt.mode": receipt_mode,
+            "melix.native_mtp.receipt.fallback_reason": "" if active else final_reason,
+            "melix.native_mtp.receipt.source": self.source,
+            "melix.native_mtp.receipt.family": self.family,
+            "melix.native_mtp.receipt.weights_present": _bool_string(self.weights_present),
+            "melix.native_mtp.receipt.weight_count": str(self.weight_count),
+            "melix.native_mtp.receipt.draft_supported": _bool_string(draft_supported and active),
+            "melix.native_mtp.receipt.effective_depth": str(self.head_count if active else 0),
+            "melix.native_mtp.receipt.depth_source": self.source if active else "none",
+            "melix.native_mtp.receipt.batch_shape": self.batch_shape,
+            "melix.native_mtp.receipt.hardware_gate": self.hardware_gate,
+            "melix.native_mtp.receipt.request_gate": self._request_gate(active=active, reason=final_reason),
+            "melix.native_mtp.receipt.runtime_scope": "text_only_singleton" if active else "none",
+            "melix.native_mtp.receipt.draft_loaded": _bool_string(active),
+            "melix.native_mtp.receipt.target_decode_started": "false",
+        }
+
+    def _reason(self, *, patch_applied: bool, active: bool, override: str | None) -> str:
+        if override is not None:
+            return str(override or "")
+        if active:
+            return ""
+        if self.patchable and not patch_applied:
+            return "patch_failed"
+        return self.refusal_reason
+
+    def _resolution(self, *, active: bool, reason: str) -> str:
+        if active:
+            return "accepted"
+        if not self.enabled and self.compatible:
+            return "legacy_only"
+        if reason:
+            return "refused"
+        return self.resolution
+
+    def _receipt_status(self, *, active: bool, reason: str) -> str:
+        if active:
+            return "admitted"
+        if not self.enabled and self.compatible:
+            return "not_requested"
+        if reason:
+            return "refused"
+        return "fallback"
+
+    def _request_gate(self, *, active: bool, reason: str) -> str:
+        if active:
+            return "native_mtp_enabled"
+        if not self.enabled:
+            return "operator_disabled"
+        if reason == "assistant_sidecar":
+            return "assistant_sidecar_refused"
+        if reason == "missing_mtp_weights":
+            return "missing_native_head_weights"
+        if reason in {"unsupported_model", "patch_failed", "patch_error"}:
+            return reason
+        return "not_admitted"
+
+
+def resolve_native_mtp_capability(
+    model_path: str | Path,
+    *,
+    metadata: Mapping[str, str],
+) -> NativeMTPCapabilityDecision:
+    model_dir = Path(model_path)
+    config_payload = _load_json_payload(model_dir / "config.json")
+    model_type = _native_mtp_model_type(config_payload)
+    head_count = _native_mtp_layer_count(config_payload)
+    weights_present, weight_count = _native_mtp_weight_presence(model_dir)
+    enabled = _truthy_string(metadata.get(NATIVE_MTP_ENABLED_EXT_KEY, ""))
+
+    if _is_assistant_sidecar(metadata=metadata, config_payload=config_payload, model_type=model_type):
+        return NativeMTPCapabilityDecision(
+            enabled=enabled,
+            compatible=False,
+            patchable=False,
+            weights_present=weights_present,
+            weight_count=weight_count,
+            family=_sidecar_family(metadata=metadata, model_type=model_type),
+            source="assistant_sidecar",
+            head_count=head_count,
+            batch_shape="unsupported",
+            hardware_gate="not_evaluated",
+            resolution="refused",
+            refusal_reason="assistant_sidecar" if enabled else "disabled",
+        )
+
+    compatible = model_type in _QWEN_NATIVE_MTP_MODEL_TYPES and head_count > 0
+    if compatible:
+        refusal_reason = _native_head_refusal_reason(enabled=enabled, weights_present=weights_present)
+        return NativeMTPCapabilityDecision(
+            enabled=enabled,
+            compatible=True,
+            patchable=True,
+            weights_present=weights_present,
+            weight_count=weight_count,
+            family="qwen3_5",
+            source="native_head",
+            head_count=head_count,
+            batch_shape="singleton_only",
+            hardware_gate="not_evaluated",
+            resolution="accepted" if enabled and weights_present else "legacy_only" if not enabled else "refused",
+            refusal_reason=refusal_reason,
+        )
+
+    return NativeMTPCapabilityDecision(
+        enabled=enabled,
+        compatible=False,
+        patchable=False,
+        weights_present=weights_present,
+        weight_count=weight_count,
+        family=model_type,
+        source="none",
+        head_count=head_count,
+        batch_shape="unsupported",
+        hardware_gate="not_evaluated",
+        resolution="refused" if enabled else "legacy_only",
+        refusal_reason="unsupported_model" if enabled else "disabled",
+    )
+
+
+def _load_json_payload(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _native_mtp_model_type(config_payload: Mapping[str, Any]) -> str:
+    text_config = config_payload.get("text_config")
+    if isinstance(text_config, Mapping):
+        value = text_config.get("model_type") or config_payload.get("model_type")
+    else:
+        value = config_payload.get("model_type")
+    return str(value or "").strip().lower()
+
+
+def _native_mtp_layer_count(config_payload: Mapping[str, Any]) -> int:
+    candidates: list[Any] = []
+    text_config = config_payload.get("text_config")
+    if isinstance(text_config, Mapping):
+        candidates.append(text_config.get("mtp_num_hidden_layers"))
+    candidates.append(config_payload.get("mtp_num_hidden_layers"))
+    for value in candidates:
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def _native_mtp_weight_presence(model_dir: Path) -> tuple[bool, int]:
+    index_payload = _load_json_payload(model_dir / "model.safetensors.index.json")
+    weight_map = index_payload.get("weight_map")
+    if not isinstance(weight_map, Mapping):
+        return False, 0
+    count = sum(1 for key in weight_map if str(key).startswith(_MTP_WEIGHT_PREFIXES))
+    return count > 0, count
+
+
+def _truthy_string(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _is_assistant_sidecar(
+    *,
+    metadata: Mapping[str, str],
+    config_payload: Mapping[str, Any],
+    model_type: str,
+) -> bool:
+    role = str(metadata.get("melix.speculative.role", "") or "").strip().lower()
+    kind = str(metadata.get("melix.speculative.kind", "") or "").strip().lower()
+    if role == "assistant" and kind == "mtp":
+        return True
+    if role == "assistant" and _has_mtp_shape(config_payload):
+        return True
+    if kind == "mtp" and "assistant" in model_type:
+        return True
+    return "assistant" in model_type and _has_mtp_shape(config_payload)
+
+
+def _has_mtp_shape(config_payload: Mapping[str, Any]) -> bool:
+    if _native_mtp_layer_count(config_payload) > 0:
+        return True
+    architectures = config_payload.get("architectures")
+    if isinstance(architectures, list):
+        return any("mtp" in str(value).lower() for value in architectures)
+    return False
+
+
+def _sidecar_family(*, metadata: Mapping[str, str], model_type: str) -> str:
+    target_family = str(metadata.get("melix.speculative.target_family", "") or "").strip().lower()
+    return target_family or model_type
+
+
+def _native_head_refusal_reason(*, enabled: bool, weights_present: bool) -> str:
+    if not enabled:
+        return "disabled"
+    if not weights_present:
+        return "missing_mtp_weights"
+    return ""
+
+
+def _bool_string(value: bool) -> str:
+    return "true" if value else "false"

--- a/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
@@ -178,8 +178,8 @@ def resolve_native_mtp_capability(
 
 def _load_json_payload(path: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(path.read_text())
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
         return {}
     return payload if isinstance(payload, dict) else {}
 

--- a/services/mlx-worker-python/worker/runtime/native_mtp/preload.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/preload.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+
+from worker.runtime.native_mtp.capability import NativeMTPCapabilityDecision
+
+
+def apply_native_mtp_preload_decision(
+    decision: NativeMTPCapabilityDecision,
+    *,
+    model_path: str,
+    failure_logger: logging.Logger | None = None,
+) -> dict[str, str]:
+    active = False
+    patch_applied = False
+    reason: str | None = None
+    native_mtp_module = None
+    try:
+        from worker.runtime import native_mtp as native_mtp_module
+
+        native_mtp_module.set_mtp_active(False)
+        native_mtp_module.set_mtp_weight_attachment(False)
+        if decision.patchable:
+            native_mtp_module.set_mtp_weight_attachment(decision.weights_present)
+            patch_applied = native_mtp_module.apply_native_mtp_patches()
+            active = bool(patch_applied and decision.enabled and decision.weights_present)
+        native_mtp_module.set_mtp_active(active)
+    except Exception as exc:  # pragma: no cover - defensive runtime guard.
+        if failure_logger is not None:
+            failure_logger.warning("Native MTP preload patch failed for %s: %s", model_path, exc)
+        reason = "patch_error"
+        if native_mtp_module is not None:
+            try:
+                native_mtp_module.set_mtp_active(False)
+                native_mtp_module.set_mtp_weight_attachment(False)
+            except Exception:
+                pass
+
+    return decision.to_metadata(patch_applied=patch_applied, active=active, reason=reason)


### PR DESCRIPTION
## Summary
- Add a native MTP capability registry for the existing Qwen native-head path, including assistant-sidecar fail-closed decisions and stable receipt metadata.
- Route text and VLM native-MTP preload through the registry plus a shared preload side-effect helper.
- Add coverage for accepted, refused, disabled, missing-weight, patch-failed, and fallback receipt paths.

## Plan or Spec
- `docs/plans/2026-07-08-issue-2602-native-mtp-capability-registry.md`
- Refs #2602. This is the first implementation slice for the registry/receipt contract and does not close the broader batched-MTP, device-policy, or additional-family work.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py
# Expected red result before implementation: ModuleNotFoundError: No module named 'worker.runtime.native_mtp.capability'

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights
# 15 passed in 0.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage report -m services/mlx-worker-python/worker/runtime/native_mtp/capability.py services/mlx-worker-python/worker/runtime/native_mtp/preload.py
# capability.py: 99%; preload.py: 100%; TOTAL: 99%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp or mtp'
# 22 passed, 2 warnings in 4.78s

git diff --check
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python --extra mlx bash -c 'python3 scripts/native_mtp_loader_safetensor_scandir_probe.py'
# speedup=1.0144; extra_speedup=6.9534; model_listing_speedup=2.2633; weight_load_speedup=1.2343

.githooks/pre-commit
# Code-change report: .runtime/pre-commit-performance/20260708-013608-0869ad83/report/report.md
# Status ok; 6 changed files; 8 selected probes; regressions 0; verification failures 0; all selected probe coverage 100.0%

.githooks/pre-commit
# Final amendment report: .runtime/pre-commit-performance/20260708-015431-a925a017/report/report.md
# make swift-test: rc=0 elapsed=138.1s
# make py-test: 4772 passed, 14 skipped, 2 warnings in 163.21s
# make integration-test: 123 passed, 1 skipped in 420.76s
# Status ok; 2 changed files; 0 selected probes; regressions 0; verification failures 0

.githooks/pre-commit
# Review fix report: .runtime/pre-commit-performance/20260708-024820-93c087b8/report/report.md
# make swift-test: rc=0 elapsed=137.2s
# make py-test: 4774 passed, 14 skipped, 2 warnings in 163.98s
# make integration-test: 123 passed, 1 skipped in 409.30s
# Status ok; 3 changed files; 0 selected probes; regressions 0; verification failures 0
```

## Coverage and Metrics
- Focused changed-scope helper coverage is above the 95% bar: `capability.py` 99%, `preload.py` 100%, total 99%.
- PR-scoped performance evidence for code changes: `.runtime/pre-commit-performance/20260708-013608-0869ad83/report/report.md`, status `ok`, 8 selected probes, 0 regressions, 0 verification failures, selected probe coverage 100.0%.
- Final staged amendment pre-commit evidence: `.runtime/pre-commit-performance/20260708-015431-a925a017/report/report.md`, status `ok`, 0 regressions, 0 verification failures.
- Review fix pre-commit evidence: `.runtime/pre-commit-performance/20260708-024820-93c087b8/report/report.md`, status `ok`, 0 regressions, 0 verification failures.
- Direct native MTP loader probe stayed neutral-to-positive: speedup 1.0144, extra speedup 6.9534, model listing speedup 2.2633, weight load speedup 1.2343.
- Observability mode: minimal. The change adds deterministic receipt metadata on the existing preload path; no sampled/debug telemetry or runtime background probe was introduced.
- Probe overhead: N/A for new observability because the new receipt fields reuse existing preload-time metadata resolution and there is no new long-lived probe.

## Known Gaps
- `make bootstrap` was not run because this change does not modify dependencies or bootstrap inputs.
- `make proto` was not run because this change does not modify protobuf schemas or generated protocol artifacts.
- Batched MTP execution, device-aware activation policy, and additional native-family registry entries remain deferred to later #2602 slices.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
