### PR TITLE
perf: trim trajectory manifest hot loader bindings

### DIFF
--- a/docs/plans/2026-07-03-trajectory-manifest-path-direct-open.md
+++ b/docs/plans/2026-07-03-trajectory-manifest-path-direct-open.md
@@ -27,3 +27,12 @@ is locally runnable on Linux.
 Local Linux validation must include the registered probe output with old/new
 mean timings and a changed-scope coverage report for the touched files. GitHub
 Actions PR-scoped performance remains the merge gate after the PR is opened.
+
+## 2026-07-08 follow-up: hot direct-open binding trimming
+
+This follow-up keeps the same Python-only boundary and registered
+`trajectory-manifest-json-load` probe. The manifest loader no longer binds the
+`Path.read_bytes` helper on the common direct-open string/`Path` inputs, and it
+reuses the decoded payload type check before deciding whether to take the exact
+`dict`, dict-subclass fallback, or non-dict empty path. Accepted manifest shapes,
+path-like fallback support, and provenance field semantics remain unchanged.

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -343,7 +343,6 @@ def _trajectory_provenance_from_snapshot_manifest(
 def load_trajectory_provenance_from_snapshot_manifest(
     manifest_path: Path | str | os.PathLike[str],
 ) -> dict[str, Any]:
-    read_bytes = _PATH_READ_BYTES
     open_file = _OPEN
     loads = _JSON_LOADS
     extract_provenance = _trajectory_provenance_from_snapshot_manifest
@@ -358,14 +357,15 @@ def load_trajectory_provenance_from_snapshot_manifest(
     else:
         manifest_path = Path(manifest_path)
         manifest_path_text = _STR(manifest_path)
-        payload = loads(read_bytes(manifest_path))
-    if type(payload) is dict:
+        payload = loads(_PATH_READ_BYTES(manifest_path))
+    payload_type = type(payload)
+    if payload_type is dict:
         return extract_provenance(
             payload,
             snapshot_manifest_path=manifest_path_text,
             copy_nested=False,
         )
-    if not isinstance(payload, dict):
+    if payload_type is not dict and not isinstance(payload, dict):
         return {}
     return extract_provenance(
         payload,


### PR DESCRIPTION
## Summary
- Trim the trajectory snapshot manifest loader hot path by avoiding the `Path.read_bytes` local binding for common direct-open string/`Path` inputs.
- Reuse the decoded payload type check before exact-dict, dict-subclass, and non-dict return decisions.
- Preserve path-like fallback support and all trajectory provenance field semantics.

## Plan or Spec
- `docs/plans/2026-07-03-trajectory-manifest-path-direct-open.md`
- Registered PR-scoped probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline local probe before this slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
exit 0; {"old_mean_ms": 1532.2727659833618, "new_mean_ms": 723.2533526024781, "delta_ms": -809.0194133808836, "speedup": 2.1185837030271535, "new_peak_bytes_mean": 54260.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_string_path_uses_direct_open services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_path_uses_direct_open services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_keeps_pathlike_support services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_path_falls_back_for_defaulted_required_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
exit 0; 18 passed in 2.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q <same focused test set>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
exit 0; changed_line_coverage=100.00%; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
exit 0; {"old_mean_ms": 1525.860732991714, "new_mean_ms": 708.5360953933559, "delta_ms": -817.3246375983581, "speedup": 2.15353987314451, "new_peak_bytes_mean": 54260.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines.
- Local registered probe (`trajectory-manifest-json-load`) after this slice: `old_mean_ms=1525.860732991714`, `new_mean_ms=708.5360953933559`, `delta_ms=-817.3246375983581`, `speedup=2.15353987314451`, `new_peak_bytes_mean=54260.0`.
- Same local probe before this slice: `new_mean_ms=723.2533526024781`; post-slice local delta vs pre-slice hot loader is `-14.7172572091222 ms` (~2.04% lower) with unchanged peak bytes.
- CI PR-scoped performance must run the registered `trajectory-manifest-json-load` probe before merge.

## Known Gaps
- Linux local validation covers this Python-only path. CI PR-scoped performance remains the registered probe merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped command-json performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
