### PR TITLE
perf: add chunker short message copy fast path

### DIFF
--- a/docs/plans/2026-07-08-training-dataset-chunker-message-copy-short-list.md
+++ b/docs/plans/2026-07-08-training-dataset-chunker-message-copy-short-list.md
@@ -1,0 +1,36 @@
+# Training Dataset Chunker Short Message Copy Fast Path
+
+## Scope
+
+This Python-only performance slice narrows the message-copy path in
+`services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`.
+The chunker emits many two-message chunks for long single-turn samples and
+three-message chunks when a system prefix is present. Each emitted chunk copies
+only message dictionaries before attaching shared top-level sample fields.
+
+## Registered Probe
+
+The affected path is already covered by the PR-scoped
+`training-dataset-chunker-top-level-base-copy` command-json probe in
+`infra/perf/pr_scoped_probes.json`. The registered probe includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`
+- `services/mlx-worker-python/tests/test_training_dataset_chunker.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/training_dataset_chunker_top_level_copy_probe.py`
+
+## Planned Optimization
+
+Add an exact-size fast path to `_copy_messages` for the dominant two- and
+three-message chunk outputs. The implementation preserves shallow message-dict
+copy semantics and falls back to the generic list comprehension for all other
+message counts.
+
+## Verification
+
+- Focused chunker tests for two-message, three-message, and independent message
+  copies.
+- Changed-scope coverage using the registered coverage command.
+- Local Linux execution of the registered command-json probe before PR creation.
+- Hosted PR-scoped performance workflow after push remains the merge gate.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -307,6 +307,11 @@ def _copy_messages(messages: list[dict[str, str]]) -> list[dict[str, str]]:
     """Copy the message containers without deep-copying immutable string payloads."""
 
     copy_dict = _COPY_DICT
+    message_count = len(messages)
+    if message_count == 2:
+        return [copy_dict(messages[0]), copy_dict(messages[1])]
+    if message_count == 3:
+        return [copy_dict(messages[0]), copy_dict(messages[1]), copy_dict(messages[2])]
     return [copy_dict(message) for message in messages]
 
 


### PR DESCRIPTION
## Summary
- Add an exact two-/three-message fast path in the training dataset chunker message-copy helper.
- Keep existing shallow-copy semantics for emitted chunk message dictionaries while avoiding the generic list-comprehension path for the dominant chunk shapes.
- Document the slice and its registered probe coverage.

## Plan or Spec
- `docs/plans/2026-07-08-training-dataset-chunker-message-copy-short-list.md`

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks
# 3 passed in 0.12s

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py; done
# baseline elapsed_ms_mean samples: 23.967597, 23.002778, 25.299603; peak_bytes_mean: 774473.714

# Focused post-change smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks
# 3 passed in 0.06s

for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py; done
# post-change elapsed_ms_mean samples: 22.514378, 23.217971, 22.367533; peak_bytes_mean: 771689.714

# Registered probe test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics
# 11 passed in 1.18s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_chunking_streams_candidate_segments_without_list_helper services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_without_system_prefix_keeps_two_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_long_single_turn_with_system_prefix_keeps_three_message_chunks services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_single_turn_search_stops_candidate_rendering_after_first_oversized_segment services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_words_into_k_matches_string_helper_output services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_split_user_content_into_k_handles_trivial_and_word_shortage_cases services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_training_dataset_chunker_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_training_dataset_chunker_top_level_copy_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py
# 11 passed in 0.27s; TOTAL 5 0 100%

# Registered probe command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/training_dataset_chunker_top_level_copy_probe.py ]; then python3 scripts/training_dataset_chunker_top_level_copy_probe.py; else python3 -c "...fallback omitted..."; fi'
# {"chunk_count": 174.0, "elapsed_ms_mean": 25.843088, "peak_bytes_mean": 771689.714, "sample_count": 7.0, "top_level_key_count": 123.0}

git diff --check
# passed
```

## Coverage and Metrics
- Registered probe: `training-dataset-chunker-top-level-base-copy` covers this path and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local repeated probe comparison: old_mean=24.089993 ms, new_mean=22.699961 ms, speedup=5.77%, delta_ms=-1.390032 ms.
- Peak memory: old_mean=774473.714 bytes, new_mean=771689.714 bytes, delta=-2784 bytes.
- Hosted PR-scoped performance CI is still required before merge.

## Known Gaps
- Linux local validation covers the Python chunker path only; no Swift runtime effect is claimed.
- The final registered probe command is a single sample and showed elapsed noise (25.843088 ms), so the repeated local probe comparison and hosted PR-scoped report are the performance decision sources.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped command-json performance probe only; production observability unchanged; probe overhead N/A because no observability code changed.
- [x] Deferred work and known gaps are stated explicitly.
