### PR TITLE
perf(tool-registry): cache always-only selection metrics

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -164,6 +164,26 @@ Expected effect:
 - leave non-empty OpenAI tool payload construction, registry selection,
   schema serialization, and protobuf config handling unchanged.
 
+## Follow-up Slice: Always-only Selection Metrics Cache
+
+The 2026-07-08 always-only follow-up keeps agentic tool selection receipts and
+selected registry identity unchanged, but reuses precomputed full-catalog metrics
+and dropped-tool counts when the selection runs against the built-in agentic tool
+catalog. Custom registries still compute their own metrics at call time. This
+narrow slice targets the registered selector probe's `always_only_*` and
+`whitespace_turn_*` workloads, which repeatedly return the always-only fallback
+receipt.
+
+Expected effect:
+
+- reduce `tool-registry-select-name-index-cache`
+  `always_only_planning_elapsed_ms_mean` and
+  `whitespace_turn_planning_elapsed_ms_mean`;
+- preserve fresh receipt payloads, selected registry identity, selected schema
+  bytes, full schema bytes, and custom-registry behavior;
+- leave registry selection, OpenAI schema generation, and protobuf config
+  materialization unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -13,6 +13,7 @@ from worker.runtime.tool_registry import (
     ToolDescriptor,
     ToolRegistry,
     ToolRegistryError,
+    ToolRegistryMetrics,
     ToolSelectionInput,
     built_in_tool_config,
     built_in_tool_registry,
@@ -963,6 +964,30 @@ def test_agentic_tool_selection_always_only_reuses_cached_registry(
 
     assert result.registry is tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
     assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selected_schema_bytes"] == (
+        tool_registry_module._ALWAYS_ONLY_TOOL_METRICS.schema_bytes
+    )
+
+
+def test_agentic_tool_selection_always_only_reuses_cached_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_metrics(self: ToolRegistry) -> ToolRegistryMetrics:
+        raise AssertionError(  # pragma: no cover
+            f"always-only selection should reuse cached metrics for {self!r}"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "metrics", fail_metrics)
+
+    result = select_agentic_tools_for_turn(ToolSelectionInput(max_selected_tools=1))
+
+    assert result.registry is tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
+    assert result.receipt["dropped_tool_count"] == (
+        tool_registry_module._ALWAYS_ONLY_DROPPED_TOOL_COUNT
+    )
+    assert result.receipt["full_schema_bytes"] == (
+        tool_registry_module._AGENTIC_TOOL_CATALOG_METRICS.schema_bytes
+    )
     assert result.receipt["selected_schema_bytes"] == (
         tool_registry_module._ALWAYS_ONLY_TOOL_METRICS.schema_bytes
     )

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -676,11 +676,14 @@ def _build_always_only_tool_selection_result(
     selected_name = "local_compute"
     if registry is _AGENTIC_TOOL_CATALOG_REGISTRY:
         selected_registry = _ALWAYS_ONLY_TOOL_REGISTRY
+        registry_metrics = _AGENTIC_TOOL_CATALOG_METRICS
         selected_metrics = _ALWAYS_ONLY_TOOL_METRICS
+        dropped_tool_count = _ALWAYS_ONLY_DROPPED_TOOL_COUNT
     else:
         selected_registry = registry.select((selected_name,))
+        registry_metrics = registry.metrics()
         selected_metrics = selected_registry.metrics()
-    registry_metrics = registry.metrics()
+        dropped_tool_count = max(0, registry_metrics.tool_count - selected_metrics.tool_count)
     return ToolSelectionResult(
         registry=selected_registry,
         receipt={
@@ -690,9 +693,7 @@ def _build_always_only_tool_selection_result(
             "vector_available": selection_input.vector_available,
             "fallback_reason": "no_keyword_match",
             "selected_tools": [{"tool_id": selected_name, "source": "always"}],
-            "dropped_tool_count": max(
-                0, registry_metrics.tool_count - selected_metrics.tool_count
-            ),
+            "dropped_tool_count": dropped_tool_count,
             "full_schema_bytes": registry_metrics.schema_bytes,
             "selected_schema_bytes": selected_metrics.schema_bytes,
         },
@@ -1060,8 +1061,13 @@ _BUILTIN_AGENTIC_TOOLS = tuple(
     tool for tool in _AGENTIC_TOOL_CATALOG_TOOLS if tool.name in _BUILTIN_TOOL_NAME_SET
 )
 _AGENTIC_TOOL_CATALOG_REGISTRY = ToolRegistry(_AGENTIC_TOOL_CATALOG_TOOLS)
+_AGENTIC_TOOL_CATALOG_METRICS = _AGENTIC_TOOL_CATALOG_REGISTRY.metrics()
 _ALWAYS_ONLY_TOOL_REGISTRY = _AGENTIC_TOOL_CATALOG_REGISTRY.select(("local_compute",))
 _ALWAYS_ONLY_TOOL_METRICS = _ALWAYS_ONLY_TOOL_REGISTRY.metrics()
+_ALWAYS_ONLY_DROPPED_TOOL_COUNT = max(
+    0,
+    _AGENTIC_TOOL_CATALOG_METRICS.tool_count - _ALWAYS_ONLY_TOOL_METRICS.tool_count,
+)
 _BUILTIN_TOOL_CONFIG_REGISTRY = ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
 _BUILTIN_TOOL_CONFIG_NAMES_LIST = list(BUILTIN_AGENTIC_TOOL_NAMES)
 _BUILTIN_TOOL_CONFIG_BYTES = (


### PR DESCRIPTION
## Summary
- Cache built-in full-catalog metrics and always-only dropped-tool counts for the agentic tool selection fallback path.
- Add a regression test proving the built-in always-only fast path no longer calls `ToolRegistry.metrics()` at request time.
- Update the governing tool-registry performance plan with the always-only metrics-cache slice.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` — Follow-up Slice: Always-only Selection Metrics Cache.

## Commands Run
```text
# baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; always_only_planning_elapsed_ms_mean=19.59300118032843; whitespace_turn_planning_elapsed_ms_mean=19.799716991838068

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_always_only_reuses_cached_metrics services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_always_only_reuses_cached_registry services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_always_only_supports_custom_registry
# exit 0; 3 passed in 0.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; always_only_planning_elapsed_ms_mean=18.3919390081428; whitespace_turn_planning_elapsed_ms_mean=19.14039639523253

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 104 passed in 1.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; 104 passed in 0.53s; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/tool_registry_select_perf.json
# exit 0; head verification passed; base/head registered probe completed
```

## Coverage and Metrics
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/tool_registry.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.
- Changed-scope coverage: 100.00% (`TOTAL 14 0 100%`).
- Local Linux registered probe comparison (`scripts/pr_scoped_performance_run.py`):
  - `always_only_planning_elapsed_ms_mean`: base `24.651678395457566` ms → head `18.197566992603242` ms (`-6.454111402854323` ms, `-26.18%`).
  - `whitespace_turn_planning_elapsed_ms_mean`: base `20.253600005526096` ms → head `18.714641802944243` ms (`-1.5389582025818527` ms, `-7.60%`).
  - Overall `elapsed_ms_mean`: base `22.32685099588707` ms → head `22.587814193684608` ms (`+0.26096319779753685` ms, `+1.17%`, within 5% warn threshold).
- Observability mode: `N/A` (no runtime observability changes).
- Probe overhead: registered local probe elapsed about 2.0s base and 1.0s head for the probe command in this run.
- GitHub Actions PR-scoped performance remains the merge gate for the registered CI probe report.

## Known Gaps
- None for the Python slice. CI must still run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
