### PR TITLE
Add base-vs-adapter held-out comparison to the LoRA training pipeline

### DIFF
--- a/docs/runbooks/phase-8-lora-adapter-workflow.md
+++ b/docs/runbooks/phase-8-lora-adapter-workflow.md
@@ -282,6 +282,14 @@ Expected training behavior:
   `heldout_test_loss`, `heldout_test_perplexity`, and
   `heldout_test_sample_count` in the adapter manifest, adapter provenance, and
   experiment run record
+- when `heldout_baseline_compare` is truthy alongside a held-out split, Melix
+  also evaluates the plain base model (no adapter) on the same `test.jsonl`
+  and records `heldout_baseline_loss`, `heldout_baseline_perplexity`,
+  `heldout_loss_delta` (baseline minus adapter loss — positive means the
+  adapter improved on the base model), and `heldout_perplexity_ratio` in the
+  held-out receipt, adapter manifest, and experiment run record; a failed
+  baseline pass records `heldout_baseline_status=failed` without disturbing
+  the adapter's own held-out metrics
 - when no held-out split is requested, Melix still writes a skipped held-out
   evaluation receipt with reason `test_split_not_requested`
 - if an `agentic_tool_trace` held-out split is selected but all held-out traces

--- a/services/mlx-worker-python/tests/test_lora_heldout_evaluation_pipeline.py
+++ b/services/mlx-worker-python/tests/test_lora_heldout_evaluation_pipeline.py
@@ -26,6 +26,41 @@ class FailingHeldoutEvaluationRunner(DeterministicLoRARunner):
         raise RuntimeError("held-out metric backend unavailable")
 
 
+class FailingBaselineHeldoutEvaluationRunner(DeterministicLoRARunner):
+    def evaluate_heldout_native(
+        self,
+        request: HeldoutEvaluationRequest,
+    ) -> HeldoutEvaluationResult:
+        if request.adapter_dir is None:
+            raise RuntimeError("baseline metric backend unavailable")
+        return super().evaluate_heldout_native(request)
+
+
+def _heldout_dataset_package(tmp_path: Path, name: str, dataset_id: str) -> Path:
+    sample_lines = [
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": f"question {index}"},
+                    {"role": "assistant", "content": f"answer {index}"},
+                ]
+            }
+        )
+        for index in range(8)
+    ]
+    return _write_dataset_package(
+        tmp_path / name,
+        manifest_payload={
+            "schema_version": "melix.training_dataset_package.v1",
+            "dataset_id": dataset_id,
+            "format": "chat_messages",
+            "sample_count": len(sample_lines),
+            "version": "1",
+        },
+        sample_lines=sample_lines,
+    )
+
+
 def test_lora_training_pipeline_records_completed_heldout_evaluation_receipt(
     tmp_path: Path,
 ) -> None:
@@ -239,6 +274,155 @@ def test_lora_training_pipeline_records_skipped_heldout_evaluation_without_test_
         "perplexity": None,
         "backend": "",
     }
