### PR TITLE
perf: bind report evidence rule getter

### DIFF
--- a/docs/plans/2026-07-08-report-evidence-rule-get-binding.md
+++ b/docs/plans/2026-07-08-report-evidence-rule-get-binding.md
@@ -1,0 +1,26 @@
+# Report Evidence Rule Getter Binding
+
+## Scope
+
+This Python performance slice is limited to the report evidence gate rule matching hot path in `services/mlx-worker-python/worker/productization/report_evidence_gate.py`.
+It does not change report validation semantics, release matrix behavior, generated protocol artifacts, or CLI surfaces.
+
+## Optimization Hypothesis
+
+`_rule_matches_report()` repeatedly reads rule fields and cached normalized rule state while the registered report evidence gate probe exercises run-kind, metric-prefix, target-field, and probe-phase rules. Binding `rule.get` once per call should reduce repeated method lookup overhead without changing the mutable rule-cache behavior or list-rule mutation semantics. The release-matrix row renderer also binds `rows.append` while keeping per-row rule lookups unchanged, preserving output shape while avoiding repeated append-method lookup in the row emission loop.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports the relevant `run_kind_elapsed_ms_mean`, `metric_prefix_elapsed_ms_mean`, `target_field_elapsed_ms_mean`, and `elapsed_ms_mean` metrics.
+
+## Verification Plan
+
+- Run the focused report evidence gate tests from the registered probe.
+- Run changed-scope coverage through the registered probe coverage command.
+- Run the registered probe locally on Linux and compare baseline versus candidate metrics.
+- Let the PR-scoped performance CI workflow provide the merge-blocking registered probe report.
+
+## Expected Effect
+
+- Lower or neutral rule-matching elapsed time in the registered report evidence gate probe.
+- Preserve cached tuple-rule behavior, list-rule mutation behavior, and probe-phase fallback behavior.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -274,9 +274,10 @@ def _release_matrix_rows(
             evidence_ids_for_role.update(evidence_ids)
 
     rows: list[dict[str, object]] = []
+    rows_append = rows.append
     for role, rule in matrix.items():
         evidence_ids = evidence_by_role_get(role)
-        rows.append(
+        rows_append(
             {
                 "role": role,
                 "required": bool(rule.get("required", True)),
@@ -378,11 +379,12 @@ def _rule_matches_report(
     metrics: list[dict[str, object]],
     probe_phases: AbstractSet[str],
 ) -> bool:
-    run_kinds = rule.get("run_kinds", ())
+    rule_get = rule.get
+    run_kinds = rule_get("run_kinds", ())
     if run_kinds:
         if isinstance(run_kinds, tuple):
-            cached_run_kind_set = rule.get("_melix_cached_run_kind_set")
-            if rule.get("_melix_cached_run_kinds") is run_kinds and isinstance(
+            cached_run_kind_set = rule_get("_melix_cached_run_kind_set")
+            if rule_get("_melix_cached_run_kinds") is run_kinds and isinstance(
                 cached_run_kind_set,
                 frozenset,
             ):
@@ -402,10 +404,10 @@ def _rule_matches_report(
             run_kind = run.get(run_kind_key, "")
             if type(run_kind) is not str and str(run_kind) in run_kind_set:
                 return True
-    metric_prefixes = rule.get("metric_prefixes", ())
+    metric_prefixes = rule_get("metric_prefixes", ())
     if metric_prefixes:
         if isinstance(metric_prefixes, tuple):
-            cached_metric_prefix_state = rule.get("_melix_cached_metric_prefix_state")
+            cached_metric_prefix_state = rule_get("_melix_cached_metric_prefix_state")
             if (
                 isinstance(cached_metric_prefix_state, tuple)
                 and len(cached_metric_prefix_state) == 4
@@ -447,11 +449,11 @@ def _rule_matches_report(
                 and metric_value.startswith(metric_prefix_tuple)
             ):
                 return True
-    target_fields = rule.get("target_fields", ())
+    target_fields = rule_get("target_fields", ())
     if target_fields:
         if isinstance(target_fields, tuple):
-            cached_target_field_set = rule.get("_melix_cached_target_field_set")
-            if rule.get("_melix_cached_target_fields") is target_fields and isinstance(
+            cached_target_field_set = rule_get("_melix_cached_target_field_set")
+            if rule_get("_melix_cached_target_fields") is target_fields and isinstance(
                 cached_target_field_set,
                 frozenset,
             ):
@@ -474,12 +476,12 @@ def _rule_matches_report(
                         return True
                 elif str(value).strip():
                     return True
-    required_probe_phases = rule.get("probe_phases", ())
+    required_probe_phases = rule_get("probe_phases", ())
     if not required_probe_phases:
         return False
     if isinstance(required_probe_phases, tuple):
-        cached_probe_phase_set = rule.get("_melix_cached_probe_phase_set")
-        if rule.get("_melix_cached_probe_phases") is required_probe_phases and isinstance(
+        cached_probe_phase_set = rule_get("_melix_cached_probe_phase_set")
+        if rule_get("_melix_cached_probe_phases") is required_probe_phases and isinstance(
             cached_probe_phase_set,
             frozenset,
         ):


### PR DESCRIPTION
## Summary
- Bind `rule.get` once inside the report evidence gate `_rule_matches_report()` hot path.
- Keep tuple-rule cache behavior, list-rule mutation behavior, and probe-phase fallback semantics unchanged.
- Bind `rows.append` in the release-matrix row emission loop to remove the CI-reported release-matrix regression while preserving row shape.
- Add the governing plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-07-08-report-evidence-rule-get-binding.md`

## Commands Run
```text
# Baseline probe on origin/main before the code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean=1009.253; run_kind_elapsed_ms_mean=210.269; metric_prefix_elapsed_ms_mean=390.283; target_field_elapsed_ms_mean=277.954

# Focused registered tests after the release-matrix row append binding adjustment
python3 - <<'PY'
import json
from pathlib import Path
probes=json.loads(Path('infra/perf/pr_scoped_probes.json').read_text())
probe=next(p for p in probes if p['id']=='report-evidence-gate-run-kind-set-membership')
for k in ('test_command','coverage_command','probe_command'):
    Path(f'/tmp/report_evidence_{k}.sh').write_text(probe[k]+"\n")
PY
bash /tmp/report_evidence_test_command.sh
# exit 0; 29 passed in 0.18s

# Changed-scope coverage using the registered coverage command
bash /tmp/report_evidence_coverage_command.sh
# exit 0; TOTAL 2 0 100%

# Candidate registered probe after the release-matrix row append binding adjustment
bash /tmp/report_evidence_probe_command.sh
# exit 0; elapsed_ms_mean=974.627; run_kind_elapsed_ms_mean=215.972; metric_prefix_elapsed_ms_mean=363.302; target_field_elapsed_ms_mean=267.820; release_matrix_elapsed_ms_mean=29.993

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for changed lines in `report_evidence_gate.py`.
- Registered local Linux probe (`report-evidence-gate-run-kind-set-membership`):
  - `elapsed_ms_mean`: 1009.253 -> 974.627 ms; delta -34.626 ms (-3.43%); speedup 1.036x.
  - `run_kind_elapsed_ms_mean`: 210.269 -> 215.972 ms; delta +5.703 ms (+2.71%); within the 5% neutral band.
  - `metric_prefix_elapsed_ms_mean`: 390.283 -> 363.302 ms; delta -26.981 ms (-6.91%); speedup 1.074x.
  - `target_field_elapsed_ms_mean`: 277.954 -> 267.820 ms; delta -10.134 ms (-3.65%); speedup 1.038x.
  - `release_matrix_elapsed_ms_mean`: CI base 31.258 ms -> local candidate 29.993 ms; delta -1.265 ms (-4.05%) for the previously regressed metric. CI PR-scoped performance remains the merge-blocking registered probe validation source.

## Known Gaps
- None for this Python-only slice. CI remains the merge-blocking registered probe validation source.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
