### PR TITLE
perf: bind retrieval context fast-path helpers

### DIFF
--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -136,6 +136,11 @@ def project_retrieval_contexts(
     user_payload_update = user_payload.update
     entry_type = RetrievalContextEntry
     dict_copy = dict.copy
+    isinstance_of = isinstance
+    str_type = str
+    dict_type = dict
+    bool_type = bool
+    strip_text = str.strip
 
     for entry in entries:
         if type(entry) is entry_type:
@@ -149,19 +154,19 @@ def project_retrieval_contexts(
             corrective_action = entry.corrective_action
             if (
                 context_kind in ("retrieved_document", "retrieved_image")
-                and isinstance(source_id, str)
-                and isinstance(payload, dict)
-                and isinstance(owner_scope_checked, bool)
-                and isinstance(segment_id, str)
-                and isinstance(source_field, str)
-                and isinstance(reason, str)
-                and isinstance(corrective_action, str)
+                and isinstance_of(source_id, str_type)
+                and isinstance_of(payload, dict_type)
+                and isinstance_of(owner_scope_checked, bool_type)
+                and isinstance_of(segment_id, str_type)
+                and isinstance_of(source_field, str_type)
+                and isinstance_of(reason, str_type)
+                and isinstance_of(corrective_action, str_type)
             ):
-                normalized_source_id = source_id.strip()
-                normalized_segment_id = segment_id.strip()
-                normalized_source_field = source_field.strip()
-                normalized_reason = reason.strip()
-                normalized_corrective_action = corrective_action.strip()
+                normalized_source_id = strip_text(source_id)
+                normalized_segment_id = strip_text(segment_id)
+                normalized_source_field = strip_text(source_field)
+                normalized_reason = strip_text(reason)
+                normalized_corrective_action = strip_text(corrective_action)
                 if (
                     normalized_source_id
                     and normalized_segment_id


### PR DESCRIPTION
## Summary
- Bind repeated type helpers and `str.strip` in the complete `RetrievalContextEntry` projection fast path.
- Keep retrieval context projection behavior unchanged while reducing per-entry global/method lookup overhead on the registered projection probe.

## Plan or Spec
- `AGENTS.md` and `docs/contributing.md` govern small, measured performance slices.
- Registered PR-scoped probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
- No docs update required: this is an internal implementation-only hot-path optimization with no behavior or workflow change.

## Commands Run
```text
# baseline before edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit 0; optimized_elapsed_ms_mean=0.112695926051986; speedup=8.781888238480253; store_optimized_elapsed_ms_mean=0.13065003000000225; lookup_copy_optimized_elapsed_ms_mean=2.5549121925100087

# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...registered retrieval-context-projection-fastpath test_command...
exit 0; 36 passed in 1.22s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...registered retrieval-context-projection-fastpath coverage_command... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
exit 0; 36 passed in 0.39s; TOTAL 10 0 100%

# registered local probe after edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/retrieval_context_projection_probe.py"; for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT" "$SCRIPT"; do if [ -f "$CANDIDATE" ]; then MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2'
exit 0; optimized_elapsed_ms_mean=0.10590794467134401; speedup=8.55931809778652; store_optimized_elapsed_ms_mean=0.13565559856942855; lookup_copy_optimized_elapsed_ms_mean=2.542099516057143

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local Linux registered probe (`retrieval-context-projection-fastpath`):
  - Before edit: `optimized_elapsed_ms_mean=0.112695926051986 ms`.
  - After edit: `optimized_elapsed_ms_mean=0.10590794467134401 ms`.
  - Local delta: `-0.006787981380641992 ms` (~6.02% lower for the optimized projection path).
  - Full after-edit probe JSON: `baseline_elapsed_ms_mean=0.9064997875248082`, `delta_ms=-0.8005918428534642`, `speedup=8.55931809778652`, `store_optimized_elapsed_ms_mean=0.13565559856942855`, `lookup_copy_optimized_elapsed_ms_mean=2.542099516057143`, `lookup_records_optimized_get_calls_mean=1.0`.
- CI PR-scoped performance workflow is required as the merge gate for the registered probe report.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this one-line Python hot-path slice; CI remains the broad validation gate.
- No Swift runtime effect is claimed or required for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. N/A: no external behavior or workflow change.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