+
+
+def test_lora_training_pipeline_records_heldout_baseline_comparison(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _heldout_dataset_package(
+        tmp_path, "dataset-with-baseline-compare", "melix-heldout-baseline"
+    )
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-heldout-baseline",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "heldout-baseline-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "test_ratio": "0.25",
+            "heldout_baseline_compare": "true",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    receipt = json.loads(
+        Path(manifest["heldout_evaluation_receipt_path"]).read_text(encoding="utf-8")
+    )
+    run_record = json.loads(
+        (tmp_path / "output" / "lora-experiment-run.json").read_text(encoding="utf-8")
+    )
+
+    assert manifest["heldout_evaluation_status"] == "completed"
+    assert manifest["heldout_test_loss"] == pytest.approx(0.29)
+    assert manifest["heldout_baseline_status"] == "completed"
+    assert manifest["heldout_baseline_reason"] == ""
+    assert manifest["heldout_baseline_backend"] == "native"
+    assert manifest["heldout_baseline_loss"] == pytest.approx(0.42)
+    assert manifest["heldout_baseline_perplexity"] == pytest.approx(math.exp(0.42))
+    assert manifest["heldout_loss_delta"] == pytest.approx(0.42 - 0.29)
+    assert manifest["heldout_perplexity_ratio"] == pytest.approx(
+        math.exp(0.42) / math.exp(0.29)
+    )
+    assert receipt["baseline_status"] == "completed"
+    assert receipt["baseline_loss"] == pytest.approx(0.42)
+    assert receipt["loss_delta"] == pytest.approx(0.13)
+    assert run_record["heldout_baseline_loss"] == pytest.approx(0.42)
+    assert run_record["heldout_loss_delta"] == pytest.approx(0.13)
+
+
+def test_lora_training_pipeline_baseline_failure_keeps_adapter_heldout_metrics(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _heldout_dataset_package(
+        tmp_path, "dataset-with-failing-baseline", "melix-heldout-baseline-fails"
+    )
+
+    result = LoRATrainingPipeline(runner=FailingBaselineHeldoutEvaluationRunner()).run(
+        job_id="train-heldout-baseline-fails",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "heldout-baseline-failed-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "test_ratio": "0.25",
+            "heldout_baseline_compare": "true",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    receipt = json.loads(
+        Path(manifest["heldout_evaluation_receipt_path"]).read_text(encoding="utf-8")
+    )
+
+    # The adapter's own held-out metrics survive a failed baseline pass.
+    assert manifest["heldout_evaluation_status"] == "completed"
+    assert manifest["heldout_test_loss"] == pytest.approx(0.29)
+    assert manifest["heldout_baseline_status"] == "failed"
+    assert manifest["heldout_baseline_reason"] == "baseline_evaluation_failed"
+    assert manifest["heldout_baseline_loss"] is None
+    assert manifest["heldout_loss_delta"] is None
+    assert receipt["baseline_status"] == "failed"
+    assert receipt["baseline_error_code"] == "backend_training_failure"
+    assert receipt["baseline_error_message"] == "baseline metric backend unavailable"
+    assert receipt["loss_delta"] is None
+
+
+def test_lora_training_pipeline_baseline_not_requested_keeps_receipt_shape(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _heldout_dataset_package(
+        tmp_path, "dataset-without-baseline-compare", "melix-heldout-no-baseline"
+    )
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-heldout-no-baseline",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "heldout-no-baseline-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "test_ratio": "0.25",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    receipt = json.loads(
+        Path(manifest["heldout_evaluation_receipt_path"]).read_text(encoding="utf-8")
+    )
+
+    assert "baseline_status" not in receipt
+    assert "heldout_baseline_status" not in manifest
+    assert "heldout_loss_delta" not in manifest
+
+
+def test_heldout_baseline_skipped_when_adapter_evaluation_fails(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _heldout_dataset_package(
+        tmp_path, "dataset-adapter-fails-baseline-requested", "melix-heldout-adapter-fails"
+    )
+
+    result = LoRATrainingPipeline(runner=FailingHeldoutEvaluationRunner()).run(
+        job_id="train-heldout-adapter-fails-baseline",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "heldout-adapter-fails-baseline",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "test_ratio": "0.25",
+            "heldout_baseline_compare": "1",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    assert manifest["heldout_evaluation_status"] == "failed"
+    assert manifest["heldout_baseline_status"] == "skipped"
+    assert manifest["heldout_baseline_reason"] == "adapter_evaluation_not_completed"
+    assert manifest["heldout_baseline_loss"] is None
+    assert manifest["heldout_loss_delta"] is None
 
 
 def test_heldout_evaluation_skipped_reason_preserves_empty_after_formatting(

--- a/services/mlx-worker-python/tests/test_lora_heldout_evaluation_pipeline.py
+++ b/services/mlx-worker-python/tests/test_lora_heldout_evaluation_pipeline.py
@@ -321,7 +321,11 @@ def test_lora_training_pipeline_records_heldout_baseline_comparison(
     assert receipt["baseline_loss"] == pytest.approx(0.42)
     assert receipt["loss_delta"] == pytest.approx(0.13)
     assert run_record["heldout_baseline_loss"] == pytest.approx(0.42)
+    assert run_record["heldout_baseline_perplexity"] == pytest.approx(math.exp(0.42))
     assert run_record["heldout_loss_delta"] == pytest.approx(0.13)
+    assert run_record["heldout_perplexity_ratio"] == pytest.approx(
+        math.exp(0.42) / math.exp(0.29)
+    )
 
 
 def test_lora_training_pipeline_baseline_failure_keeps_adapter_heldout_metrics(
@@ -423,6 +427,86 @@ def test_heldout_baseline_skipped_when_adapter_evaluation_fails(
     assert manifest["heldout_baseline_reason"] == "adapter_evaluation_not_completed"
     assert manifest["heldout_baseline_loss"] is None
     assert manifest["heldout_loss_delta"] is None
+
+
+def test_heldout_baseline_requested_without_test_split_reuses_skip_reason(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _write_dataset_package(tmp_path / "dataset-baseline-no-split")
+
+    result = LoRATrainingPipeline(runner=DeterministicLoRARunner()).run(
+        job_id="train-heldout-baseline-no-split",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "heldout-baseline-no-split-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "heldout_baseline_compare": "true",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    # No held-out split: the baseline reason mirrors the receipt's own skip
+    # reason instead of implying the adapter evaluation ran and failed.
+    assert manifest["heldout_evaluation_status"] == "skipped"
+    assert manifest["heldout_baseline_status"] == "skipped"
+    assert manifest["heldout_baseline_reason"] == "test_split_not_requested"
+    assert manifest["heldout_baseline_loss"] is None
+    assert manifest["heldout_loss_delta"] is None
+
+
+class InfinitePerplexityBaselineRunner(DeterministicLoRARunner):
+    def evaluate_heldout_native(
+        self,
+        request: HeldoutEvaluationRequest,
+    ) -> HeldoutEvaluationResult:
+        if request.adapter_dir is None:
+            return HeldoutEvaluationResult(
+                loss=800.0,
+                perplexity=float("inf"),
+                sample_count=request.test_sample_count,
+                execution_backend="native",
+            )
+        return super().evaluate_heldout_native(request)
+
+
+def test_heldout_baseline_non_finite_perplexity_ratio_is_dropped(
+    tmp_path: Path,
+) -> None:
+    dataset_dir = _heldout_dataset_package(
+        tmp_path, "dataset-inf-baseline-perplexity", "melix-heldout-inf-ppl"
+    )
+
+    result = LoRATrainingPipeline(runner=InfinitePerplexityBaselineRunner()).run(
+        job_id="train-heldout-inf-ppl",
+        request_ext={
+            "operation": "train_lora",
+            "adapter_name": "heldout-inf-ppl-adapter",
+            "dataset_uri": str(dataset_dir),
+            "max_steps": "0",
+            "test_ratio": "0.25",
+            "heldout_baseline_compare": "true",
+        },
+        source_model=_text_model(family_id="qwen"),
+        output_dir=tmp_path / "output",
+        jobs_root=tmp_path / "jobs",
+    )
+
+    manifest = result.manifest
+    receipt = json.loads(
+        Path(manifest["heldout_evaluation_receipt_path"]).read_text(encoding="utf-8")
+    )
+
+    assert manifest["heldout_baseline_status"] == "completed"
+    assert manifest["heldout_baseline_loss"] == pytest.approx(800.0)
+    assert manifest["heldout_loss_delta"] == pytest.approx(800.0 - 0.29)
+    # inf / finite would serialize as an Infinity token strict JSON decoders
+    # reject; the non-finite ratio is dropped instead.
+    assert receipt["perplexity_ratio"] is None
+    assert manifest["heldout_perplexity_ratio"] is None
 
 
 def test_heldout_evaluation_skipped_reason_preserves_empty_after_formatting(

--- a/services/mlx-worker-python/worker/model_ops/deterministic_lora_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/deterministic_lora_runner.py
@@ -84,9 +84,12 @@ class DeterministicLoRARunner(MLXLMRunner):
         self,
         request: HeldoutEvaluationRequest,
     ) -> HeldoutEvaluationResult:
+        # Baseline pass (no adapter) reports a deterministically higher loss
+        # so pipeline tests can assert a positive adapter improvement delta.
+        loss = 0.42 if request.adapter_dir is None else 0.29
         return HeldoutEvaluationResult(
-            loss=0.29,
-            perplexity=math.exp(0.29),
+            loss=loss,
+            perplexity=math.exp(loss),
             sample_count=request.test_sample_count,
             execution_backend="native",
         )

--- a/services/mlx-worker-python/worker/model_ops/lora_heldout_evaluation.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_heldout_evaluation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -80,7 +81,10 @@ def evaluate_heldout_if_requested(
             "backend": "",
         }
         if include_baseline:
-            receipt.update(_baseline_not_run_fields("adapter_evaluation_not_completed"))
+            # No held-out split exists, so the adapter pass was never attempted;
+            # reuse the receipt's own skip reason instead of implying the
+            # adapter evaluation ran and failed to finish.
+            receipt.update(_baseline_not_run_fields(str(receipt["reason"])))
         return receipt
 
     heldout_request = HeldoutEvaluationRequest(
@@ -188,6 +192,10 @@ def _baseline_comparison_fields(
         if adapter_result.perplexity and adapter_result.perplexity > 0
         else None
     )
+    # A divergent loss overflows math.exp to inf on either pass; inf/inf is
+    # NaN and inf/finite is inf — neither survives strict JSON serialization.
+    if perplexity_ratio is not None and not math.isfinite(perplexity_ratio):
+        perplexity_ratio = None
     return {
         "baseline_status": "completed",
         "baseline_reason": "",

--- a/services/mlx-worker-python/worker/model_ops/lora_heldout_evaluation.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_heldout_evaluation.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 from packages.protocol.python.worker.v1 import common_pb2
 
 from worker.model_ops.errors import ModelOperationError
-from worker.model_ops.mlx_lm_runner import HeldoutEvaluationRequest, MLXLMRunner
+from worker.model_ops.mlx_lm_runner import (
+    HeldoutEvaluationRequest,
+    HeldoutEvaluationResult,
+    MLXLMRunner,
+)
 from worker.model_ops.training_config import LoRATrainingConfig
 from worker.model_ops.training_dataset import NormalizedDatasetSnapshot
 from worker.model_ops.training_runtime_preflight import call_with_training_failure_cleanup
@@ -57,9 +62,10 @@ def evaluate_heldout_if_requested(
     trainer_dataset_format: str,
     test_ratio: float,
     runtime_failure_details: dict[str, Any],
+    include_baseline: bool = False,
 ) -> dict[str, Any]:
     if normalized_snapshot.test_path is None or normalized_snapshot.test_sample_count <= 0:
-        return {
+        receipt = {
             "schema_version": "melix.lora_heldout_evaluation_receipt.v1",
             "status": "skipped",
             "reason": _skipped_reason(
@@ -73,28 +79,30 @@ def evaluate_heldout_if_requested(
             "perplexity": None,
             "backend": "",
         }
+        if include_baseline:
+            receipt.update(_baseline_not_run_fields("adapter_evaluation_not_completed"))
+        return receipt
 
+    heldout_request = HeldoutEvaluationRequest(
+        job_id=job_id,
+        base_model_id=source_model.model_id,
+        model_path=training_model_path,
+        model_revision=source_model.revision,
+        adapter_dir=adapter_output_dir,
+        normalized_dataset_dir=normalized_snapshot.dataset_dir,
+        config=config,
+        dataset_format=trainer_dataset_format,
+        test_sample_count=normalized_snapshot.test_sample_count,
+        source_model_kind=source_model.model_kind,
+        source_model_ext=dict(source_model.ext),
+    )
     try:
         result = call_with_training_failure_cleanup(
-            lambda: runner.evaluate_heldout(
-                HeldoutEvaluationRequest(
-                    job_id=job_id,
-                    base_model_id=source_model.model_id,
-                    model_path=training_model_path,
-                    model_revision=source_model.revision,
-                    adapter_dir=adapter_output_dir,
-                    normalized_dataset_dir=normalized_snapshot.dataset_dir,
-                    config=config,
-                    dataset_format=trainer_dataset_format,
-                    test_sample_count=normalized_snapshot.test_sample_count,
-                    source_model_kind=source_model.model_kind,
-                    source_model_ext=dict(source_model.ext),
-                )
-            ),
+            lambda: runner.evaluate_heldout(heldout_request),
             details=runtime_failure_details,
         )
     except ModelOperationError as exc:
-        return {
+        receipt = {
             "schema_version": "melix.lora_heldout_evaluation_receipt.v1",
             "status": "failed",
             "reason": "heldout_evaluation_failed",
@@ -107,7 +115,10 @@ def evaluate_heldout_if_requested(
             "error_code": exc.code,
             "error_message": exc.message,
         }
-    return {
+        if include_baseline:
+            receipt.update(_baseline_not_run_fields("adapter_evaluation_not_completed"))
+        return receipt
+    receipt = {
         "schema_version": "melix.lora_heldout_evaluation_receipt.v1",
         "status": "completed",
         "reason": "",
@@ -117,6 +128,76 @@ def evaluate_heldout_if_requested(
         "loss": result.loss,
         "perplexity": result.perplexity,
         "backend": result.execution_backend,
+    }
+    if include_baseline:
+        receipt.update(
+            _baseline_comparison_fields(
+                runner=runner,
+                request=heldout_request,
+                adapter_result=result,
+                runtime_failure_details=runtime_failure_details,
+            )
+        )
+    return receipt
+
+
+def _baseline_not_run_fields(reason: str) -> dict[str, Any]:
+    return {
+        "baseline_status": "skipped",
+        "baseline_reason": reason,
+        "baseline_loss": None,
+        "baseline_perplexity": None,
+        "baseline_backend": "",
+        "loss_delta": None,
+        "perplexity_ratio": None,
+    }
+
+
+def _baseline_comparison_fields(
+    *,
+    runner: MLXLMRunner,
+    request: HeldoutEvaluationRequest,
+    adapter_result: HeldoutEvaluationResult,
+    runtime_failure_details: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate the plain base model on the same test split.
+
+    A failed baseline pass never fails the adapter receipt: the adapter
+    metrics stand on their own and the failure is recorded next to them.
+    """
+    baseline_request = replace(request, adapter_dir=None)
+    try:
+        baseline = call_with_training_failure_cleanup(
+            lambda: runner.evaluate_heldout(baseline_request),
+            details=runtime_failure_details,
+        )
+    except ModelOperationError as exc:
+        return {
+            "baseline_status": "failed",
+            "baseline_reason": "baseline_evaluation_failed",
+            "baseline_loss": None,
+            "baseline_perplexity": None,
+            "baseline_backend": "",
+            "loss_delta": None,
+            "perplexity_ratio": None,
+            "baseline_error_code": exc.code,
+            "baseline_error_message": exc.message,
+        }
+    perplexity_ratio = (
+        baseline.perplexity / adapter_result.perplexity
+        if adapter_result.perplexity and adapter_result.perplexity > 0
+        else None
+    )
+    return {
+        "baseline_status": "completed",
+        "baseline_reason": "",
+        "baseline_loss": baseline.loss,
+        "baseline_perplexity": baseline.perplexity,
+        "baseline_backend": baseline.execution_backend,
+        # Positive delta / ratio > 1 means the adapter beat the base model on
+        # the held-out split.
+        "loss_delta": baseline.loss - adapter_result.loss,
+        "perplexity_ratio": perplexity_ratio,
     }
 
 

--- a/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_training_pipeline.py
@@ -284,6 +284,9 @@ class LoRATrainingPipeline:
                     trainer_dataset_format=trainer_dataset_format,
                     test_ratio=test_ratio,
                     runtime_failure_details=runtime_failure_details,
+                    include_baseline=truthy(
+                        request_ext.get("heldout_baseline_compare", "")
+                    ),
                 ),
             )
         )
@@ -606,7 +609,7 @@ def _int_ext(ext: dict[str, str], key: str) -> int:
 
 
 def _heldout_evaluation_manifest_fields(*, receipt: dict[str, Any]) -> dict[str, Any]:
-    return {
+    fields = {
         "heldout_evaluation_receipt_path": str(receipt["receipt_path"]),
         "heldout_evaluation_status": str(receipt["status"]),
         "heldout_evaluation_reason": str(receipt["reason"]),
@@ -617,6 +620,21 @@ def _heldout_evaluation_manifest_fields(*, receipt: dict[str, Any]) -> dict[str,
         "heldout_test_loss": receipt["loss"],
         "heldout_test_perplexity": receipt["perplexity"],
     }
+    # Baseline-comparison fields travel only when the operator opted in via
+    # heldout_baseline_compare, keeping default manifests shape-stable.
+    if "baseline_status" in receipt:
+        fields.update(
+            {
+                "heldout_baseline_status": str(receipt["baseline_status"]),
+                "heldout_baseline_reason": str(receipt.get("baseline_reason", "")),
+                "heldout_baseline_backend": str(receipt.get("baseline_backend", "")),
+                "heldout_baseline_loss": receipt.get("baseline_loss"),
+                "heldout_baseline_perplexity": receipt.get("baseline_perplexity"),
+                "heldout_loss_delta": receipt.get("loss_delta"),
+                "heldout_perplexity_ratio": receipt.get("perplexity_ratio"),
+            }
+        )
+    return fields
 
 
 def _write_alignment_trace(path: Path, samples: list[dict[str, Any]]) -> None:

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -159,7 +159,9 @@ class HeldoutEvaluationRequest:
     base_model_id: str
     model_path: Path
     model_revision: str
-    adapter_dir: Path
+    # None evaluates the plain base model (baseline comparison pass) instead
+    # of the trained adapter.
+    adapter_dir: Path | None
     normalized_dataset_dir: Path
     config: LoRATrainingConfig
     dataset_format: str
@@ -726,6 +728,8 @@ def _load_lora_evaluation_model(
     request: HeldoutEvaluationRequest,
     load_fn: Any,
 ) -> tuple[Any, Any]:
+    if request.adapter_dir is None:
+        return load_fn(str(request.model_path), lazy=False)
     return load_fn(
         str(request.model_path),
         adapter_path=str(request.adapter_dir),
@@ -736,12 +740,19 @@ def _load_lora_evaluation_model(
 def _training_request_for_heldout_evaluation(
     request: HeldoutEvaluationRequest,
 ) -> TrainingRequest:
+    # adapter_output_dir only shapes args.adapter_path in the lora namespace,
+    # which the evaluation path (train=False) never reads; a baseline request
+    # without an adapter substitutes the dataset dir to satisfy the Path field.
     return TrainingRequest(
         job_id=request.job_id,
         base_model_id=request.base_model_id,
         model_path=request.model_path,
         model_revision=request.model_revision,
-        adapter_output_dir=request.adapter_dir,
+        adapter_output_dir=(
+            request.adapter_dir
+            if request.adapter_dir is not None
+            else request.normalized_dataset_dir
+        ),
         normalized_dataset_dir=request.normalized_dataset_dir,
         config=request.config,
         dataset_format=request.dataset_format,
@@ -840,7 +851,7 @@ def _serialize_heldout_evaluation_request(request: HeldoutEvaluationRequest) -> 
         "base_model_id": request.base_model_id,
         "model_path": str(request.model_path),
         "model_revision": request.model_revision,
-        "adapter_dir": str(request.adapter_dir),
+        "adapter_dir": str(request.adapter_dir) if request.adapter_dir is not None else "",
         "normalized_dataset_dir": str(request.normalized_dataset_dir),
         "dataset_format": request.dataset_format,
         "test_sample_count": request.test_sample_count,
@@ -861,7 +872,11 @@ def _deserialize_heldout_evaluation_request(payload: dict) -> HeldoutEvaluationR
         base_model_id=str(payload["base_model_id"]),
         model_path=Path(payload["model_path"]),
         model_revision=str(payload["model_revision"]),
-        adapter_dir=Path(payload["adapter_dir"]),
+        adapter_dir=(
+            Path(str(payload["adapter_dir"]))
+            if str(payload.get("adapter_dir", "") or "").strip()
+            else None
+        ),
         normalized_dataset_dir=Path(payload["normalized_dataset_dir"]),
         config=config,
         dataset_format=str(payload["dataset_format"]),

--- a/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
+++ b/services/mlx-worker-python/worker/model_ops/training_runtime_preflight.py
@@ -224,7 +224,10 @@ def _cleanup_training_failure_exception(exc: BaseException) -> dict[str, str]:
 def _retained_tensor_bytes_after_failure() -> int:
     try:
         import mlx.core as mx
-    except ModuleNotFoundError:
+    except ImportError:
+        # Covers both a missing package (ModuleNotFoundError) and an installed
+        # package whose native library fails to load (plain ImportError, e.g.
+        # libmlx.so on non-Metal hosts) — failure cleanup must never raise.
         return 0
     try:
         if hasattr(mx, "metal") and hasattr(mx.metal, "get_active_memory"):

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -436,6 +436,12 @@ class LoraExperimentStore:
                 final_metrics.get("heldout_test_perplexity"),
                 _manifest_optional_float(manifest, "heldout_test_perplexity"),
             ),
+            "heldout_baseline_loss": _optional_finite_float(
+                _manifest_optional_float(manifest, "heldout_baseline_loss")
+            ),
+            "heldout_loss_delta": _optional_finite_float(
+                _manifest_optional_float(manifest, "heldout_loss_delta")
+            ),
             "loss_series_row_count": _int_value(training.get("loss_series_row_count")),
             "loss_series": _list_value(training.get("loss_series")),
             "base_model": base_model,

--- a/services/mlx-worker-python/worker/productization/lora_experiment_store.py
+++ b/services/mlx-worker-python/worker/productization/lora_experiment_store.py
@@ -439,8 +439,14 @@ class LoraExperimentStore:
             "heldout_baseline_loss": _optional_finite_float(
                 _manifest_optional_float(manifest, "heldout_baseline_loss")
             ),
+            "heldout_baseline_perplexity": _optional_finite_float(
+                _manifest_optional_float(manifest, "heldout_baseline_perplexity")
+            ),
             "heldout_loss_delta": _optional_finite_float(
                 _manifest_optional_float(manifest, "heldout_loss_delta")
+            ),
+            "heldout_perplexity_ratio": _optional_finite_float(
+                _manifest_optional_float(manifest, "heldout_perplexity_ratio")
             ),
             "loss_series_row_count": _int_value(training.get("loss_series_row_count")),
             "loss_series": _list_value(training.get("loss_series")),


### PR DESCRIPTION
## Summary
- Close the last gap in the solo-user LoRA train → evaluate loop: the held-out evaluation stage (#2608) reports the trained adapter's test loss/perplexity, but gives no way to tell whether the adapter actually **improved on the base model**. With `heldout_baseline_compare` truthy alongside a `test_ratio` split, the pipeline now evaluates the plain base model (no adapter) on the same `test.jsonl` and records `heldout_baseline_loss`, `heldout_baseline_perplexity`, `heldout_loss_delta` (baseline − adapter; positive = the adapter helped) and `heldout_perplexity_ratio` in the held-out receipt, adapter manifest, and experiment run record.
- `HeldoutEvaluationRequest.adapter_dir` accepts `None` for the baseline pass (native load skips `adapter_path`; serialization and the subprocess fallback handle the empty form).
- Failure isolation: a failed baseline pass records `heldout_baseline_status=failed` (+ typed error fields) without disturbing the adapter's own held-out metrics; when the adapter pass is itself skipped/failed the baseline records `adapter_evaluation_not_completed`. Baseline fields travel **only when opted in**, keeping default receipts and manifests shape-stable.
- The deterministic runner reports a fixed higher baseline loss (0.42 vs 0.29) so the delta is testable end to end; experiment run records gain `heldout_baseline_loss` / `heldout_loss_delta` for run-over-run comparison.
- Robustness fix discovered en route: `_retained_tensor_bytes_after_failure` caught only `ModuleNotFoundError`, so an installed mlx whose native library fails to load (plain `ImportError`, e.g. `libmlx.so` on non-Metal hosts) escaped from the failure-cleanup path. Now catches `ImportError`; this repairs four environment-dependent test failures on Linux containers.

## Plan or Spec
- Follows `docs/plans/2026-07-07-issue-2608-lora-heldout-evaluation.md` (baseline comparison completes that plan's evaluation stage); runbook updated in `docs/runbooks/phase-8-lora-adapter-workflow.md`.

## Commands Run
```text
uv run --project services/mlx-worker-python --extra mlx pytest \
  services/mlx-worker-python/tests/test_lora_heldout_evaluation_pipeline.py -q
→ 8 passed

uv run ... pytest test_lora_heldout_evaluation_pipeline.py test_lora_model_ops_unit.py \
  test_lora_training_receipts.py test_training_log_events.py test_lora_experiment_store.py \
  test_lora_adapter_provenance.py test_lora_model_ops.py -q
→ 263 passed, 3 failed (all three fail identically on clean main in this
   Linux container — native-mlx-only paths)

uv run ... pytest services/mlx-worker-python/tests -q  (full suite)
→ branch: 54 failed, 4718 passed | clean main, same container: 58 failed, 4710 passed
   Diff of failure sets: the branch introduces zero new failures and repairs
   four pre-existing ones (via the ImportError cleanup fix).
```

## Coverage and Metrics
- 4 new pipeline tests: completed baseline comparison (delta + ratio assertions across receipt/manifest/run record), baseline failure keeps adapter metrics, opt-out keeps receipt shape stable, baseline skipped when the adapter pass fails.
- Native-path (Apple Silicon) validation of the baseline pass is deferred — same boundary as the existing held-out stage. `N/A: no MLX runtime in this container`; the deterministic runner covers the contract.

## Known Gaps
- The baseline pass reloads the base model for evaluation; on-device it could reuse the loaded training model with adapters detached — left as a follow-up optimization.
- Baseline comparison is loss/perplexity only; generation-quality compare on the held-out prompts remains covered by the existing `eval.compare` / release-compare surfaces.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [ ] Protocol changes include regenerated generated artifacts. — `N/A: no proto changes`
- [ ] Dependency changes include updated lockfiles. — `N/A: no dependency changes`
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UD6W9yzWXfKY13xUhdEke7

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD6W9yzWXfKY13xUhdEke7)_