### PR TITLE
perf(native-mtp): bind JSON index load helpers

### DIFF
--- a/docs/plans/2026-07-08-native-mtp-json-load-bind.md
+++ b/docs/plans/2026-07-08-native-mtp-json-load-bind.md
@@ -1,0 +1,37 @@
+# Native MTP Loader JSON Load Bindings
+
+## Scope
+
+This Python-only performance slice is limited to the native-MTP loader's
+`model.safetensors.index.json` payload read in
+`services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
+It preserves the existing behavior: missing, unreadable, invalid, or non-object
+index payloads still produce an empty mapping, and sidecar shard discovery keeps
+its existing filtering, duplicate handling, missing-shard warnings, and base
+`model*.safetensors` exclusion semantics.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.
+The registry entry already includes focused `test_command`, `coverage_command`,
+and `probe_command` entries covering the native-MTP loader, its regression tests,
+and the JSON-emitting performance probe script.
+
+## Slice plan
+
+1. Keep the sidecar shard discovery algorithm unchanged.
+2. Bind the module-level binary-open helper and JSON loader used by
+   `_load_json_payload(...)` so repeated native-MTP index reads avoid global
+   builtins and module attribute lookups.
+3. Reuse the existing native-MTP regression tests and changed-scope coverage
+   command from the registered probe.
+4. Run the registered probe locally on Linux before opening the PR. GitHub
+   Actions PR-scoped performance remains the merge gate for the registered probe
+   report.
+
+## Validation boundary
+
+This slice changes Python worker code only. Linux local validation covers the
+Python regression tests, changed-scope coverage, and registered probe command.
+No Swift/macOS runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from builtins import open as _OPEN
 import importlib.util
 import json
 import logging
@@ -16,13 +17,15 @@ from worker.runtime.quantized_tensor_metadata import (
 logger = logging.getLogger(__name__)
 
 _PATCHED = False
+_JSON_LOADS = json.loads
 _MTP_WEIGHT_KEY_PREFIXES = ("language_model.mtp.", "mtp.")
 
 
 def _load_json_payload(path: Path) -> dict[str, Any]:
+    loads = _JSON_LOADS
     try:
-        with open(path, "rb") as payload_file:
-            payload = json.loads(payload_file.read())
+        with _OPEN(path, "rb") as payload_file:
+            payload = loads(payload_file.read())
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}
     return payload if isinstance(payload, dict) else {}


### PR DESCRIPTION
## Summary
- Bind the native-MTP JSON index open helper and JSON loader at module scope.
- Keep sidecar shard discovery semantics unchanged while reducing repeated global/module lookups on index reads.
- Add a focused plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-08-native-mtp-json-load-bind.md`
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_weight_load_probe_tolerates_loader_timer_noise_without_weakening_counts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_model_listing_probe_tolerates_loader_timer_noise_without_weakening_counts`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 13 passed.
- Changed-scope coverage: 100.00% (`TOTAL 5 0 100%`).
- Local registered probe metrics on Linux:
  - `old_mean_ms=15.70261039887555`
  - `new_mean_ms=12.404733593575656`
  - `delta_ms=-3.297876805299893`
  - `speedup=1.2658563185111726`
  - `extra_old_mean_ms=289.9208489980083`
  - `extra_new_mean_ms=42.70190780516714`
  - `extra_speedup=6.789412087179076`

## Known Gaps
- This is a Python-only slice validated locally on Linux.
- GitHub Actions PR-scoped performance must complete successfully before merge; no Swift/macOS runtime effect is claimed.

## Evidence Checklist
- [x] Affected path has registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at or above the required threshold.
- [x] Registered probe ran locally and emitted JSON metrics.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
