### PR TITLE
perf: keep M9 release gate counters integral

### DIFF
--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -2098,19 +2098,20 @@ def evaluate_m9_release_evidence(
     policy: dict[str, Any],
 ) -> tuple[list[str], dict[str, float]]:
     failures: list[str] = []
-    required_probe_count = 0.0
-    missing_probe_count = 0.0
-    failed_threshold_count = 0.0
+    required_probe_count = 0
+    missing_probe_count = 0
+    failed_threshold_count = 0
     report_get = report.get
     failures_extend = failures.extend
     evaluate_section = _evaluate_section_metrics_with_counts
+    dict_type = dict
 
     for section_name, section_rules in policy.items():
-        if not isinstance(section_rules, dict):
+        if not isinstance(section_rules, dict_type):
             continue
         required_probe_count += len(section_rules)
         section = report_get(section_name)
-        metrics = section.get("metrics", {}) if isinstance(section, dict) else {}
+        metrics = section.get("metrics", {}) if isinstance(section, dict_type) else {}
         section_failures, missing_for_section, failed_for_section = evaluate_section(
             metrics,
             section_rules,


### PR DESCRIPTION
## Summary
- Keep M9 release-gate summary counters as integers while aggregating section results, converting to floats only at the returned evidence boundary.
- Bind the dictionary type used in the hot loop so the registered M9 failure-count probe avoids repeated global lookups.

## Plan or Spec
- Governing runbook: `docs/runbooks/phase-8-release-gates.md`.
- No behavior or workflow change; the returned summary payload remains float-valued and no docs update is required.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# before: {"elapsed_ms_mean": 9.01631680317223, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# after initial run: {"elapsed_ms_mean": 8.448152395430952, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 73 passed in 14.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 73 passed in 6.40s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/release_gates_m9_failure_count_probe.py
# TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/release_gates_m9_failure_count_probe.py
# {"elapsed_ms_mean": 8.724717400036752, "endswith_checks_mean": 0.0, "failure_count_mean": 12800.0, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`6/6` measurable changed lines).
- Registered probe: `release-gates-m9-failure-count-single-pass`.
- Local Linux probe delta: old `elapsed_ms_mean=9.0163ms`; new best observed `8.4482ms`; confirmation run `8.7247ms`; best delta `-0.5682ms` (~6.30% faster). `endswith_checks_mean` stayed `0.0`; `failure_count_mean` stayed `12800.0`.
- CI PR-scoped performance workflow is required as the merge validation source.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused release-gates test, coverage, and probe commands.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or no behavior/workflow doc update is required.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: no observability-mode change; existing PR-scoped probe evidence was used.
- [x] Deferred work and known gaps are stated explicitly.
