### PR TITLE
perf: guard hub size marker scans

### DIFF
--- a/docs/plans/2026-07-08-hub-size-marker-presence-guard.md
+++ b/docs/plans/2026-07-08-hub-size-marker-presence-guard.md
@@ -1,0 +1,37 @@
+# Hub catalog size marker presence guard performance slice
+
+## Scope
+
+This Python-only performance slice is limited to Hub catalog size-hint marker
+screening in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+The changed helper is `_may_contain_model_marker(...)`, which is called before
+running explicit size-hint parsing for `description`, `readme`, and
+`cardData.description` text fields.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `hub-catalog-size-hint-regex-precompile` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries and the probe
+reports `elapsed_ms_mean` for the size-hint workload.
+
+## Implementation plan
+
+1. Preserve the existing case-insensitive two-character marker behavior for
+   `MO`, `Mo`, `mo`, and `mO` sequences.
+2. Add a cheap single-character presence guard so marker-free text exits before
+   the four pair scans used by the existing helper.
+3. Keep the existing focused Hub catalog tests as behavior parity coverage.
+4. Run the registered focused tests, changed-scope coverage, and local Linux
+   size-hint probe before pushing. CI remains the merge gate for the registered
+   PR-scoped performance report.
+
+## Acceptance criteria
+
+- Focused Hub catalog and PR-scoped performance tests pass.
+- Changed-scope coverage for `hub_catalog.py`, related tests, registry test, and
+  the size-hint probe meets the repository threshold.
+- The local registered probe shows a neutral-to-improved `elapsed_ms_mean`
+  versus the same-worktree `origin/main` baseline.
+- The PR-scoped performance workflow completes successfully before merge.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -1066,7 +1066,9 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
 
 
 def _may_contain_model_marker(text: str) -> bool:
-    return "MO" in text or "Mo" in text or "mo" in text or "mO" in text
+    return ("m" in text or "M" in text) and (
+        "MO" in text or "Mo" in text or "mo" in text or "mO" in text
+    )
 
 
 def _parameter_count(value: Any) -> int:


### PR DESCRIPTION
## Summary
- Adds a cheap single-character presence guard before Hub catalog size marker pair scans.
- Preserves the existing case-insensitive `MO`/`Mo`/`mo`/`mO` marker behavior while reducing work for marker-free description/readme text.

## Plan or Spec
- `docs/plans/2026-07-08-hub-size-marker-presence-guard.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_ITERATIONS=200000 MELIX_HUB_CATALOG_COMPATIBILITY_ITERATIONS=200000 MELIX_HUB_CATALOG_SIZE_HINT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-size-marker-guard-20260708 --output /tmp/hub_size_marker_guard_pr_probe_clean.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 94 passed.
- Changed-scope coverage: 100.00% (1/1 changed measurable line covered).
- Local direct probe: `elapsed_ms_mean` 1264.400 ms baseline-style pre-change sample -> 1260.275 ms after change.
- Local registered base/head probe (`hub-catalog-size-hint-regex-precompile`):
  - `elapsed_ms_mean`: base 1281.883 ms, head 1271.071 ms, delta -10.813 ms (~0.84% faster).
  - `payload_compatibility_elapsed_ms_mean`: base 194.154 ms, head 192.216 ms, delta -1.938 ms.
  - `size_hint_calls_mean`: base 0.0, head 0.0.
  - `peak_bytes_mean`: base 230838.2, head 230838.2.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Linux local validation covers Python behavior and the registered Python probe only.
- Hosted CI remains the source of truth for the PR-scoped performance workflow and overall repository checks.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests pass.
- [x] Changed-scope coverage meets the repository threshold.
- [x] Local registered base/head probe shows neutral-to-improved metrics.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
