### PR TITLE
perf: bind model load trust constants

### DIFF
--- a/docs/plans/2026-07-07-model-load-config-os-binding.md
+++ b/docs/plans/2026-07-07-model-load-config-os-binding.md
@@ -22,6 +22,10 @@ This keeps trust-policy semantics unchanged while avoiding repeated global attri
 
 This follow-up Python-only slice is still limited to `services/mlx-worker-python/worker/model_load_trust.py` and the registered `model-load-config-json-bytes` probe. The config JSON read path now also binds `builtins.open` as `_OPEN` and uses that module-local binding for the direct binary read in `_read_model_config_for_stat(...)`. The behavior remains identical: config files are opened directly in binary mode, parsed from bytes through `_JSON_LOADS`, and cached by `(path, mtime_ns, size)`.
 
+## 2026-07-09 Trust Constant Binding Follow-up Slice
+
+This follow-up Python-only slice keeps the same `services/mlx-worker-python/worker/model_load_trust.py` boundary and the registered `model-load-config-json-bytes` probe. The repeated trust-policy resolution path now binds the hot protobuf enum constants and the `ModelLoadTrustPolicy` constructor at module import time and uses those local aliases in `_requested_mode(...)`, `_route_class(...)`, hot policy construction, and the trust-mode branch checks. Behavior remains identical; the slice only avoids repeated protobuf module attribute lookups in the config JSON trust-policy hot path.
+
 ## Verification Plan
 
 Run locally on Linux before PR:

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -23,6 +23,12 @@ BLOCK_REASON_CUSTOM_LOADER_REQUIRES_TRUST = "custom_loader_requires_trust_remote
 CONFIG_JSON_DETECTION = (False, CONFIG_JSON_SOURCE)
 CONFIG_JSON_ABSENT_DETECTION = (False, CONFIG_JSON_ABSENT_SOURCE)
 CONFIG_JSON_AUTO_MAP_DETECTION = (True, CONFIG_JSON_AUTO_MAP_SOURCE)
+MODEL_LOAD_TRUST_DEFAULT_SAFE = common_pb2.MODEL_LOAD_TRUST_DEFAULT_SAFE
+MODEL_LOAD_TRUST_TRUST_REMOTE_CODE = common_pb2.MODEL_LOAD_TRUST_TRUST_REMOTE_CODE
+MODEL_LOAD_TRUST_NOT_APPLICABLE = common_pb2.MODEL_LOAD_TRUST_NOT_APPLICABLE
+MODEL_LOAD_TRUST_POLICY = common_pb2.ModelLoadTrustPolicy
+WORKER_ROUTE_CLASS_UNSPECIFIED = common_pb2.WORKER_ROUTE_CLASS_UNSPECIFIED
+WORKER_ROUTE_PYTHON_TEXT_COMPATIBILITY = common_pb2.WORKER_ROUTE_PYTHON_TEXT_COMPATIBILITY
 _JSON_LOADS = json.loads
 _OS_STAT = os.stat
 _OS_SCANDIR = os.scandir
@@ -38,8 +44,8 @@ EXECUTABLE_MODEL_FILE_PREFIXES = (
 )
 VALID_REQUESTED_TRUST_MODES = frozenset(
     {
-        common_pb2.MODEL_LOAD_TRUST_DEFAULT_SAFE,
-        common_pb2.MODEL_LOAD_TRUST_TRUST_REMOTE_CODE,
+        MODEL_LOAD_TRUST_DEFAULT_SAFE,
+        MODEL_LOAD_TRUST_TRUST_REMOTE_CODE,
     }
 )
 TRUST_APPLICABLE_TEXT_LOADERS = frozenset({"mlx_lm", "mlx_lm_unavailable"})
