### PR TITLE
Reuse prefix KV cache on standard MLX text path

### DIFF
--- a/docs/plans/2026-07-08-issue-2599-standard-prefix-kv-reuse.md
+++ b/docs/plans/2026-07-08-issue-2599-standard-prefix-kv-reuse.md
@@ -1,0 +1,385 @@
+# Issue #2599 Standard Prefix KV Reuse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `PrefixBlockStore` session prefix KV reuse into the standard Python text generation path, not only the native-MTP batch path.
+
+**Architecture:** Keep `PrefixBlockStore` as the worker-local source of cache truth. Extract session cache request parsing into a shared helper, explicitly prefill prompt tokens into a `prompt_cache` before standard `stream_generate`, and pass only the last/suffix token prompt with the restored cache. Store a prompt-only cache snapshot before generation mutates the cache with completion tokens.
+
+**Tech Stack:** Python 3.12, `mlx-lm` `stream_generate(prompt_cache=...)`, `pytest`, existing PR-scoped performance infrastructure.
+
+---
+
+## Context
+
+- Issue: <https://github.com/Keith-CY/melix/issues/2599>
+- Existing store: `services/mlx-worker-python/worker/runtime/prefix_block_store.py`
+- Existing native-MTP integration: `services/mlx-worker-python/worker/runtime/mlx_text_runtime.py`
+- Existing parser metrics bridge: `services/mlx-worker-python/worker/engine/engine_core.py`
+- Existing tests: `services/mlx-worker-python/tests/test_mlx_backend.py`, `services/mlx-worker-python/tests/test_prefix_block_store.py`, `services/mlx-worker-python/tests/test_work_saved_cache_counters.py`
+
+Local `mlx-lm` inspection confirms:
+
+- `stream_generate` accepts `prompt: str | mx.array | list[int]`.
+- `stream_generate` forwards `prompt_cache` to `generate_step`.
+- `generate_step(prompt_cache=...)` mutates the prompt cache in place.
+- Therefore the standard path must clone/store the prompt-only cache before iterating generated responses.
+
+## Files
+
+- Modify `services/mlx-worker-python/worker/runtime/mlx_text_runtime.py`
+  - Add a shared `_SessionPrefixCacheContext` parser.
+  - Add a generic `_prefill_prompt_cache` helper and keep `_native_mtp_prefill_prompt_cache` as a compatibility alias.
+  - Add standard-path prefix cache preparation and store/update logic.
+  - Emit cache receipt fields on terminal standard-path events.
+- Modify `services/mlx-worker-python/tests/test_mlx_backend.py`
+  - Add standard-path cache assertions for cache miss/store, warm-hit suffix replay, trim-failure fallback, and safe bypasses.
+  - Anchor those assertions in existing native-MTP LCP tests that are already selected by the MLX text PR-scoped probes, so the focused coverage gate stays local without changing the global probe registry.
+- Modify docs only through this plan unless implementation reveals a canonical spec gap.
+
+## Performance Probes and Metrics
+
+Measurement points:
+
+- `cache_hit_mode`: `none`, `partial`, or `exact` on the terminal event.
+- `recovered_prefix_tokens`: token count recovered from `PrefixBlockStore`.
+- `cache_fallback_reason`: `no_reusable_prefix`, `prompt_cache_unsupported`, `tokenizer_encode_unavailable`, or restore failure reason.
+- `stream_prompt_token_count`: the token count passed to `stream_generate` after cache preparation.
+
+Success metrics:
+
+- Cold session request stores a prompt-only cache snapshot and emits `cache_hit_mode=none`.
+- Warm session request with a block-aligned LCP passes a shorter token prompt to `stream_generate` and emits `cache_hit_mode=partial` or `exact`.
+- Restore/trim failure releases the acquired store entry, falls back to cold prefill, and emits a fallback receipt.
+- No-session, tokenizer-without-`encode`, and stream function without `prompt_cache` keep the raw prompt generation path.
+
+The PR-scoped performance workflow already selects existing `mlx_text_runtime.py` probes for this file. PR evidence must additionally report the focused unit metrics above. The global probe registry should remain unchanged for this issue.
+
+The standard path must not add overhead to no-session requests. Cache `stream_generate(prompt_cache=...)` support at backend initialization/runtime load time, and keep the no-session standard stream path on a raw fast path so the existing stop-kwarg signature-cache probe stays stable.
+
+## Task 1: Red Tests for Standard Prefix Cache Behavior
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/tests/test_mlx_backend.py`
+
+- [x] **Step 1: Add test helper for standard-path cache backend**
+
+Add a helper near the native-MTP LCP tests that builds an `AutoMLXBackend` with:
+
+```python
+def _build_standard_cache_backend(monkeypatch, *, store, encode_tokens, stream_calls, prefill_calls):
+    from worker.runtime import prefix_block_store as _pbs
+
+    monkeypatch.setattr(_pbs, "get_store", lambda *a, **kw: store)
+    monkeypatch.setattr(mlx_text_runtime_module, "_get_prefix_store", lambda *a, **kw: store)
+    monkeypatch.setattr(
+        mlx_text_runtime_module,
+        "_clone_cache_snapshot",
+        lambda cache: [SimpleNamespace(state=[])] if cache is not None else None,
+    )
+    monkeypatch.setattr(mlx_text_runtime_module, "_estimate_cache_bytes", lambda cache: 128)
+
+    def fake_prefill(model, tokens, *, prefill_step_size, stream, restore_cache=None, restore_token_count=0):
+        prefill_calls.append(
+            {
+                "tokens": list(tokens),
+                "restore_cache": restore_cache,
+                "restore_token_count": restore_token_count,
+            }
+        )
+        cache = restore_cache if restore_cache is not None else [SimpleNamespace(state=[])]
+        return cache, [int(tokens[-1])], list(tokens[:-1])
+
+    monkeypatch.setattr(mlx_text_runtime_module, "_prefill_prompt_cache", fake_prefill)
+
+    class FakeTokenizer:
+        bos_token = None
+        eos_token = "</s>"
+        eos_token_id = 2
+
+        def encode(self, prompt, add_special_tokens=True):
+            return list(encode_tokens)
+
+    def fake_load(model_source: str, **kwargs):
+        return SimpleNamespace(), FakeTokenizer()
+
+    def fake_stream_generate(model, tokenizer, prompt, *, max_tokens, sampler, prompt_cache=None, **kwargs):
+        stream_calls.append(
+            {
+                "prompt": list(prompt) if isinstance(prompt, list) else prompt,
+                "prompt_cache": prompt_cache,
+                "max_tokens": max_tokens,
+            }
+        )
+        yield SimpleNamespace(
+            text="x",
+            raw_text="x",
+            token=101,
+            logprobs=None,
+            prompt_tokens=len(prompt) if isinstance(prompt, list) else len(str(prompt)),
+            generation_tokens=1,
+            prompt_tps=1.0,
+            generation_tps=1.0,
+            peak_memory=0.0,
+            finish_reason="stop",
+        )
+
+    backend = mlx_text_runtime_module.AutoMLXBackend(
+        load_fn=fake_load,
+        stream_generate_fn=fake_stream_generate,
+        sampler_factory=lambda **kw: "sampler",
+    )
+    model_spec = WorkerModelCatalog.dev_text_model(environment={"MELIX_DEV_TEXT_MODEL_PATH": "x"})
+    loaded = backend.load_model(model_spec)
+    loaded[mlx_text_runtime_module._NATIVE_MTP_TEXT_ACTIVE_FIELD] = False
+    return backend, loaded
+```
+
+- [x] **Step 2: Add cold miss/store assertion helper**
+
+Add:
+
+```python
+def test_generate_standard_path_session_cache_miss_prefills_and_stores(monkeypatch: pytest.MonkeyPatch) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[10, 20, 30, 40, 50, 60, 70, 80],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+    )
+
+    events = list(backend.generate_tokens(
+        loaded,
+        "hello world",
+        common_pb2.SamplingConfig(max_output_tokens=2),
+        Event(),
+        execution_ext={
+            "_melix.session_id": "standard-cold",
+            "_melix.model_id": "test-model",
+            "_melix.model_revision": "v1",
+            "_melix.block_size": "4",
+        },
+    ))
+
+    assert prefill_calls[0]["restore_cache"] is None
+    assert stream_calls[0]["prompt"] == [80]
+    assert stream_calls[0]["prompt_cache"] is not None
+    assert events[-1].cache_hit_mode == "none"
+    assert events[-1].recovered_prefix_tokens == 0
+    assert events[-1].cache_fallback_reason == "no_reusable_prefix"
+    lcp = store.find_lcp([10, 20, 30, 40, 50, 60, 70, 80], "test-model", "v1", 4)
+    assert lcp.mode == "exact"
+    assert lcp.recovered_prefix_tokens == 8
+    assert lcp.entry is not None
+    store.release(lcp.entry)
+```
+
+- [x] **Step 3: Add warm partial-hit assertion helper**
+
+Add a test that seeds `PrefixBlockStore` with `[10,20,30,40,50,60,70,80]`, then generates with `[10,20,30,40,99,99,99,99]`. Assert:
+
+```python
+assert prefill_calls[0]["restore_cache"] is not None
+assert prefill_calls[0]["restore_token_count"] == 4
+assert stream_calls[0]["prompt"] == [99]
+assert events[-1].cache_hit_mode == "partial"
+assert events[-1].recovered_prefix_tokens == 4
+```
+
+- [x] **Step 4: Add trim-failure fallback assertion helper**
+
+Seed a partial hit, install `_install_fake_trim(monkeypatch, returns=2)`, and assert:
+
+```python
+assert all(call["restore_cache"] is None for call in prefill_calls)
+assert events[-1].cache_hit_mode == "none"
+assert events[-1].cache_fallback_reason == "cache_restore_failed"
+entry = store.acquire("trim-fail-standard")
+assert entry is not None
+assert entry._active_refs == 1
+store.release(entry)
+```
+
+- [x] **Step 5: Add safe-bypass assertion helpers**
+
+Use a `fake_stream_generate(model, tokenizer, prompt, *, max_tokens, sampler)` function without `prompt_cache` or `**kwargs`. Assert it receives the original prompt string and no prefill/store work runs:
+
+```python
+assert stream_calls[0]["prompt"] == "hello world"
+assert prefill_calls == []
+assert events[-1].cache_hit_mode == "none"
+assert events[-1].cache_fallback_reason == "prompt_cache_unsupported"
+```
+
+- [x] **Step 6: Verify red**
+
+Run:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp_lcp_store_consulted_with_session_id or native_mtp_lcp_warm_path_uses_restored_cache or native_mtp_partial_hit_falls_back_when_trim_incomplete or native_mtp_no_session_reports_no_session_id' -q
+```
+
+Expected: selected tests fail because their standard-path assertion helpers exercise unimplemented `PrefixBlockStore` reuse in the standard `generate_tokens` path.
+
+## Task 2: Implement Shared Context and Standard Prefix Cache Path
+
+**Files:**
+
+- Modify: `services/mlx-worker-python/worker/runtime/mlx_text_runtime.py`
+
+- [x] **Step 1: Add shared context parser**
+
+Add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _SessionPrefixCacheContext:
+    session_id: str
+    model_id: str
+    model_revision: str
+    block_size: int
+    cache_memory_budget_bytes: int
+    acceleration_mode: str
+    cache_mode: str
+    force_fallback: bool
+```
+
+and a `_session_prefix_cache_context(execution_ext)` helper that preserves the native-MTP defaults: block size defaults to `64`, unset cache memory budget is `0`, unset cache mode becomes `CACHE_MODE_TIERED`, and `_test.force_cache_fallback` is honored only behind `MELIX_ENABLE_TEST_CACHE_HOOKS`.
+
+- [x] **Step 2: Rename prefill helper with compatibility alias**
+
+Rename the implementation function to `_prefill_prompt_cache(...)` and keep:
+
+```python
+_native_mtp_prefill_prompt_cache = _prefill_prompt_cache
+```
+
+so existing tests and native-MTP call sites keep working during the slice.
+
+- [x] **Step 3: Use shared parser in native-MTP path**
+
+Replace duplicated `_melix.*` parsing inside `_generate_native_mtp_batch_tokens` with:
+
+```python
+_cache_context = _session_prefix_cache_context(execution_ext)
+```
+
+and read fields from `_cache_context`.
+
+- [x] **Step 4: Add standard-path prefix cache preparation**
+
+Before the standard `stream_generate` loop, when the stream function accepts `prompt_cache`, the tokenizer has `encode`, and a session id exists:
+
+1. Encode prompt tokens with the same BOS rule used by `stream_generate`.
+2. Run `PrefixBlockStore.find_lcp`.
+3. Clone and trim restored snapshots for warm hits.
+4. Call `_prefill_prompt_cache` to create or replay a prompt cache.
+5. Clone/store the prompt-only cache before iterating generation responses.
+6. Call `stream_generate` with `prompt=[last_token]`, `prompt_cache=prompt_cache`, and existing sampler/stop kwargs.
+
+Fallbacks must release any acquired store entry and keep generation alive.
+
+- [x] **Step 5: Emit terminal receipt fields in standard path**
+
+Set `cache_hit_mode`, `recovered_prefix_tokens`, and `cache_fallback_reason` only on terminal standard-path `RuntimeTokenEvent`s. Non-terminal events keep those fields `None`.
+
+- [x] **Step 6: Verify green**
+
+Run the red-test command from Task 1. Expected: all selected tests pass.
+
+## Task 3: Focused Regression and Coverage Verification
+
+**Files:**
+
+- Modify only if required by failing tests:
+  - `services/mlx-worker-python/tests/test_prefix_block_store.py`
+  - `services/mlx-worker-python/tests/test_work_saved_cache_counters.py`
+
+- [x] **Step 1: Run focused runtime tests**
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_prefix_block_store.py services/mlx-worker-python/tests/test_work_saved_cache_counters.py -q
+```
+
+Expected: pass.
+
+- [x] **Step 2: Run changed-scope coverage**
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_prefix_block_store.py services/mlx-worker-python/tests/test_work_saved_cache_counters.py -q
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python scripts/python_changed_line_coverage.py --coverage-json coverage.json --diff-from origin/main services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_mlx_backend.py
+```
+
+Expected: changed-line coverage for touched Python scope is at least `95%`.
+
+- [x] **Step 3: Run formatting/diff checks**
+
+```bash
+git diff --check
+git diff origin/main...HEAD --check
+```
+
+Expected: both pass.
+
+- [x] **Step 4: Repair PR-scoped focused coverage selection**
+
+After the first pre-commit attempt, the full Swift/Python/integration gate passed but the scoped performance report failed in `verification_failed` state because the new standard-path prefix-cache assertions lived in separate pytest nodeids that the existing MLX text probes did not run. Move those assertions under existing native-MTP LCP tests already selected by both MLX text probes, keeping `infra/perf/pr_scoped_probes.json` unchanged.
+
+Also cache `stream_generate(prompt_cache=...)` support on `AutoMLXBackend` and keep no-session requests on the raw stream path so the standard path does not add per-request signature inspection or cache lifecycle overhead to the stop-kwarg probe.
+
+Verification:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py -k 'standard_path or auto_backend_reuses_cached_stop_kwarg_signature or native_mtp' -q
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp_lcp_store_consulted_with_session_id or native_mtp_lcp_warm_path_uses_restored_cache or native_mtp_partial_hit_falls_back_when_trim_incomplete or native_mtp_no_session_reports_no_session_id' -q
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_pr_scoped_performance.py -k 'mlx_text_stop or registered_probes_expose_focused_commands' -q
+```
+
+Expected: pass.
+
+Scoped performance result:
+
+```text
+Melix PR Scoped Performance Report
+Status: ok
+Changed files: 3
+Selected probes: 2
+Regressions: 0
+Verification failures: 0
+```
+
+## Task 4: PR Evidence, Full Gate, and Issue Closure
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add docs/plans/2026-07-08-issue-2599-standard-prefix-kv-reuse.md services/mlx-worker-python/worker/runtime/mlx_text_runtime.py services/mlx-worker-python/tests/test_mlx_backend.py
+git commit -m "feat: reuse standard text prefix cache"
+```
+
+Expected: the versioned pre-commit hook runs or reports a justified skip. On this host it should run the full local gate.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin codex/issue-2599-standard-prefix-kv-reuse-20260708
+```
+
+Open a PR with the repository template headings and `Closes #2599`.
+
+- [ ] **Step 3: Monitor PR to terminal state**
+
+Wait for code review, CI, and PR-scoped performance report. Merge only when:
+
+- review threads are resolved,
+- required checks are green,
+- performance report status is `ok` with `Regressions: 0`,
+- branch is current with latest `origin/main`.

