### PR TITLE
perf(trajectory): fast path seven-item scalar lists

### DIFF
--- a/docs/plans/2026-06-25-trajectory-copy-list-literal.md
+++ b/docs/plans/2026-06-25-trajectory-copy-list-literal.md
@@ -55,3 +55,14 @@ resolving the builtin `type` during every field iteration. Copy isolation,
 empty-value filtering, and scalar forwarding semantics stay unchanged. The
 registered `trajectory-provenance-copy-elision` probe remains the local Linux and
 CI validation gate for the affected path.
+
+## 2026-07-08 follow-up: seven-item scalar list fast path
+
+This follow-up remains limited to `worker.trajectory_provenance._copy_json_list`.
+The registered probe's scalar-list fixture uses the common seven-field token
+metrics shape, so the copier now handles exact seven-item scalar lists with an
+unrolled type guard and direct list literal. Lists with mutable members, including
+seven-item lists, immediately fall back to recursive copying after the unrolled
+check to preserve container isolation without a second scalar scan. The
+registered `trajectory-provenance-copy-elision` probe remains the local Linux and
+CI validation gate for this small Python-only slice.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -733,15 +733,28 @@ def test_copy_json_list_uses_literal_copy_for_scalar_lists(
     assert type(copied) is list
 
 
-def test_copy_json_list_still_copies_nested_mutable_items() -> None:
-    source = ["agentic", {"labels": ["trajectory"]}]
-
+@pytest.mark.parametrize(
+    "source,nested_index",
+    [
+        (["agentic", {"labels": ["trajectory"]}], 1),
+        (["agentic", "trajectory", "quality", 3, True, None, {"score": [0.75]}], 6),
+    ],
+)
+def test_copy_json_list_still_copies_nested_mutable_items(
+    source: list[object],
+    nested_index: int,
+) -> None:
     copied = trajectory_provenance_module._copy_json_list(source)
 
     assert copied == source
     assert copied is not source
-    assert copied[1] is not source[1]
-    assert copied[1]["labels"] is not source[1]["labels"]
+    assert copied[nested_index] is not source[nested_index]
+    key = "labels" if nested_index == 1 else "score"
+    copied_nested = copied[nested_index]
+    source_nested = source[nested_index]
+    assert isinstance(copied_nested, dict)
+    assert isinstance(source_nested, dict)
+    assert copied_nested[key] is not source_nested[key]
 
 
 @pytest.mark.parametrize(

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -57,6 +57,19 @@ def _is_clean_manifest_text(value: Any) -> bool:
 def _copy_json_list(value: list[Any]) -> list[Any]:
     immutable_types = _JSON_IMMUTABLE_TYPE_SET
     value_type = _TYPE
+    if len(value) == 7:
+        item_0, item_1, item_2, item_3, item_4, item_5, item_6 = value
+        if (
+            value_type(item_0) in immutable_types
+            and value_type(item_1) in immutable_types
+            and value_type(item_2) in immutable_types
+            and value_type(item_3) in immutable_types
+            and value_type(item_4) in immutable_types
+            and value_type(item_5) in immutable_types
+            and value_type(item_6) in immutable_types
+        ):
+            return [item_0, item_1, item_2, item_3, item_4, item_5, item_6]
+        return [_copy_trajectory_provenance_value(item) for item in value]
     for item in value:
         if value_type(item) not in immutable_types:
             return [_copy_trajectory_provenance_value(item) for item in value]


### PR DESCRIPTION
## Summary
- Add a seven-item scalar-list fast path in `worker.trajectory_provenance._copy_json_list` using an unrolled scalar type guard and direct list literal copy.
- Return directly to recursive copying when a seven-item list contains mutable payloads, avoiding a redundant second scalar scan while preserving container isolation.
- Extend the nested-list regression test so seven-item lists with mutable payloads still recurse and preserve container isolation.
- Document the 2026-07-08 trajectory provenance follow-up slice.

## Plan or Spec
- `docs/plans/2026-06-25-trajectory-copy-list-literal.md`
- Registered probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline from origin/main before the slice:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
exit 0; scalar_list_elapsed_ms_mean=0.6659528007730842; scalar_list_speedup=1.434395351727675; optimized_elapsed_ms_mean=349.83953500632197

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_copies_flat_scalar_dicts_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
exit 0; 24 passed in 0.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_copies_flat_scalar_dicts_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
exit 0; 21 passed in 0.87s; changed_line_coverage=100.00%; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
exit 0; scalar_list_elapsed_ms_mean=0.6477391929365695; scalar_list_speedup=1.5250165918190375; optimized_elapsed_ms_mean=356.25478019937873

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for the final review-fix hunk in `services/mlx-worker-python/worker/trajectory_provenance.py` (`TOTAL 1 0 100%`); the pre-review slice run covered `TOTAL 4 0 100%`, and CI PR-scoped coverage remains the final full-branch gate.
- Registered local Linux probe (`trajectory-provenance-copy-elision`):
  - `scalar_list_elapsed_ms_mean`: `0.6659528007730842` ms -> `0.6477391929365695` ms (`delta=-0.01821360783651471` ms, about `2.73%` lower).
  - `scalar_list_speedup`: `1.434395351727675` -> `1.5250165918190375`.
  - Full provenance guardrail `optimized_elapsed_ms_mean`: `349.83953500632197` ms -> `356.25478019937873` ms; local sample is noisier and remains below the registered 5% warning threshold.
- Observability mode: `evidence` via existing PR-scoped command-json probe.
- Probe overhead: unchanged; this slice reuses the existing synthetic local/CI probe.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this narrow Python-only slice.
- GitHub Actions PR-scoped performance is required as the final registered probe validation source before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
