### PR TITLE
perf: bind model config open helper

### DIFF
--- a/docs/plans/2026-07-07-model-load-config-os-binding.md
+++ b/docs/plans/2026-07-07-model-load-config-os-binding.md
@@ -18,6 +18,10 @@ Bind the hot OS and stat helpers used by the repeated config probe path at modul
 
 This keeps trust-policy semantics unchanged while avoiding repeated global attribute resolution in the hot config stat and executable-file fallback paths.
 
+## 2026-07-08 Open Binding Follow-up Slice
+
+This follow-up Python-only slice is still limited to `services/mlx-worker-python/worker/model_load_trust.py` and the registered `model-load-config-json-bytes` probe. The config JSON read path now also binds `builtins.open` as `_OPEN` and uses that module-local binding for the direct binary read in `_read_model_config_for_stat(...)`. The behavior remains identical: config files are opened directly in binary mode, parsed from bytes through `_JSON_LOADS`, and cached by `(path, mtime_ns, size)`.
+
 ## Verification Plan
 
 Run locally on Linux before PR:

--- a/services/mlx-worker-python/tests/test_model_load_trust.py
+++ b/services/mlx-worker-python/tests/test_model_load_trust.py
@@ -373,7 +373,15 @@ def test_trust_policy_reads_config_json_bytes_with_direct_open(
     def fail_read_bytes(path: Path) -> bytes:  # pragma: no cover - only runs on regression.
         raise AssertionError(f"config.json should use direct open(), not Path.read_bytes(): {path}")
 
-    monkeypatch.setattr(model_load_trust_module, "open", counted_open, raising=False)
+    monkeypatch.setattr(model_load_trust_module, "_OPEN", counted_open)
+    monkeypatch.setattr(
+        model_load_trust_module,
+        "open",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("config.json should use the module-local open binding")
+        ),
+        raising=False,
+    )
     monkeypatch.setattr(model_load_trust_module.Path, "read_bytes", fail_read_bytes)
     monkeypatch.setattr(model_load_trust_module.Path, "read_text", fail_read_text)
 
@@ -442,7 +450,7 @@ def test_trust_policy_caches_config_json_by_file_stat(
         open_calls += 1
         return original_open(*args, **kwargs)
 
-    monkeypatch.setattr(model_load_trust_module, "open", counted_open, raising=False)
+    monkeypatch.setattr(model_load_trust_module, "_OPEN", counted_open)
 
     for _ in range(2):
         with pytest.raises(model_load_trust_module.ModelLoadTrustRejection) as exc_info:

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from builtins import open as _OPEN
 from dataclasses import dataclass
 from functools import lru_cache
 import json
@@ -394,7 +395,7 @@ def _read_model_config_for_stat(
     _ = (mtime_ns, size)
     loads = _JSON_LOADS
     try:
-        with open(config_path, "rb") as handle:
+        with _OPEN(config_path, "rb") as handle:
             payload = loads(handle.read())
     except (OSError, json.JSONDecodeError):
         return None


### PR DESCRIPTION
## Summary
- Bind the model-load config JSON binary read to a module-local `_OPEN` helper.
- Update the direct-open regression tests to assert the hot path uses the module-local binding, while preserving binary read and stat-cache behavior.

## Plan or Spec
- `docs/plans/2026-07-07-model-load-config-os-binding.md` documents this follow-up Python-only open-binding slice.
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/model_load_trust.py` with focused test, coverage, and probe commands.

## Commands Run
```text
# Baseline focused tests on origin/main worktree before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <model-load-config-json-bytes test_command>
# 29 passed in 0.56s

# Baseline local probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py
# {"elapsed_ms_mean": 5.56750043844139, "elapsed_ms_min": 5.422382004326209, "peak_bytes_mean": 3194.285714285714, "samples": 7, "iterations": 300, "rejections_mean": 300.0, ...}

# Focused registered tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <model-load-config-json-bytes test_command>
# 29 passed in 0.59s

# Changed-scope coverage after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <model-load-config-json-bytes focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_load_trust.py services/mlx-worker-python/tests/test_model_load_trust.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_load_config_json_bytes_probe.py
# TOTAL 6 0 100%

# Registered local base-vs-head probe after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-load-config-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-model-load-config-open-bind-20260708 --output /tmp/model-load-open-bind-perf.json
# test: 29 passed in 0.54s; coverage: TOTAL 5 0 100%
# base elapsed_ms_mean=5.957114859484136, head elapsed_ms_mean=5.464466716927875

# Whitespace check
 git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 5 0 100%` in the registered local base-vs-head probe run; earlier direct coverage run also reported `TOTAL 6 0 100%`).
- Local registered probe (`model-load-config-json-bytes`): base `elapsed_ms_mean=5.957114859484136`, head `elapsed_ms_mean=5.464466716927875`, delta `-0.492648142556261 ms` (~8.27% faster), `peak_bytes_mean` unchanged at `3187.4285714285716` bytes.
- GitHub Actions PR-scoped performance is still required as the merge gate for registered CI validation.

## Known Gaps
- Local verification is Linux/Python-only. No Swift runtime behavior is touched.
- CI PR-scoped performance report must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A; this changes an existing Python hot path and uses the registered synthetic PR-scoped probe.
- [x] Deferred work and known gaps are stated explicitly.
