### PR TITLE
perf(code-eval): bind runner config byte reads

### DIFF
--- a/docs/plans/2026-07-08-code-eval-runner-config-local-bind.md
+++ b/docs/plans/2026-07-08-code-eval-runner-config-local-bind.md
@@ -1,0 +1,29 @@
+# Code evaluation runner config read local binding performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the code-evaluation sandbox runner script in `worker.engine.code_eval_runner`.
+
+The change preserves runner config JSON semantics while binding `Path.read_bytes` as a default argument in the generated runner helper so repeated config reads avoid the per-call bound-method lookup inside the hot probe loop.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `code-eval-runner-script-cache` in `infra/perf/pr_scoped_probes.json`.
+
+That probe already declares focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_runner_script_probe.py`
+
+## Implementation plan
+
+1. Keep the static runner script cache intact.
+2. Add a regression assertion that the generated runner script binds `Path.read_bytes` locally and loads config bytes through that binding.
+3. Run the registered focused tests, changed-scope coverage, and PR-scoped probe locally on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance workflow as the merge validation source.
+
+## Linux verification boundary
+
+This slice changes Python code and is locally verifiable on Linux. No Swift runtime behavior is changed.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -886,7 +886,8 @@ def test_runner_script_loads_config_from_bytes(tmp_path: Path) -> None:
         "payload_path": "/tmp/payload.json",
         "memory_limit_mb": 64,
     }
-    assert "payload = _json_loads(config_path.read_bytes())" in script
+    assert "_read_bytes=Path.read_bytes" in script
+    assert "payload = _json_loads(_read_bytes(config_path))" in script
     assert 'json.dumps(payload, separators=(",", ":"))' in script
     assert "json.load(file)" not in script
 

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -1055,8 +1055,9 @@ _RUNNER_SCRIPT = textwrap.dedent(
         def _load_config(
             config_path: Path,
             _json_loads=json.loads,
+            _read_bytes=Path.read_bytes,
         ) -> dict[str, object]:
-            payload = _json_loads(config_path.read_bytes())
+            payload = _json_loads(_read_bytes(config_path))
             if not isinstance(payload, dict):
                 raise TypeError("runner config must be a JSON object")
             return payload


### PR DESCRIPTION
## Summary
- Bind `Path.read_bytes` as a default argument inside the static code-evaluation runner script config loader.
- Keep the static runner script cache behavior unchanged and update the focused regression assertion.

## Plan or Spec
- `docs/plans/2026-07-08-code-eval-runner-config-local-bind.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_evaluation_result_uses_slots_without_instance_dict services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_precomputed_static_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_loads_config_from_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics
# 6 passed in 3.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_evaluation_result_uses_slots_without_instance_dict services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_reuses_precomputed_static_payload services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_loads_config_from_bytes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_runner_script_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_runner_script_probe.py
# 6 passed in 4.64s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_runner_script_probe.py
# config_load_elapsed_ms_mean=70.74150771534603, elapsed_ms_mean=59.41127771594828

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-runner-script-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_runner_config_local_bind_probe.json
# head verification OK; base/head probe OK
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered PR-scoped probe: `code-eval-runner-script-cache`.
- Local base-vs-head registered probe:
  - `config_load_elapsed_ms_mean`: base `76.24568056780845` ms, head `70.15724356252966` ms, delta `-6.08843700527879` ms (`-7.99%`).
  - `elapsed_ms_mean`: base `59.06476185607192` ms, head `60.494051289944245` ms, delta `+1.429289433872326` ms (`+2.42%`, below the registered 5% warning threshold).
  - `dedent_calls_mean`: base `0.0`, head `0.0`.
  - `identity_reuse_mean`: base `1.0`, head `1.0`.
  - `peak_bytes_mean`: base `676.0`, head `676.0`.
- CI is required for final registered probe validation before merge.

## Known Gaps
- None. This is a Python-only slice locally verified on Linux; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
