### PR TITLE
perf(engine): fast path integer usage counters

### DIFF
--- a/docs/plans/2026-07-08-engine-usage-delta-local-bind.md
+++ b/docs/plans/2026-07-08-engine-usage-delta-local-bind.md
@@ -1,0 +1,36 @@
+# Engine usage non-negative integer fast path
+
+## Scope
+
+This Python-only performance slice is limited to `_non_negative_int()` in
+`services/mlx-worker-python/worker/engine/engine_core.py`.
+
+`_non_negative_int()` normalizes usage counters while emitting streaming
+`Generate` response usage. These counters are already plain Python integers in
+the hot path. This slice keeps behavior equivalent while returning directly for
+exact `int` inputs, avoiding the fallback `int(value or 0)` conversion and
+`max()` call for the common case.
+
+## Registered Probe
+
+Registered PR-scoped probe: `engine-generate-usage-token-elision`.
+
+The registry entry covers `engine_core.py` and provides focused `test_command`,
+`coverage_command`, and `probe_command` values. The probe reports no-usage stream
+latency and fallback usage latency through `elapsed_ms_mean` and
+`fallback_elapsed_ms_mean`, plus token/counting guard metrics.
+
+## Verification Plan
+
+- Run the registered focused test command for the engine usage slice.
+- Run the registered changed-scope coverage command.
+- Run `scripts/engine_generate_usage_token_probe.py` locally on Linux and compare
+  the relevant metrics before and after the change.
+- Let the PR-scoped performance workflow validate the registered probe on CI
+  before merge.
+
+## Expected Behavior
+
+Usage payloads remain unchanged. The direct path only handles exact `int` values;
+`bool`, strings, `None`, and custom numeric-like objects continue through the
+existing fallback conversion path.

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -166,6 +166,8 @@ def _text_native_mtp_parser_metrics(event: RuntimeTokenEvent | None) -> dict[str
 
 
 def _non_negative_int(value: object) -> int:
+    if type(value) is int:
+        return value if value > 0 else 0
     try:
         return max(0, int(value or 0))
     except (TypeError, ValueError):


### PR DESCRIPTION
## Summary
- Add an exact-`int` fast path to engine usage counter normalization in `_non_negative_int()`.
- Keep non-int, bool, string, `None`, and error fallback behavior on the existing conversion path.

## Plan or Spec
- `docs/plans/2026-07-08-engine-usage-delta-local-bind.md`
- Registered PR-scoped probe: `engine-generate-usage-token-elision`.

## Commands Run
```text
# Baseline before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
# 1 passed in 2.16s
MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# {"elapsed_ms_mean": 31.68015298433602, "fallback_elapsed_ms_mean": 124.52967721037567, ...}

# Focused post-change smoke
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_reuses_runtime_event_prompt_tokens_without_fallback_count services/mlx-worker-python/tests/test_generate_stream.py::test_generate_usage_counts_prompt_tokens_only_for_missing_event_total services/mlx-worker-python/tests/test_generate_stream.py::test_generate_streams_token_and_terminal_completion services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics
# 4 passed in 0.59s
MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# {"elapsed_ms_mean": 31.734528625383973, "fallback_elapsed_ms_mean": 122.83503358485177, ...}

# Registered focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <engine-generate-usage-token-elision test_command targets>
# 25 passed in 0.56s

# Registered changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <engine-generate-usage-token-elision coverage targets> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
# TOTAL 2 0 100%

# Registered local probe after implementation
MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# {"elapsed_ms_mean": 32.68446378642693, "fallback_elapsed_ms_mean": 121.38528662035242, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe baseline: `elapsed_ms_mean=31.68015298433602`, `fallback_elapsed_ms_mean=124.52967721037567`.
- Local registered probe final: `elapsed_ms_mean=32.68446378642693`, `fallback_elapsed_ms_mean=121.38528662035242`.
- Local fallback usage delta: `-3.144390590023249 ms` (`~2.53%` lower). The no-usage stream metric is not expected to materially exercise `_non_negative_int()` and moved from `31.68015298433602` to `32.68446378642693` locally; CI PR-scoped probe validation is required before merge.

## Known Gaps
- Linux local verification covers the Python path only.
- CI PR-scoped performance report is required for base-vs-head validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
