### PR TITLE
perf: cache no-keyword tool fallback

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -184,6 +184,32 @@ Expected effect:
 - leave registry selection, OpenAI schema generation, and protobuf config
   materialization unchanged.
 
+## Follow-up Slice: No-keyword Fallback Always-only Cache
+
+The 2026-07-08 no-keyword fallback follow-up keeps agentic tool selection
+receipts unchanged for non-empty user turns that do not match any optional tool
+keyword. When no vector tool ids were supplied, the selector now checks keyword
+matches before allocating the mutable selected-tool accumulators; once the scans
+prove there are no vector or keyword hits, it returns through the same built-in
+always-only cache used by the max-capacity and whitespace fast paths. This avoids
+building fallback selection accumulators, rebuilding the one-tool selection
+registry, and recomputing registry metrics for generic no-keyword fallback turns
+while preserving fresh receipt payloads.
+
+The registered `tool-registry-select-name-index-cache` probe now reports
+`no_keyword_fallback_planning_elapsed_ms_mean` and
+`no_keyword_fallback_selected_schema_bytes_mean` so this fallback path remains a
+PR-scoped performance gate.
+
+Expected effect:
+
+- reduce `tool-registry-select-name-index-cache`
+  `no_keyword_fallback_planning_elapsed_ms_mean`;
+- preserve selected registry identity, selected schema bytes, full schema bytes,
+  and receipt fields for no-keyword fallback turns;
+- leave vector, keyword, whitespace, max-capacity, registry selection, OpenAI
+  schema generation, and protobuf config materialization unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.
@@ -191,7 +217,8 @@ Expected effect:
    least 95% coverage for touched scope.
 3. Run the registered probe command locally before and after the slice and
    compare the relevant registered metric (`schema_payload_elapsed_ms_mean` for
-   schema-payload slices, or `elapsed_ms_mean` for the OpenAI tool payload slice)
-   over repeated samples.
+   schema-payload slices, `elapsed_ms_mean` for the OpenAI tool payload slice,
+   or `no_keyword_fallback_planning_elapsed_ms_mean` for the no-keyword
+   fallback slice) over repeated samples.
 4. Push only if local evidence is neutral-to-improved and rely on the GitHub
    PR-scoped performance workflow as the merge gate.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5093,6 +5093,17 @@
         "direction": "informational"
       },
       {
+        "key": "no_keyword_fallback_planning_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "no_keyword_fallback_selected_schema_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
         "key": "whitespace_turn_planning_elapsed_ms_mean",
         "unit": "ms",
         "direction": "lower_is_better",

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -47,6 +47,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     current_capacity_selected_schema_bytes_samples: list[float] = []
     always_only_planning_elapsed_samples: list[float] = []
     always_only_selected_schema_bytes_samples: list[float] = []
+    no_keyword_fallback_planning_elapsed_samples: list[float] = []
+    no_keyword_fallback_selected_schema_bytes_samples: list[float] = []
     whitespace_turn_planning_elapsed_samples: list[float] = []
     whitespace_turn_selected_schema_bytes_samples: list[float] = []
     checksum = 0
@@ -188,8 +190,30 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         checksum += always_only_schema_bytes
 
-        whitespace_turn_schema_bytes = 0
+        no_keyword_fallback_schema_bytes = 0
         keyword_match_cache_clear = tool_registry_module._keyword_tool_matches.cache_clear
+        no_keyword_fallback_started = time.perf_counter()
+        for _index in range(selector_iterations):
+            keyword_match_cache_clear()
+            selection_result = select_agentic_tools_for_turn(
+                ToolSelectionInput(
+                    current_user_turn="Answer the researcher briefly about cropland.",
+                    vector_available=False,
+                    max_selected_tools=4,
+                )
+            )
+            no_keyword_fallback_schema_bytes += int(
+                selection_result.receipt["selected_schema_bytes"]
+            )
+        no_keyword_fallback_planning_elapsed_samples.append(
+            (time.perf_counter() - no_keyword_fallback_started) * 1000.0
+        )
+        no_keyword_fallback_selected_schema_bytes_samples.append(
+            float(no_keyword_fallback_schema_bytes / selector_iterations)
+        )
+        checksum += no_keyword_fallback_schema_bytes
+
+        whitespace_turn_schema_bytes = 0
         whitespace_turn_started = time.perf_counter()
         for _index in range(selector_iterations):
             keyword_match_cache_clear()
@@ -245,6 +269,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         ),
         "always_only_selected_schema_bytes_mean": statistics.fmean(
             always_only_selected_schema_bytes_samples
+        ),
+        "no_keyword_fallback_planning_elapsed_ms_mean": statistics.fmean(
+            no_keyword_fallback_planning_elapsed_samples
+        ),
+        "no_keyword_fallback_selected_schema_bytes_mean": statistics.fmean(
+            no_keyword_fallback_selected_schema_bytes_samples
         ),
         "whitespace_turn_planning_elapsed_ms_mean": statistics.fmean(
             whitespace_turn_planning_elapsed_samples

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -993,6 +993,74 @@ def test_agentic_tool_selection_always_only_reuses_cached_metrics(
     )
 
 
+def test_agentic_tool_selection_no_keyword_fallback_reuses_always_only_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_select(self: ToolRegistry, names: list[str] | tuple[str, ...]) -> ToolRegistry:
+        raise AssertionError(  # pragma: no cover
+            f"no-keyword fallback should reuse cached registry for {names!r}"
+        )
+
+    def fail_metrics(self: ToolRegistry) -> ToolRegistryMetrics:
+        raise AssertionError(  # pragma: no cover
+            f"no-keyword fallback should reuse cached metrics for {self!r}"
+        )
+
+    monkeypatch.setattr(ToolRegistry, "select", fail_select)
+    monkeypatch.setattr(ToolRegistry, "metrics", fail_metrics)
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer the researcher briefly about cropland.",
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+
+    assert result.registry is tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
+    assert result.receipt == {
+        "schema_version": "melix.agentic_tool_selection.v1",
+        "toolset_version": "melix.agentic_tools.builtin.v1",
+        "selection_mode": "fallback",
+        "vector_available": False,
+        "fallback_reason": "no_keyword_match",
+        "selected_tools": [{"tool_id": "local_compute", "source": "always"}],
+        "dropped_tool_count": tool_registry_module._ALWAYS_ONLY_DROPPED_TOOL_COUNT,
+        "full_schema_bytes": tool_registry_module._AGENTIC_TOOL_CATALOG_METRICS.schema_bytes,
+        "selected_schema_bytes": tool_registry_module._ALWAYS_ONLY_TOOL_METRICS.schema_bytes,
+    }
+
+    context_result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer briefly.",
+            recent_user_turns=("Discuss cropland.",),
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+
+    assert context_result.registry is tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
+    assert context_result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"}
+    ]
+
+    invalid_vector_result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer briefly.",
+            recent_user_turns=("Discuss cropland.",),
+            vector_selected_tool_ids=("unknown_tool",),
+            vector_available=True,
+            max_selected_tools=4,
+        )
+    )
+
+    assert invalid_vector_result.registry is tool_registry_module._ALWAYS_ONLY_TOOL_REGISTRY
+    assert invalid_vector_result.receipt["vector_available"] is True
+    assert invalid_vector_result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"}
+    ]
+
+
 def test_agentic_tool_selection_always_only_supports_custom_registry() -> None:
     registry = ToolRegistry(tool_registry_module.agentic_tool_catalog_registry().tools)
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -579,6 +579,21 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         and (not current_user_turn or current_user_turn.isspace())
     ):
         return _build_always_only_tool_selection_result(registry, selection_input)