--- a/services/mlx-worker-python/tests/test_mlx_backend.py
+++ b/services/mlx-worker-python/tests/test_mlx_backend.py
@@ -2511,6 +2511,7 @@ def test_generate_native_mtp_lcp_store_consulted_with_session_id(
         4,
     )
     assert lcp.mode == "none"
+    _assert_standard_path_session_cache_miss_prefills_and_stores(monkeypatch)
 
 
 def test_generate_native_mtp_lcp_warm_path_uses_restored_cache(
@@ -2662,6 +2663,7 @@ def test_generate_native_mtp_lcp_warm_path_uses_restored_cache(
     assert len(events) > 0
     final = events[-1]
     assert final.cache_hit_mode in ("partial", "exact")
+    _assert_standard_path_warm_partial_hit_replays_suffix_with_restored_cache(monkeypatch)
 
 
 def _build_lcp_backend(monkeypatch, *, store, clone_fn, responses, encode_tokens=None,
@@ -2908,6 +2910,7 @@ def test_generate_native_mtp_partial_hit_falls_back_when_trim_incomplete(
     assert entry is not None
     assert entry._active_refs == 1
     store.release(entry)
+    _assert_standard_path_trim_failure_releases_and_falls_back(monkeypatch)
 
 
 def test_generate_native_mtp_unset_block_size_defaults_not_one(
@@ -2995,3 +2998,407 @@ def test_generate_native_mtp_no_session_reports_no_session_id(
     ))
     assert events[-1].cache_hit_mode == "none"
     assert events[-1].cache_fallback_reason == "no_session_id"
+    _assert_standard_path_no_session_uses_raw_stream(monkeypatch)
+    _assert_standard_path_prompt_cache_bypass_when_unsupported(monkeypatch)
+    _assert_standard_path_tokenizer_without_encode_bypasses_cache(monkeypatch)
+    _assert_standard_path_empty_encoded_prompt_bypasses_cache(monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# generate_tokens standard stream path - PrefixBlockStore integration
+# ---------------------------------------------------------------------------
+
+
+def _build_standard_cache_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    store,
+    encode_tokens: list[int],
+    stream_calls: list[dict],
+    prefill_calls: list[dict],
+    stream_supports_prompt_cache: bool = True,
+    tokenizer_has_encode: bool = True,
+):
+    from worker.runtime import prefix_block_store as _pbs
+
+    monkeypatch.setattr(_pbs, "get_store", lambda *a, **kw: store)
+    monkeypatch.setattr(mlx_text_runtime_module, "_get_prefix_store", lambda *a, **kw: store)
+    monkeypatch.setattr(
+        mlx_text_runtime_module,
+        "_clone_cache_snapshot",
+        lambda cache: [SimpleNamespace(state=[])] if cache is not None else None,
+    )
+    monkeypatch.setattr(mlx_text_runtime_module, "_estimate_cache_bytes", lambda cache: 128)
+
+    def fake_prefill(model, tokens, *, prefill_step_size, stream, restore_cache=None, restore_token_count=0):
+        prefill_calls.append(
+            {
+                "tokens": list(tokens),
+                "restore_cache": restore_cache,
+                "restore_token_count": restore_token_count,
+            }
+        )
+        cache = restore_cache if restore_cache is not None else [SimpleNamespace(state=[])]
+        return cache, [int(tokens[-1])], list(tokens[:-1])
+
+    monkeypatch.setattr(mlx_text_runtime_module, "_prefill_prompt_cache", fake_prefill, raising=False)
+    monkeypatch.setattr(mlx_text_runtime_module, "_native_mtp_prefill_prompt_cache", fake_prefill)
+
+    if tokenizer_has_encode:
+
+        class FakeTokenizer:
+            bos_token = None
+            eos_token = "</s>"
+            eos_token_id = 2
+
+            def encode(self, prompt, add_special_tokens=True):
+                return list(encode_tokens)
+
+    else:
+
+        class FakeTokenizer:
+            bos_token = None
+            eos_token = "</s>"
+            eos_token_id = 2
+
+    def fake_load(model_source: str, **kwargs):
+        return SimpleNamespace(), FakeTokenizer()
+
+    def make_response(prompt):
+        return SimpleNamespace(
+            text="x",
+            raw_text="x",
+            token=101,
+            logprobs=None,
+            prompt_tokens=len(prompt) if isinstance(prompt, list) else len(str(prompt)),
+            generation_tokens=1,
+            prompt_tps=1.0,
+            generation_tps=1.0,
+            peak_memory=0.0,
+            finish_reason="stop",
+        )
+
+    if stream_supports_prompt_cache:
+
+        def fake_stream_generate(model, tokenizer, prompt, *, max_tokens, sampler, prompt_cache=None, **kwargs):
+            stream_calls.append(
+                {
+                    "prompt": list(prompt) if isinstance(prompt, list) else prompt,
+                    "prompt_cache": prompt_cache,
+                    "max_tokens": max_tokens,
+                }
+            )
+            yield make_response(prompt)
+
+    else:
+
+        def fake_stream_generate(model, tokenizer, prompt, *, max_tokens, sampler):
+            stream_calls.append(
+                {
+                    "prompt": list(prompt) if isinstance(prompt, list) else prompt,
+                    "prompt_cache": None,
+                    "max_tokens": max_tokens,
+                }
+            )
+            yield make_response(prompt)
+
+    backend = mlx_text_runtime_module.AutoMLXBackend(
+        load_fn=fake_load,
+        stream_generate_fn=fake_stream_generate,
+        sampler_factory=lambda **kw: "sampler",
+    )
+    model_spec = WorkerModelCatalog.dev_text_model(environment={"MELIX_DEV_TEXT_MODEL_PATH": "x"})
+    loaded = backend.load_model(model_spec)
+    loaded[mlx_text_runtime_module._NATIVE_MTP_TEXT_ACTIVE_FIELD] = False
+    return backend, loaded
+
+
+def _assert_standard_path_session_cache_miss_prefills_and_stores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[10, 20, 30, 40, 50, 60, 70, 80],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={
+                "_melix.session_id": "standard-cold",
+                "_melix.model_id": "test-model",
+                "_melix.model_revision": "v1",
+                "_melix.block_size": "4",
+            },
+        )
+    )
+
+    assert prefill_calls[0]["restore_cache"] is None
+    assert stream_calls[0]["prompt"] == [80]
+    assert stream_calls[0]["prompt_cache"] is not None
+    assert events[-1].cache_hit_mode == "none"
+    assert events[-1].recovered_prefix_tokens == 0
+    assert events[-1].cache_fallback_reason == "no_reusable_prefix"
+    lcp = store.find_lcp([10, 20, 30, 40, 50, 60, 70, 80], "test-model", "v1", 4)
+    assert lcp.mode == "exact"
+    assert lcp.recovered_prefix_tokens == 8
+    assert lcp.entry is not None
+    store.release(lcp.entry)
+
+
+def _assert_standard_path_warm_partial_hit_replays_suffix_with_restored_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    store.put(
+        session_id="standard-warm",
+        token_ids=[10, 20, 30, 40, 50, 60, 70, 80],
+        cache_snapshot=[SimpleNamespace(state=[])],
+        cache_mode="CACHE_MODE_TIERED",
+        model_id="test-model",
+        model_revision="v1",
+        block_size=4,
+        total_bytes=512,
+    )
+    _install_fake_trim(monkeypatch, returns=4)
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[10, 20, 30, 40, 99, 99, 99, 99],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={
+                "_melix.session_id": "standard-warm",
+                "_melix.model_id": "test-model",
+                "_melix.model_revision": "v1",
+                "_melix.block_size": "4",
+            },
+        )
+    )
+
+    assert prefill_calls[0]["restore_cache"] is not None
+    assert prefill_calls[0]["restore_token_count"] == 4
+    assert stream_calls[0]["prompt"] == [99]
+    assert events[-1].cache_hit_mode == "partial"
+    assert events[-1].recovered_prefix_tokens == 4
+
+
+def _assert_standard_path_trim_failure_releases_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    store.put(
+        session_id="trim-fail-standard",
+        token_ids=[10, 20, 30, 40, 50, 60, 70, 80],
+        cache_snapshot=[SimpleNamespace(state=[])],
+        cache_mode="CACHE_MODE_TIERED",
+        model_id="test-model",
+        model_revision="v1",
+        block_size=4,
+        total_bytes=512,
+    )
+    _install_fake_trim(monkeypatch, returns=2)
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[10, 20, 30, 40, 99, 99, 99, 99],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={
+                "_melix.session_id": "trim-fail-standard",
+                "_melix.model_id": "test-model",
+                "_melix.model_revision": "v1",
+                "_melix.block_size": "4",
+            },
+        )
+    )
+
+    assert all(call["restore_cache"] is None for call in prefill_calls)
+    assert events[-1].cache_hit_mode == "none"
+    assert events[-1].cache_fallback_reason == "cache_restore_failed"
+    entry = store.acquire("trim-fail-standard")
+    assert entry is not None
+    assert entry._active_refs == 1
+    store.release(entry)
+
+
+def _assert_standard_path_no_session_uses_raw_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[10, 20, 30, 40],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={"_melix.model_id": "test-model", "_melix.model_revision": "v1"},
+        )
+    )
+
+    assert stream_calls[0]["prompt"] == "hello world"
+    assert stream_calls[0]["prompt_cache"] is None
+    assert prefill_calls == []
+    assert events[-1].cache_hit_mode is None
+    assert events[-1].recovered_prefix_tokens is None
+    assert events[-1].cache_fallback_reason is None
+
+
+def _assert_standard_path_prompt_cache_bypass_when_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[10, 20, 30, 40],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+        stream_supports_prompt_cache=False,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={
+                "_melix.session_id": "standard-unsupported",
+                "_melix.model_id": "test-model",
+                "_melix.model_revision": "v1",
+                "_melix.block_size": "4",
+            },
+        )
+    )
+
+    assert stream_calls[0]["prompt"] == "hello world"
+    assert prefill_calls == []
+    assert events[-1].cache_hit_mode == "none"
+    assert events[-1].cache_fallback_reason == "prompt_cache_unsupported"
+
+
+def _assert_standard_path_tokenizer_without_encode_bypasses_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+        tokenizer_has_encode=False,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={
+                "_melix.session_id": "standard-no-encode",
+                "_melix.model_id": "test-model",
+                "_melix.model_revision": "v1",
+                "_melix.block_size": "4",
+            },
+        )
+    )
+
+    assert stream_calls[0]["prompt"] == "hello world"
+    assert prefill_calls == []
+    assert events[-1].cache_hit_mode == "none"
+    assert events[-1].cache_fallback_reason == "tokenizer_encode_unavailable"
+
+
+def _assert_standard_path_empty_encoded_prompt_bypasses_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker.runtime.prefix_block_store import PrefixBlockStore
+
+    store = PrefixBlockStore()
+    stream_calls: list[dict] = []
+    prefill_calls: list[dict] = []
+    backend, loaded = _build_standard_cache_backend(
+        monkeypatch,
+        store=store,
+        encode_tokens=[],
+        stream_calls=stream_calls,
+        prefill_calls=prefill_calls,
+    )
+
+    events = list(
+        backend.generate_tokens(
+            loaded,
+            "hello world",
+            common_pb2.SamplingConfig(max_output_tokens=2),
+            Event(),
+            execution_ext={
+                "_melix.session_id": "standard-empty-prompt",
+                "_melix.model_id": "test-model",
+                "_melix.model_revision": "v1",
+                "_melix.block_size": "4",
+            },
+        )
+    )
+
+    assert stream_calls[0]["prompt"] == "hello world"
+    assert prefill_calls == []
+    assert events[-1].cache_hit_mode == "none"
+    assert events[-1].cache_fallback_reason == "empty_prompt"

