### PR TITLE
perf: elide default media usage mapping

### DIFF
--- a/docs/plans/2026-07-08-engine-media-usage-default-elision.md
+++ b/docs/plans/2026-07-08-engine-media-usage-default-elision.md
@@ -1,0 +1,28 @@
+# Engine media usage default elision performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the standard text `EngineCore.generate()` finalization path in `services/mlx-worker-python/worker/engine/engine_core.py`.
+
+The current no-usage path already avoids prompt-token fallback work, but it still builds a zero-valued media-feature usage mapping before request finalization. This slice keeps response metrics identical while deferring media-feature usage mapping construction until usage reporting actually needs a runtime media probe snapshot.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/engine_core.py`
+- `services/mlx-worker-python/tests/test_generate_stream.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/engine_generate_usage_token_probe.py`
+
+## Implementation plan
+
+1. Extend the existing no-usage regression test so it proves `_media_feature_usage_from_probe()` is not called for `return_usage=False` text generation.
+2. Replace eager zero media-usage mapping construction with a `None` sentinel in `EngineCore.generate()`.
+3. Build the `TextFinalizationUsage` object without media keyword expansion when no media usage was collected, preserving zero-valued finalization metrics through dataclass defaults.
+4. Run the registered focused test command, changed-scope coverage command, and registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate for the registered probe report.
+
+## Validation boundary
+
+This slice changes Python worker code only. Linux local validation covers focused Python tests, changed-scope coverage, and the registered performance probe. No Swift/macOS runtime effect is claimed for this slice.

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -671,21 +671,35 @@ def test_generate_without_usage_skips_prompt_token_count_fallback(monkeypatch) -
     inference_service, model_handle = build_usage_counting_services(runtime)
 
     summary_calls = 0
+    media_usage_calls = 0
     original_summary = EngineCore._media_admission_summary
+    original_media_usage = engine_core_module._media_feature_usage_from_probe
 
     def counted_media_summary(messages):
         nonlocal summary_calls
         summary_calls += 1
         return original_summary(messages)
 
+    def counted_media_usage(probe):
+        nonlocal media_usage_calls
+        media_usage_calls += 1
+        return original_media_usage(probe)
+
     monkeypatch.setattr(EngineCore, "_media_admission_summary", staticmethod(counted_media_summary))
+    monkeypatch.setattr(engine_core_module, "_media_feature_usage_from_probe", counted_media_usage)
 
     events = list(inference_service.Generate(generate_usage_request(model_handle, return_usage=False), context=None))
-    rejected_events = list(inference_service.Generate(media_rejection_request(model_handle), context=None))
 
     assert [event.token_delta.text for event in events if event.HasField("token_delta")] == ["counted"]
     assert not any(event.HasField("usage_delta") for event in events)
     assert runtime.prompt_token_count_calls == 0
+    assert media_usage_calls == 0
+
+    usage_events = list(inference_service.Generate(generate_usage_request(model_handle, return_usage=True), context=None))
+    rejected_events = list(inference_service.Generate(media_rejection_request(model_handle), context=None))
+
+    assert any(event.HasField("usage_delta") for event in usage_events)
+    assert media_usage_calls == 1
     assert summary_calls == 1
     assert len(rejected_events) == 1
     assert rejected_events[0].HasField("error")

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -372,10 +372,10 @@ class EngineCore:
         prompt_tokens_default: int | None = None
         track_usage = bool(request.return_usage)
         completion_token_count = 0
-        finalized_prompt_tokens = 0
-        finalized_completion_tokens = 0
-        finalized_cached_prompt_tokens = 0
-        finalized_media_usage = _media_feature_usage_from_probe(None)
+        finalized_prompt_tokens: int = 0
+        finalized_completion_tokens: int = 0
+        finalized_cached_prompt_tokens: int = 0
+        finalized_media_usage: dict[str, int] | None = None
         usage_trailer_emitted = False
         last_token_event: RuntimeTokenEvent | None = None
         last_finish_reason = ""
@@ -600,7 +600,7 @@ class EngineCore:
                     prompt_tokens = int(last_token_event.prompt_tokens)
                 else:
                     if prompt_tokens_default is None:
-                        prompt_tokens_default = (
+                        prompt_tokens_default = int(
                             runtime.prompt_token_count(prompt)
                             if hasattr(runtime, "prompt_token_count")
                             else _whitespace_token_count(prompt)
@@ -709,17 +709,26 @@ class EngineCore:
                 parser_metrics["token_route_receipt_json"] = token_route_receipt_json
                 parser_metrics["allowed_tools_receipt_json"] = allowed_tools_receipt_json
             _apply_prompt_context_receipt_metrics(parser_metrics, execution_ext)
+            if finalized_media_usage:
+                finalization_usage = TextFinalizationUsage(
+                    prompt_tokens=finalized_prompt_tokens,
+                    completion_tokens=finalized_completion_tokens,
+                    cached_prompt_tokens=finalized_cached_prompt_tokens,
+                    **finalized_media_usage,
+                )
+            else:
+                finalization_usage = TextFinalizationUsage(
+                    prompt_tokens=finalized_prompt_tokens,
+                    completion_tokens=finalized_completion_tokens,
+                    cached_prompt_tokens=finalized_cached_prompt_tokens,
+                )
+
             finalization_receipt = finalize_text_response(
                 response_id=request_id,
                 created=created,
                 stream_mode=bool(request.stream),
                 finish_reason=finish_reason,
-                usage=TextFinalizationUsage(
-                    prompt_tokens=finalized_prompt_tokens,
-                    completion_tokens=finalized_completion_tokens,
-                    cached_prompt_tokens=finalized_cached_prompt_tokens,
-                    **finalized_media_usage,
-                ),
+                usage=finalization_usage,
                 usage_trailer_emitted=usage_trailer_emitted,
                 reasoning_text=assembled.reasoning_text,
                 tool_call_count=assembled.tool_call_count,


### PR DESCRIPTION
## Summary
- Defer zero-valued media-feature usage mapping construction in `EngineCore.generate()` until usage reporting actually collects a media probe snapshot.
- Extend the no-usage generate regression test to prove `return_usage=False` avoids both prompt-token fallback and media-usage helper work while preserving the usage path.
- Add the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-08-engine-media-usage-default-elision.md`
- Registered probe: `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_without_usage_skips_prompt_token_count_fallback
# Before implementation: failed as expected, media_usage_calls was 1 for return_usage=False.
# After implementation: 1 passed in 0.56s

python3 - <<'PY'
import json, subprocess
p=json.load(open('infra/perf/pr_scoped_probes.json'))
for key in ('test_command','coverage_command'):
    cmd=next(pr[key] for pr in p if pr['id']=='engine-generate-usage-token-elision')
    rc=subprocess.run(cmd, shell=True).returncode
    if rc:
        raise SystemExit(rc)
PY
# test_command: 25 passed in 0.55s
# coverage_command: 25 passed in 1.18s; TOTAL 19 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# before: {"elapsed_ms_mean": 33.38939439272508, "fallback_elapsed_ms_mean": 143.34525120211765, ...}
# after:  {"elapsed_ms_mean": 31.96953599108383, "fallback_elapsed_ms_mean": 131.23333278344944, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 19 0 100%` from the registered `engine-generate-usage-token-elision` coverage command.
- Local Linux registered probe (`scripts/engine_generate_usage_token_probe.py`):
  - `elapsed_ms_mean`: 33.3894 ms -> 31.9695 ms (`-1.4199 ms`, ~4.25% faster)
  - `fallback_elapsed_ms_mean`: 143.3453 ms -> 131.2333 ms (`-12.0119 ms`, ~8.38% faster)
  - `prompt_token_count_calls_per_request`: 0.0 -> 0.0
  - `request_state_append_calls_per_request`: 0.0 -> 0.0
- CI PR-scoped performance report is required before merge and remains the authoritative registered probe gate.

## Known Gaps
- No Swift/macOS runtime effect is claimed; this is a Python worker slice validated locally on Linux plus CI.
- Performance probe timing is synthetic and may vary; merge should wait for the registered PR-scoped performance workflow and green checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