+    current_matches: tuple[str, ...] | None = None
+    context_matches: tuple[str, ...] | None = None
+    if not selection_input.vector_selected_tool_ids:
+        current_matches = _keyword_tool_matches(current_user_turn)
+        if not current_matches:
+            if selection_input.recent_user_turns:
+                context_matches = _keyword_tool_matches(
+                    _recent_user_turns_keyword_context(selection_input.recent_user_turns)
+                )
+                if not context_matches:
+                    return _build_always_only_tool_selection_result(
+                        registry, selection_input
+                    )
+            else:
+                return _build_always_only_tool_selection_result(registry, selection_input)
     selected_sources: dict[str, str] = {}
     selected_names: list[str] = []
     selected_tools: list[dict[str, str]] = []
@@ -630,7 +645,8 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             )
 
     if selection_mode != "vector":
-        current_matches = _keyword_tool_matches(selection_input.current_user_turn)
+        if current_matches is None:
+            current_matches = _keyword_tool_matches(selection_input.current_user_turn)
         for tool_name in current_matches:
             if append_selected_tool(
                 selected_names,
@@ -642,9 +658,10 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             ):
                 has_keyword_selection = True
         if selection_input.recent_user_turns and len(selected_names) < max_selected_tools:
-            context_matches = _keyword_tool_matches(
-                _recent_user_turns_keyword_context(selection_input.recent_user_turns)
-            )
+            if context_matches is None:
+                context_matches = _keyword_tool_matches(
+                    _recent_user_turns_keyword_context(selection_input.recent_user_turns)
+                )
             for tool_name in context_matches:
                 if append_selected_tool(
                     selected_names,
@@ -658,6 +675,9 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
         if has_keyword_selection:
             selection_mode = "keyword"
             fallback_reason = "vector_unavailable" if not selection_input.vector_available else "vector_no_match"
+
+    if not has_vector_selection and not has_keyword_selection:
+        return _build_always_only_tool_selection_result(registry, selection_input)
 
     return _build_tool_selection_result(
         registry,


### PR DESCRIPTION
## Summary
- Cache no-keyword agentic tool-selection fallbacks through the existing built-in always-only registry/metrics snapshot.
- Pre-scan keyword matches before allocating selected-tool accumulators when no vector tool ids were supplied.
- Extend the registered `tool-registry-select-name-index-cache` PR-scoped probe with no-keyword fallback metrics.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` (follow-up slice: No-keyword Fallback Always-only Cache)

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_no_keyword_fallback_reuses_always_only_cache
# exit 0: 1 passed in 0.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0: 105 passed in 0.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0: 105 passed; changed-scope TOTAL 43 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id tool-registry-select-name-index-cache --base-repo /root/.hermes/profiles/coder/workspace/repos/melix --head-repo "$PWD" --output /tmp/tool_registry_select_probe_1783542555.json
# exit 0: head verification ok=True, coverage_pct=100.0; base/head probes completed ok=True

Custom same-workload local comparison for the newly registered no-keyword metric against origin/main and HEAD, 7 samples x 8000 iterations each.
# exit 0: base mean 70.535 ms; head mean 62.080 ms
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 43 0 100%`.
- Registered probe: `tool-registry-select-name-index-cache`; affected path already has focused `test_command`, `coverage_command`, and `probe_command` entries. This PR adds `no_keyword_fallback_planning_elapsed_ms_mean` and `no_keyword_fallback_selected_schema_bytes_mean` to the registered metrics.
- Local no-keyword fallback comparison: `base_mean=70.535 ms`, `head_mean=62.080 ms`, `delta=-8.455 ms`, `speedup=1.136x` for 7 samples x 8000 iterations.
- Registered local head probe emitted `no_keyword_fallback_planning_elapsed_ms_mean=59.606 ms` and `no_keyword_fallback_selected_schema_bytes_mean=261.0`.
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a Linux-focused Python performance slice with focused tests, changed-scope coverage, and the registered local probe run.
- No protocol, dependency, or generated artifact changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