--- a/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/mlx_text_runtime.py
@@ -203,10 +203,64 @@ _NATIVE_MTP_TEXT_ACTIVE_FIELD = "_melix.native_mtp_text_active"
 _NATIVE_MTP_TEXT_BATCH_GENERATOR_FIELD = "_melix.native_mtp_text_batch_generator"
 _NATIVE_MTP_TEXT_BATCH_GENERATOR_CONFIG_FIELD = "_melix.native_mtp_text_batch_generator_config"
 _NATIVE_MTP_TEXT_DETOKENIZER_FIELD = "_melix.native_mtp_text_detokenizer"
+_SESSION_PREFIX_CACHE_DEFAULT_BLOCK_SIZE = 64
+
+
+@dataclass(frozen=True, slots=True)
+class _SessionPrefixCacheContext:
+    session_id: str
+    model_id: str
+    model_revision: str
+    block_size: int
+    cache_memory_budget_bytes: int
+    acceleration_mode: str
+    cache_mode: str
+    force_fallback: bool
 
 
 def _truthy_string(value: str | None) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _positive_ext_int(raw_value: object, *, default: int) -> int:
+    raw = str(raw_value or "").strip()
+    if raw in ("", "0"):
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value < 1:
+        return default
+    return value
+
+
+def _session_prefix_cache_context(
+    execution_ext: dict[str, str] | None,
+) -> _SessionPrefixCacheContext:
+    ext = execution_ext or {}
+    cache_mode = str(ext.get("_melix.cache_mode", "") or "")
+    if not cache_mode or cache_mode in ("0", "CACHE_MODE_UNSPECIFIED"):
+        cache_mode = "CACHE_MODE_TIERED"
+    return _SessionPrefixCacheContext(
+        session_id=str(ext.get("_melix.session_id", "") or ""),
+        model_id=str(ext.get("_melix.model_id", "") or ""),
+        model_revision=str(ext.get("_melix.model_revision", "") or ""),
+        block_size=_positive_ext_int(
+            ext.get("_melix.block_size", ""),
+            default=_SESSION_PREFIX_CACHE_DEFAULT_BLOCK_SIZE,
+        ),
+        cache_memory_budget_bytes=_positive_ext_int(
+            ext.get("_melix.cache_memory_budget_bytes", ""),
+            default=0,
+        ),
+        acceleration_mode=str(ext.get("_melix.acceleration_mode", "") or ""),
+        cache_mode=cache_mode,
+        force_fallback=(
+            _truthy_string(os.environ.get("MELIX_ENABLE_TEST_CACHE_HOOKS"))
+            and str(ext.get("_test.force_cache_fallback", "") or "").lower() in ("1", "true", "yes")
+        ),
+    )
 
 
 def maybe_apply_native_mtp_text_preload_patches(
@@ -302,7 +356,7 @@ def _copyable_native_mtp_text_detokenizer(loaded_model: Any, tokenizer: Any) -> 
     return detokenizer
 
 
-def _native_mtp_prefill_prompt_cache(
+def _prefill_prompt_cache(
     model: Any,
     prompt_tokens: list[int],
     *,
@@ -378,6 +432,9 @@ def _native_mtp_prefill_prompt_cache(
             run_prefill()
 
     return prompt_cache, last_token, prefill_tokens
+
+
+_native_mtp_prefill_prompt_cache = _prefill_prompt_cache
 
 
 def _trim_restored_cache(prompt_cache: Any, trim_tokens: int) -> bool:
@@ -920,6 +977,7 @@ class AutoMLXBackend:
         sampler_factory=None,
     ) -> None:
         self._stream_stop_kwarg = ""
+        self._stream_accepts_prompt_cache = False
         self._sampler_penalty_kwargs: tuple[str, ...] = ()
         if load_fn is not None and stream_generate_fn is not None and sampler_factory is not None:
             self._available = True
@@ -928,6 +986,7 @@ class AutoMLXBackend:
             self._stream_generate_fn = stream_generate_fn
             self._sampler_factory = sampler_factory
             self._stream_stop_kwarg = _first_declared_kwarg(stream_generate_fn, _STREAM_STOP_KWARG_NAMES)
+            self._stream_accepts_prompt_cache = _callable_accepts_kwarg(stream_generate_fn, "prompt_cache")
             self._sampler_penalty_kwargs = _declared_kwargs(sampler_factory, _SAMPLER_PENALTY_KWARG_NAMES)
             self.runtime_name = "mlx-lm"
             return
@@ -960,6 +1019,7 @@ class AutoMLXBackend:
             self._stream_generate_fn = stream_generate
             self._sampler_factory = make_sampler
             self._stream_stop_kwarg = _first_declared_kwarg(stream_generate, _STREAM_STOP_KWARG_NAMES)
+            self._stream_accepts_prompt_cache = _callable_accepts_kwarg(stream_generate, "prompt_cache")
             self._sampler_penalty_kwargs = _declared_kwargs(make_sampler, _SAMPLER_PENALTY_KWARG_NAMES)
 
     def load_model(self, model_spec, *, trust_remote_code: bool = False) -> dict[str, Any]:
@@ -1096,76 +1156,288 @@ class AutoMLXBackend:
             )
             return
 
+        if not execution_ext or not str(execution_ext.get("_melix.session_id", "") or "").strip():
+            cumulative_raw_text = ""
+            for response in self._stream_generate_fn(
+                loaded_model["model"],
+                loaded_model["tokenizer"],
+                prompt,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                **stream_kwargs,
+            ):
+                if cancel_event.is_set():
+                    return
+                text = getattr(response, "text", "")
+                finish_reason = getattr(response, "finish_reason", None)
+                if not text and finish_reason is None:
+                    continue
+                response_raw_text = getattr(response, "raw_text", None)
+                if response_raw_text is None:
+                    cumulative_raw_text += str(text or "")
+                    raw_text = cumulative_raw_text
+                else:
+                    raw_text = response_raw_text
+                yield RuntimeTokenEvent(
+                    text=text,
+                    raw_text=raw_text,
+                    token_ids=_int_tuple(
+                        _first_present(
+                            getattr(response, "token_ids", None),
+                            getattr(response, "tokens", None),
+                            getattr(response, "token", None),
+                            getattr(response, "token_id", None),
+                        )
+                    ),
+                    token_logprobs=_float_tuple(
+                        _first_present(
+                            getattr(response, "token_logprobs", None),
+                            getattr(response, "logprobs", None),
+                            getattr(response, "logprob", None),
+                        )
+                    ),
+                    token_bytes=_bytes_value(
+                        _first_present(
+                            getattr(response, "token_bytes", None),
+                            getattr(response, "byte_fallback_bytes", None),
+                        )
+                    ),
+                    parser_observation=str(getattr(response, "parser_observation", "") or ""),
+                    prompt_tokens=getattr(response, "prompt_tokens", None),
+                    completion_tokens=getattr(response, "generation_tokens", None),
+                    prompt_tps=getattr(response, "prompt_tps", None),
+                    generation_tps=getattr(response, "generation_tps", None),
+                    peak_memory=getattr(response, "peak_memory", None),
+                    finish_reason=finish_reason,
+                    speculative_acceptance_rate=getattr(response, "speculative_acceptance_rate", None),
+                    speculative_rollback_rate=getattr(response, "speculative_rollback_rate", None),
+                    speculative_accepted_tokens=getattr(response, "speculative_accepted_tokens", None),
+                    speculative_rejected_tokens=getattr(response, "speculative_rejected_tokens", None),
+                    speculative_fallback_count=getattr(response, "speculative_fallback_count", None),
+                    speculative_num_draft_tokens=getattr(response, "speculative_num_draft_tokens", None),
+                    speculative_draft_model_configured=getattr(
+                        response,
+                        "speculative_draft_model_configured",
+                        None,
+                    ),
+                    speculative_draft_propose_ms=getattr(response, "speculative_draft_propose_ms", None),
+                    speculative_target_verify_ms=getattr(response, "speculative_target_verify_ms", None),
+                    dflash_enabled=getattr(response, "dflash_enabled", None),
+                    dflash_block_size=getattr(response, "dflash_block_size", None),
+                    dflash_rollback_count=getattr(response, "dflash_rollback_count", None),
+                    dflash_target_hidden_layers=getattr(response, "dflash_target_hidden_layers", None),
+                    cache_hit_mode=None,
+                    recovered_prefix_tokens=None,
+                    cache_fallback_reason=None,
+                )
+            return
+
         cumulative_raw_text = ""
-        for response in self._stream_generate_fn(
-            loaded_model["model"],
-            loaded_model["tokenizer"],
-            prompt,
-            max_tokens=max_tokens,
-            sampler=sampler,
-            **stream_kwargs,
-        ):
-            if cancel_event.is_set():
-                return
-            text = getattr(response, "text", "")
-            finish_reason = getattr(response, "finish_reason", None)
-            if not text and finish_reason is None:
-                continue
-            response_raw_text = getattr(response, "raw_text", None)
-            if response_raw_text is None:
-                cumulative_raw_text += str(text or "")
-                raw_text = cumulative_raw_text
-            else:
-                raw_text = response_raw_text
-            yield RuntimeTokenEvent(
-                text=text,
-                raw_text=raw_text,
-                token_ids=_int_tuple(
-                    _first_present(
-                        getattr(response, "token_ids", None),
-                        getattr(response, "tokens", None),
-                        getattr(response, "token", None),
-                        getattr(response, "token_id", None),
+        stream_prompt: str | list[int] = prompt
+        stream_call_kwargs = dict(stream_kwargs)
+        _standard_prefix_store: Any = None
+        _standard_lcp_entry_to_release: Any = None
+        _standard_cache_hit_mode: str | None = None
+        _standard_recovered_prefix_tokens: int | None = None
+        _standard_cache_fallback_reason: str | None = None
+
+        try:
+            _execution_ext = execution_ext or {}
+            _session_id = str(_execution_ext.get("_melix.session_id", "") or "").strip()
+            if _session_id and not self._stream_accepts_prompt_cache:
+                _standard_cache_hit_mode = "none"
+                _standard_recovered_prefix_tokens = 0
+                _standard_cache_fallback_reason = "prompt_cache_unsupported"
+            elif _session_id:
+                _cache_context = _session_prefix_cache_context(_execution_ext)
+                _tokenizer = loaded_model["tokenizer"]
+                if not hasattr(_tokenizer, "encode"):
+                    _standard_cache_hit_mode = "none"
+                    _standard_recovered_prefix_tokens = 0
+                    _standard_cache_fallback_reason = "tokenizer_encode_unavailable"
+                else:
+                    add_special_tokens = getattr(_tokenizer, "bos_token", None) is None or not prompt.startswith(
+                        str(getattr(_tokenizer, "bos_token", "") or "")
                     )
-                ),
-                token_logprobs=_float_tuple(
-                    _first_present(
-                        getattr(response, "token_logprobs", None),
-                        getattr(response, "logprobs", None),
-                        getattr(response, "logprob", None),
-                    )
-                ),
-                token_bytes=_bytes_value(
-                    _first_present(
-                        getattr(response, "token_bytes", None),
-                        getattr(response, "byte_fallback_bytes", None),
-                    )
-                ),
-                parser_observation=str(getattr(response, "parser_observation", "") or ""),
-                prompt_tokens=getattr(response, "prompt_tokens", None),
-                completion_tokens=getattr(response, "generation_tokens", None),
-                prompt_tps=getattr(response, "prompt_tps", None),
-                generation_tps=getattr(response, "generation_tps", None),
-                peak_memory=getattr(response, "peak_memory", None),
-                finish_reason=finish_reason,
-                speculative_acceptance_rate=getattr(response, "speculative_acceptance_rate", None),
-                speculative_rollback_rate=getattr(response, "speculative_rollback_rate", None),
-                speculative_accepted_tokens=getattr(response, "speculative_accepted_tokens", None),
-                speculative_rejected_tokens=getattr(response, "speculative_rejected_tokens", None),
-                speculative_fallback_count=getattr(response, "speculative_fallback_count", None),
-                speculative_num_draft_tokens=getattr(response, "speculative_num_draft_tokens", None),
-                speculative_draft_model_configured=getattr(
-                    response,
-                    "speculative_draft_model_configured",
-                    None,
-                ),
-                speculative_draft_propose_ms=getattr(response, "speculative_draft_propose_ms", None),
-                speculative_target_verify_ms=getattr(response, "speculative_target_verify_ms", None),
-                dflash_enabled=getattr(response, "dflash_enabled", None),
-                dflash_block_size=getattr(response, "dflash_block_size", None),
-                dflash_rollback_count=getattr(response, "dflash_rollback_count", None),
-                dflash_target_hidden_layers=getattr(response, "dflash_target_hidden_layers", None),
-            )
+                    prompt_tokens = list(_tokenizer.encode(prompt, add_special_tokens=add_special_tokens))
+                    if prompt_tokens:
+                        _standard_prefix_store = _get_prefix_store()
+                        _lcp = _standard_prefix_store.find_lcp(
+                            prompt_tokens,
+                            _cache_context.model_id,
+                            _cache_context.model_revision,
+                            _cache_context.block_size,
+                            acceleration_mode=_cache_context.acceleration_mode,
+                            force_fallback=_cache_context.force_fallback,
+                        )
+                        _standard_lcp_entry_to_release = _lcp.entry if _lcp is not None else None
+                        _use_lcp = (
+                            _lcp is not None
+                            and _lcp.mode != "none"
+                            and _lcp.entry is not None
+                            and _lcp.entry.cache_snapshot is not None
+                        )
+                        _restore_failed = False
+                        _restored = None
+                        if _use_lcp:
+                            assert _lcp is not None and _lcp.entry is not None
+                            _restored = _clone_cache_snapshot(_lcp.entry.cache_snapshot)
+                            _trim_tokens = len(_lcp.entry.token_ids) - _lcp.recovered_prefix_tokens
+                            _trim_ok = True
+                            if _restored is not None and _trim_tokens > 0:
+                                _trim_ok = _trim_restored_cache(_restored, _trim_tokens)
+                            if _restored is None or not _trim_ok:
+                                _restore_failed = True
+                                _use_lcp = False
+                                _restored = None
+                                _entry = _standard_lcp_entry_to_release
+                                _standard_lcp_entry_to_release = None
+                                if _entry is not None:
+                                    _standard_prefix_store.release(_entry)
+
+                        if _use_lcp:
+                            prompt_cache, last_token, _cached_tokens = _prefill_prompt_cache(
+                                loaded_model["model"],
+                                prompt_tokens,
+                                prefill_step_size=_native_mtp_text_prefill_step_size(),
+                                stream=None,
+                                restore_cache=_restored,
+                                restore_token_count=_lcp.recovered_prefix_tokens,
+                            )
+                            _standard_cache_hit_mode = _lcp.mode
+                            _standard_recovered_prefix_tokens = _lcp.recovered_prefix_tokens
+                            _standard_cache_fallback_reason = _lcp.fallback_reason
+                        else:
+                            prompt_cache, last_token, _cached_tokens = _prefill_prompt_cache(
+                                loaded_model["model"],
+                                prompt_tokens,
+                                prefill_step_size=_native_mtp_text_prefill_step_size(),
+                                stream=None,
+                            )
+                            _standard_cache_hit_mode = "none"
+                            _standard_recovered_prefix_tokens = 0
+                            if _restore_failed:
+                                _standard_cache_fallback_reason = "cache_restore_failed"
+                            elif _lcp is not None:
+                                _standard_cache_fallback_reason = _lcp.fallback_reason
+                            else:
+                                _standard_cache_fallback_reason = "no_reusable_prefix"
+
+                        _snapshot = _clone_cache_snapshot(prompt_cache)
+                        if _snapshot is not None:
+                            _snapshot_bytes = _estimate_cache_bytes(prompt_cache)
+                            if (
+                                _cache_context.cache_memory_budget_bytes <= 0
+                                or _snapshot_bytes <= _cache_context.cache_memory_budget_bytes
+                            ):
+                                _standard_prefix_store.put(
+                                    session_id=_cache_context.session_id,
+                                    token_ids=list(prompt_tokens),
+                                    cache_snapshot=_snapshot,
+                                    cache_mode=_cache_context.cache_mode,
+                                    model_id=_cache_context.model_id,
+                                    model_revision=_cache_context.model_revision,
+                                    block_size=_cache_context.block_size,
+                                    total_bytes=_snapshot_bytes,
+                                    acceleration_mode=_cache_context.acceleration_mode,
+                                )
+
+                        stream_prompt = last_token
+                        stream_call_kwargs["prompt_cache"] = prompt_cache
+                    else:
+                        _standard_cache_hit_mode = "none"
+                        _standard_recovered_prefix_tokens = 0
+                        _standard_cache_fallback_reason = "empty_prompt"
+
+            for response in self._stream_generate_fn(
+                loaded_model["model"],
+                loaded_model["tokenizer"],
+                stream_prompt,
+                max_tokens=max_tokens,
+                sampler=sampler,
+                **stream_call_kwargs,
+            ):
+                if cancel_event.is_set():
+                    return
+                text = getattr(response, "text", "")
+                finish_reason = getattr(response, "finish_reason", None)
+                if not text and finish_reason is None:
+                    continue
+                response_raw_text = getattr(response, "raw_text", None)
+                if response_raw_text is None:
+                    cumulative_raw_text += str(text or "")
+                    raw_text = cumulative_raw_text
+                else:
+                    raw_text = response_raw_text
+                if finish_reason is not None:
+                    _event_cache_hit_mode = _standard_cache_hit_mode
+                    _event_recovered_prefix_tokens = _standard_recovered_prefix_tokens
+                    _event_cache_fallback_reason = _standard_cache_fallback_reason
+                else:
+                    _event_cache_hit_mode = None
+                    _event_recovered_prefix_tokens = None
+                    _event_cache_fallback_reason = None
+                yield RuntimeTokenEvent(
+                    text=text,
+                    raw_text=raw_text,
+                    token_ids=_int_tuple(
+                        _first_present(
+                            getattr(response, "token_ids", None),
+                            getattr(response, "tokens", None),
+                            getattr(response, "token", None),
+                            getattr(response, "token_id", None),
+                        )
+                    ),
+                    token_logprobs=_float_tuple(
+                        _first_present(
+                            getattr(response, "token_logprobs", None),
+                            getattr(response, "logprobs", None),
+                            getattr(response, "logprob", None),
+                        )
+                    ),
+                    token_bytes=_bytes_value(
+                        _first_present(
+                            getattr(response, "token_bytes", None),
+                            getattr(response, "byte_fallback_bytes", None),
+                        )
+                    ),
+                    parser_observation=str(getattr(response, "parser_observation", "") or ""),
+                    prompt_tokens=getattr(response, "prompt_tokens", None),
+                    completion_tokens=getattr(response, "generation_tokens", None),
+                    prompt_tps=getattr(response, "prompt_tps", None),
+                    generation_tps=getattr(response, "generation_tps", None),
+                    peak_memory=getattr(response, "peak_memory", None),
+                    finish_reason=finish_reason,
+                    speculative_acceptance_rate=getattr(response, "speculative_acceptance_rate", None),
+                    speculative_rollback_rate=getattr(response, "speculative_rollback_rate", None),
+                    speculative_accepted_tokens=getattr(response, "speculative_accepted_tokens", None),
+                    speculative_rejected_tokens=getattr(response, "speculative_rejected_tokens", None),
+                    speculative_fallback_count=getattr(response, "speculative_fallback_count", None),
+                    speculative_num_draft_tokens=getattr(response, "speculative_num_draft_tokens", None),
+                    speculative_draft_model_configured=getattr(
+                        response,
+                        "speculative_draft_model_configured",
+                        None,
+                    ),
+                    speculative_draft_propose_ms=getattr(response, "speculative_draft_propose_ms", None),
+                    speculative_target_verify_ms=getattr(response, "speculative_target_verify_ms", None),
+                    dflash_enabled=getattr(response, "dflash_enabled", None),
+                    dflash_block_size=getattr(response, "dflash_block_size", None),
+                    dflash_rollback_count=getattr(response, "dflash_rollback_count", None),
+                    dflash_target_hidden_layers=getattr(response, "dflash_target_hidden_layers", None),
+                    cache_hit_mode=_event_cache_hit_mode,
+                    recovered_prefix_tokens=_event_recovered_prefix_tokens,
+                    cache_fallback_reason=_event_cache_fallback_reason,
+                )
+        finally:
+            if _standard_lcp_entry_to_release is not None and _standard_prefix_store is not None:
+                try:
+                    _standard_prefix_store.release(_standard_lcp_entry_to_release)
+                except Exception:
+                    pass
+                _standard_lcp_entry_to_release = None
+            if _standard_prefix_store is not None:
+                _standard_prefix_store.flush_deferred_clear()
 
     def _generate_native_mtp_batch_tokens(
         self,
@@ -1215,57 +1487,18 @@ class AutoMLXBackend:
         if callable(reset):
             reset()
 
-        _ext = execution_ext or {}
-        _session_id = str(_ext.get("_melix.session_id", "") or "")
-        _model_id = str(_ext.get("_melix.model_id", "") or "")
-        _model_revision = str(_ext.get("_melix.model_revision", "") or "")
-        _DEFAULT_BLOCK_SIZE = 64
-        # An unset proto field arrives as "0"; treat "0"/"" as "use the default"
-        # rather than letting max(1, int("0")) collapse to a degenerate 1-token block.
-        _raw_block_size = str(_ext.get("_melix.block_size", "") or "").strip()
-        if _raw_block_size in ("", "0"):
-            _block_size = _DEFAULT_BLOCK_SIZE
-        else:
-            try:
-                _block_size = int(_raw_block_size)
-            except (ValueError, TypeError):
-                _block_size = _DEFAULT_BLOCK_SIZE
-            if _block_size < 1:
-                _block_size = _DEFAULT_BLOCK_SIZE
-        _raw_cache_memory_budget = str(_ext.get("_melix.cache_memory_budget_bytes", "") or "").strip()
-        if _raw_cache_memory_budget in ("", "0"):
-            _cache_memory_budget_bytes = 0
-        else:
-            try:
-                _cache_memory_budget_bytes = int(_raw_cache_memory_budget)
-            except (ValueError, TypeError):
-                _cache_memory_budget_bytes = 0
-            if _cache_memory_budget_bytes < 1:
-                _cache_memory_budget_bytes = 0
-        _acceleration_mode = str(_ext.get("_melix.acceleration_mode", "") or "")
-        # Cache mode flows from the request; unspecified ("", "0") stores as a
-        # standard tiered cache. A rotating value is preserved so find_lcp's
-        # rotating-exclusion gate can reject the stored entry on the next turn.
-        _cache_mode = str(_ext.get("_melix.cache_mode", "") or "")
-        if not _cache_mode or _cache_mode in ("0", "CACHE_MODE_UNSPECIFIED"):
-            _cache_mode = "CACHE_MODE_TIERED"
-        # Debug-only fallback hook: never honored from a live request unless the
-        # operator has explicitly enabled test cache hooks for the process.
-        _force_fallback = (
-            _truthy_string(os.environ.get("MELIX_ENABLE_TEST_CACHE_HOOKS"))
-            and _ext.get("_test.force_cache_fallback", "").lower() in ("1", "true", "yes")
-        )
+        _cache_context = _session_prefix_cache_context(execution_ext)
         _prefix_store = _get_prefix_store()
 
         _lcp: _LCPResult | None = None
-        if _session_id:
+        if _cache_context.session_id:
             _lcp = _prefix_store.find_lcp(
                 prompt_tokens,
-                _model_id,
-                _model_revision,
-                _block_size,
-                acceleration_mode=_acceleration_mode,
-                force_fallback=_force_fallback,
+                _cache_context.model_id,
+                _cache_context.model_revision,
+                _cache_context.block_size,
+                acceleration_mode=_cache_context.acceleration_mode,
+                force_fallback=_cache_context.force_fallback,
             )
 
         # find_lcp may have acquired an active ref on the matched entry; track it
@@ -1343,23 +1576,26 @@ class AutoMLXBackend:
 
             prefill_ms = (time.perf_counter() - prefill_started_at) * 1000.0
 
-            if _session_id:
+            if _cache_context.session_id:
                 # Always update store with the full prompt_tokens so multi-turn
                 # conversations accumulate context even after an LCP warm hit.
                 _snapshot = _clone_cache_snapshot(prompt_cache)
                 if _snapshot is not None:
                     _snapshot_bytes = _estimate_cache_bytes(prompt_cache)
-                    if _cache_memory_budget_bytes <= 0 or _snapshot_bytes <= _cache_memory_budget_bytes:
+                    if (
+                        _cache_context.cache_memory_budget_bytes <= 0
+                        or _snapshot_bytes <= _cache_context.cache_memory_budget_bytes
+                    ):
                         _prefix_store.put(
-                            session_id=_session_id,
+                            session_id=_cache_context.session_id,
                             token_ids=list(prompt_tokens),
                             cache_snapshot=_snapshot,
-                            cache_mode=_cache_mode,
-                            model_id=_model_id,
-                            model_revision=_model_revision,
-                            block_size=_block_size,
+                            cache_mode=_cache_context.cache_mode,
+                            model_id=_cache_context.model_id,
+                            model_revision=_cache_context.model_revision,
+                            block_size=_cache_context.block_size,
                             total_bytes=_snapshot_bytes,
-                            acceleration_mode=_acceleration_mode,
+                            acceleration_mode=_cache_context.acceleration_mode,
                         )
 
             batch_insert_started_at = time.perf_counter()


### PR DESCRIPTION
## Summary
- Route standard MLX text generation requests with `_melix.session_id` through the existing session prefix-block cache path.
- Share prefix-cache option parsing and prompt-cache prefill helpers between standard generation and native MTP.
- Add focused regression coverage for cold, warm partial-hit, unsupported, tokenizer-missing, empty-prompt, trim-failure, and no-session paths.

Closes #2599.

## Plan or Spec
- `docs/plans/2026-07-08-issue-2599-standard-prefix-kv-reuse.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py::test_generate_native_mtp_lcp_store_consulted_with_session_id services/mlx-worker-python/tests/test_mlx_backend.py::test_generate_native_mtp_lcp_warm_path_uses_restored_cache -q
# passed: 2 passed, 2 warnings

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_prefix_block_store.py services/mlx-worker-python/tests/test_work_saved_cache_counters.py -q
# passed: 119 passed, 2 warnings

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_prefix_block_store.py services/mlx-worker-python/tests/test_work_saved_cache_counters.py --cov=services/mlx-worker-python/worker/runtime/mlx_text_runtime.py --cov=services/mlx-worker-python/tests/test_mlx_backend.py --cov-report=term-missing --cov-fail-under=95 -q
# passed: 119 passed, 2 warnings; total coverage 96.54%

git diff --check && git diff origin/main...HEAD --check
# passed

make swift-test
# passed via pre-commit hook; elapsed 190.4s

make py-test
# passed via pre-commit hook; 4777 passed, 14 skipped, 2 warnings in 162.16s

make integration-test
# passed via pre-commit hook; 123 passed, 1 skipped in 413.28s
```

## Coverage and Metrics
- Changed-scope coverage: 96.54% total across `worker/runtime/mlx_text_runtime.py` and `tests/test_mlx_backend.py`.
- Pre-commit scoped performance report: `.runtime/pre-commit-performance/20260708-115217-70f901ce/report/report.md`.
- Scoped performance status: `ok`; changed files: 3; selected probes: 2; regressions: 0; verification failures: 0.
- `mlx-text-stop-kwarg-signature-cache`: coverage pass 96.0%; elapsed +2.12% neutral; inspect signature calls neutral; stream signature calls neutral.
- `mlx-text-stop-filter-prefix-cache`: coverage pass 96.0%; elapsed -1.40% neutral; peak bytes neutral; prefix computations neutral.
- Observability mode: `minimal`; no new runtime observability plane or debug artifact is introduced.
- Probe overhead: N/A: this change reuses existing PR-scoped performance probes and does not add a new probe or observability hook.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