@@ -49,7 +55,7 @@ TRUST_APPLICABLE_VLM_LOADERS_COMMON = frozenset(
     {"mlx-vlm", "mlx_vlm", "python_vlm", "mlx_vlm_unavailable"}
 )
 ROUTE_CLASS_BY_RUNTIME_KIND = {
-    "text": common_pb2.WORKER_ROUTE_PYTHON_TEXT_COMPATIBILITY,
+    "text": WORKER_ROUTE_PYTHON_TEXT_COMPATIBILITY,
     "vlm": common_pb2.WORKER_ROUTE_PYTHON_VLM,
     "ocr": common_pb2.WORKER_ROUTE_PYTHON_OCR,
     "embedding": common_pb2.WORKER_ROUTE_PYTHON_EMBEDDING,
@@ -100,7 +106,7 @@ def resolve_model_load_trust_policy(
     if not _is_trust_applicable(runtime_kind, loader_family, runtime_name, runtime):
         return _not_applicable_policy(requested_mode, route_class, loader_family)
 
-    policy = common_pb2.ModelLoadTrustPolicy()
+    policy = MODEL_LOAD_TRUST_POLICY()
     policy.requested_mode = requested_mode
     policy.policy_source = _non_empty(
         getattr(request_policy, "policy_source", "") if request_policy is not None else "",
@@ -112,7 +118,7 @@ def resolve_model_load_trust_policy(
     custom_loader_required, detection_source = _detect_custom_loader_requirement(model_spec)
     policy.custom_loader_required = custom_loader_required
     policy.custom_loader_detection_source = detection_source
-    if custom_loader_required and requested_mode != common_pb2.MODEL_LOAD_TRUST_TRUST_REMOTE_CODE:
+    if custom_loader_required and requested_mode != MODEL_LOAD_TRUST_TRUST_REMOTE_CODE:
         policy.block_reason = BLOCK_REASON_CUSTOM_LOADER_REQUIRES_TRUST
         raise ModelLoadTrustRejection(policy)
     return policy
@@ -131,8 +137,8 @@ def default_not_applicable_load_trust_policy(
     if _is_trust_applicable(runtime_kind, runtime_name, runtime_name, runtime):
         return None
     return _not_applicable_policy(
-        common_pb2.MODEL_LOAD_TRUST_DEFAULT_SAFE,
-        common_pb2.WORKER_ROUTE_PYTHON_TEXT_COMPATIBILITY,
+        MODEL_LOAD_TRUST_DEFAULT_SAFE,
+        WORKER_ROUTE_PYTHON_TEXT_COMPATIBILITY,
         runtime_name,
     )
 
@@ -145,7 +151,7 @@ def _not_applicable_policy(
 ) -> common_pb2.ModelLoadTrustPolicy:
     return common_pb2.ModelLoadTrustPolicy(
         requested_mode=requested_mode,
-        effective_mode=common_pb2.MODEL_LOAD_TRUST_NOT_APPLICABLE,
+        effective_mode=MODEL_LOAD_TRUST_NOT_APPLICABLE,
         policy_source=NOT_APPLICABLE_SOURCE,
         custom_loader_detection_source=NOT_APPLICABLE_SOURCE,
         route_class=route_class,
@@ -154,7 +160,7 @@ def _not_applicable_policy(
 
 
 def load_kwargs_for_policy(policy: common_pb2.ModelLoadTrustPolicy) -> dict[str, Any]:
-    if policy.effective_mode != common_pb2.MODEL_LOAD_TRUST_TRUST_REMOTE_CODE:
+    if policy.effective_mode != MODEL_LOAD_TRUST_TRUST_REMOTE_CODE:
         return {}
     return {"trust_remote_code": True}
 
@@ -171,7 +177,7 @@ def _requested_mode(
         and model_spec.settings.load_trust_mode in valid_requested_modes
     ):
         return model_spec.settings.load_trust_mode, MODEL_SETTINGS_SOURCE
-    return common_pb2.MODEL_LOAD_TRUST_DEFAULT_SAFE, DEFAULT_SAFE_SOURCE
+    return MODEL_LOAD_TRUST_DEFAULT_SAFE, DEFAULT_SAFE_SOURCE
 
 
 def _route_class(
@@ -179,11 +185,11 @@ def _route_class(
     request_policy: common_pb2.ModelLoadTrustPolicy | None,
     runtime_kind: str,
 ) -> int:
-    if request_policy is not None and request_policy.route_class != common_pb2.WORKER_ROUTE_CLASS_UNSPECIFIED:
+    if request_policy is not None and request_policy.route_class != WORKER_ROUTE_CLASS_UNSPECIFIED:
         return request_policy.route_class
-    if model_spec.route_class != common_pb2.WORKER_ROUTE_CLASS_UNSPECIFIED:
+    if model_spec.route_class != WORKER_ROUTE_CLASS_UNSPECIFIED:
         return model_spec.route_class
-    return ROUTE_CLASS_BY_RUNTIME_KIND.get(runtime_kind, common_pb2.WORKER_ROUTE_CLASS_UNSPECIFIED)
+    return ROUTE_CLASS_BY_RUNTIME_KIND.get(runtime_kind, WORKER_ROUTE_CLASS_UNSPECIFIED)
 
 
 def _loader_family(


### PR DESCRIPTION
## Summary
- Bind hot model-load trust protobuf enum constants at module import time.
- Bind the hot `ModelLoadTrustPolicy` constructor for repeated policy construction in the config JSON custom-loader path.
- Keep behavior unchanged while reducing protobuf module attribute lookup overhead in the registered model-load config probe.

## Plan or Spec
- `docs/plans/2026-07-07-model-load-config-os-binding.md` (2026-07-09 trust constant binding follow-up slice).
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/model_load_trust.py` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
$ git fetch origin && git reset --hard origin/main
HEAD is now at 8c165fa3 perf: bind retrieval context fast-path helpers (#2685)

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...model-load-config-json-bytes focused tests...
29 passed in 0.56s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py ...
29 passed in 1.07s
TOTAL 2 0 100%

$ MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_SAMPLES=21 MELIX_MODEL_LOAD_CONFIG_BYTES_PROBE_ITERATIONS=1000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-load-config-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/model-load-config-json-bytes-result3.json
head verification: 29 passed; changed-scope coverage TOTAL 2 0 100%
base elapsed_ms_mean=20.240600087812968
head elapsed_ms_mean=18.76669909272875

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 2 0 100%`) for changed executable lines in `services/mlx-worker-python/worker/model_load_trust.py`.
- Registered probe local base-vs-head (`model-load-config-json-bytes`, 21 samples x 1000 iterations):
  - `old_mean=20.240600087812968 ms`
  - `new_mean=18.76669909272875 ms`
  - `delta_ms=-1.473900995084218 ms`
  - `speedup=1.0785x` (~7.28% lower elapsed mean)
  - `peak_bytes_mean` unchanged at `1834.5714285714287` bytes
- CI PR-scoped performance report is still required as the merge gate.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and integration tests were not run locally for this Python micro-slice.
- Local Linux validates only the Python path; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe only; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
