### PR TITLE
perf: bind diagnostic evidence path prefix

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -232,6 +232,13 @@ covered by the exact table now skip the union marker scan and phrase loop,
 whereas non-exact lines continue through the same marker, phrase, and regex
 fallbacks.
 
+A follow-up 2026-07-08 diagnosis evidence-path prefix slice keeps diagnosis
+semantics, matched pattern ids, and emitted evidence anchors unchanged while
+binding the repeated `diagnostics/redacted-log-excerpt.txt#line-` prefix once per
+excerpt scan. Exact-text, fast-phrase, and regex fallback matches now append the
+line number to that bound prefix instead of formatting the full evidence path in
+each matched branch.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -845,6 +845,7 @@ def _diagnoses_from_excerpt(
     exact_fast_text_patterns = _DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS
     source_lines_local = source_lines
     has_diagnosis_marker = _has_diagnosis_marker
+    evidence_path_prefix = f"{excerpt_path}#line-"
     remaining_known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
     for index, line_number in line_numbers.items():
         if remaining_known_code_count == 0:
@@ -865,7 +866,7 @@ def _diagnoses_from_excerpt(
                     "matched_pattern_id": fast_pattern.pattern_id,
                     "operator_message": fast_pattern.operator_message,
                     "remediation": fast_pattern.remediation,
-                    "evidence_path": f"{excerpt_path}#line-{line_number}",
+                    "evidence_path": evidence_path_prefix + str(line_number),
                 }
             )
             continue
@@ -889,7 +890,7 @@ def _diagnoses_from_excerpt(
                     "matched_pattern_id": fast_pattern.pattern_id,
                     "operator_message": fast_pattern.operator_message,
                     "remediation": fast_pattern.remediation,
-                    "evidence_path": f"{excerpt_path}#line-{line_number}",
+                    "evidence_path": evidence_path_prefix + str(line_number),
                 }
             )
             continue
@@ -920,7 +921,7 @@ def _diagnoses_from_excerpt(
                     "matched_pattern_id": pattern.pattern_id,
                     "operator_message": pattern.operator_message,
                     "remediation": pattern.remediation,
-                    "evidence_path": f"{excerpt_path}#line-{line_number}",
+                    "evidence_path": evidence_path_prefix + str(line_number),
                 }
             )
             break


### PR DESCRIPTION
## Summary
- Bind the repeated runtime export diagnostic evidence anchor prefix once per excerpt scan.
- Reuse the bound prefix for exact-text, fast-phrase, and regex fallback diagnosis matches without changing matched codes, pattern ids, or emitted anchors.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 82 passed in 1.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 82 passed in 1.41s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# exit 0; elapsed_ms_mean=2597.9150319995824; diagnosis_matching_elapsed_ms_mean=0.17596399993635714

MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=10 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=40 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/runtime-export-diagnostic-evidence-prefix-report-samples10.json
# exit 0; head verification 82 passed; changed-scope coverage TOTAL 1 0 100%; base/head probe completed

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`aggregate_measurable_changed_lines=1`, `aggregate_covered_changed_lines=1`, `aggregate_missed_changed_lines=0`).
- Registered probe local Linux comparison (`runtime-export-diagnostic-parser`, samples=10, iterations=40):
  - `elapsed_ms_mean`: base `3480.877793606487`, head `3478.5846961050993`, delta `-2.2930975013878196 ms` (`-0.06587698958003275%`).
  - `diagnosis_matching_elapsed_ms_mean`: base `0.24617661256343126`, head `0.23340749903582036`, delta `-0.012769113527610898 ms` (`-5.18697263507139%`).
  - `diagnostic_latency_ms`: base `7.833112991647795`, head `7.7826090273447335`, delta `-0.050503964303061366 ms` (`-0.6447495951725983%`).
  - `path_redaction_elapsed_ms_mean`: base `23.087136799586006`, head `22.327414000756107`, delta `-0.7597227988298982 ms` (`-3.290675692810559%`).
  - `peak_bytes_mean`: base `205395.4`, head `206878.8`, delta `+1483.4 bytes` (`+0.7222167585057865%`, below the registered 5% warning threshold).
  - Invariant metrics unchanged: `diagnostic_parser_coverage=1.0`, `parsed_failure_count=27.0`, `unknown_failure_count=1.0`, `diagnosis_code_count=9.0`.
- Observability mode: `N/A` (no runtime observability mode change).
- Probe overhead: `N/A` (uses existing PR-scoped performance probe only).

## Known Gaps
- CI must run the registered PR-scoped performance workflow and publish the GitHub probe report before merge.
- Local validation is Linux/Python-only; no Swift runtime behavior changed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
