### PR TITLE
perf: cache dataset record content digest

### DIFF
--- a/docs/plans/2026-07-08-dataset-record-digest-local-bind.md
+++ b/docs/plans/2026-07-08-dataset-record-digest-local-bind.md
@@ -1,0 +1,31 @@
+# Dataset record content digest cache
+
+## Scope
+
+This Python performance slice is limited to `worker.productization.dataset_preparation._record()` record materialization. Dataset ingest and probe fixtures can materialize many records with repeated normalized text; the previous hot path encoded the same normalized text and recomputed its content SHA-256 for every record even when only the source path changed.
+
+This slice adds a bounded `lru_cache` helper for the normalized-text content digest and byte-size pair. `_record()` still computes the source-id hash from each path independently, keeps metadata copy isolation, and returns the same record schema. The cache is bounded to avoid unbounded retention while accelerating repeated normalized text bodies.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+## Verification plan
+
+1. Run the registered focused test command for `dataset-source-records-scandir` locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and keep coverage at or above 95%.
+3. Run the registered probe command locally on Linux and compare against the pre-change baseline, focusing on `record_elapsed_ms_mean` and `record_elapsed_ms_p95` while ensuring file count, source-kind classification, and byte accounting remain unchanged.
+4. Let GitHub Actions run the registered PR-scoped performance workflow before merging.
+
+## Acceptance
+
+- `_record()` preserves stable per-path `source_id`, `content_sha256`, `byte_size`, `source_uri`, and metadata copy semantics.
+- Repeated normalized text records reuse the bounded digest/size cache without sharing path-derived identifiers.
+- Focused dataset ingest and PR-scoped registry tests pass.
+- Changed-scope coverage for the touched scope remains at or above the repository threshold.
+- The registered `dataset-source-records-scandir` probe is non-regressing or improved for source record construction.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -19,6 +19,7 @@ from worker.productization.dataset_preparation import (
     _language_for_suffix,
     _normalize_line_endings,
     _record,
+    _record_content_digest_and_size,
     _read_source_text,
     _source_size_entries,
     _source_kind,
@@ -223,6 +224,20 @@ def test_dataset_ingest_record_copies_nonempty_metadata_and_fast_paths_empty_met
     metadata["language"] = "swift"
 
     assert record["metadata"] == {"language": "python"}
+
+
+def test_dataset_ingest_record_reuses_normalized_text_digest_cache() -> None:
+    _record_content_digest_and_size.cache_clear()
+
+    first_record = _record(Path("first.txt"), "text", "hello\n", {}, normalized=True)
+    second_record = _record(Path("second.txt"), "text", "hello\n", {}, normalized=True)
+
+    cache_info = _record_content_digest_and_size.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.misses == 1
+    assert first_record["content_sha256"] == second_record["content_sha256"]
+    assert first_record["byte_size"] == second_record["byte_size"] == len(b"hello\n")
+    assert first_record["source_id"] != second_record["source_id"]
 
 
 def test_dataset_ingest_record_accepts_pre_normalized_text(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1514,7 +1514,7 @@ def _record(
     normalized: bool = False,
 ) -> dict[str, Any]:
     normalized_text = text if normalized else _normalize_line_endings(text)
-    normalized_bytes = normalized_text.encode("utf-8")
+    content_sha256, byte_size = _record_content_digest_and_size(normalized_text)
     record_metadata = dict(metadata) if metadata else {}
     sha256 = hashlib.sha256
     path_name = path.name
@@ -1523,12 +1523,18 @@ def _record(
         "source_id": sha256(path_key).hexdigest()[:16],
         "source_uri": path_name,
         "source_kind": source_kind,
-        "content_sha256": sha256(normalized_bytes).hexdigest(),
-        "byte_size": len(normalized_bytes),
+        "content_sha256": content_sha256,
+        "byte_size": byte_size,
         "record_count": 1,
         "text": normalized_text,
         "metadata": record_metadata,
     }
+
+
+@lru_cache(maxsize=4096)
+def _record_content_digest_and_size(normalized_text: str) -> tuple[str, int]:
+    normalized_bytes = normalized_text.encode("utf-8")
+    return hashlib.sha256(normalized_bytes).hexdigest(), len(normalized_bytes)
 
 
 def _failure_id(reason: str, name: str) -> str:


### PR DESCRIPTION
## Summary
- Cache normalized dataset record content digest and byte-size calculations behind a bounded helper.
- Add a focused regression test proving repeated text reuses the cache while path-derived source IDs stay distinct.
- Document the slice and registered probe coverage in `docs/plans/2026-07-08-dataset-record-digest-local-bind.md`.

## Plan or Spec
- `docs/plans/2026-07-08-dataset-record-digest-local-bind.md`
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting` → 47 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py` → TOTAL 15 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- Three-run local base/head comparison of the registered probe command.

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Baseline `record_elapsed_ms_mean` samples: 20.852565, 20.588790, 20.605459 ms; mean 20.682272 ms.
- Head `record_elapsed_ms_mean` samples: 17.692734, 17.859056, 17.348468 ms; mean 17.633420 ms.
- Delta: -3.048852 ms; record-construction speedup: 14.741379%.
- Local registered probe output after the change: `record_elapsed_ms_mean=17.577689`, `record_elapsed_ms_p95=18.555908`, `file_count_mean=7000.0`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Linux local validation covers the Python worker path only.
- The cache is bounded (`maxsize=4096`) and optimizes repeated normalized text; unique text bodies should preserve behavior but may not benefit.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally above 95%.
- [x] Registered probe ran locally with base/head metrics.
- [ ] GitHub Actions completed successfully.
- [ ] Registered PR-scoped performance workflow completed successfully.
