### PR TITLE
perf: guard hub size marker scans by o presence

### DIFF
--- a/docs/plans/2026-07-08-hub-size-marker-presence-guard.md
+++ b/docs/plans/2026-07-08-hub-size-marker-presence-guard.md
@@ -20,8 +20,8 @@ reports `elapsed_ms_mean` for the size-hint workload.
 
 1. Preserve the existing case-insensitive two-character marker behavior for
    `MO`, `Mo`, `mo`, and `mO` sequences.
-2. Add a cheap single-character presence guard so marker-free text exits before
-   the four pair scans used by the existing helper.
+2. Add cheap single-character presence guards for both `m/M` and `o/O` so
+   marker-free text exits before the four pair scans used by the existing helper.
 3. Keep the existing focused Hub catalog tests as behavior parity coverage.
 4. Run the registered focused tests, changed-scope coverage, and local Linux
    size-hint probe before pushing. CI remains the merge gate for the registered
@@ -33,5 +33,6 @@ reports `elapsed_ms_mean` for the size-hint workload.
 - Changed-scope coverage for `hub_catalog.py`, related tests, registry test, and
   the size-hint probe meets the repository threshold.
 - The local registered probe shows a neutral-to-improved `elapsed_ms_mean`
-  versus the same-worktree `origin/main` baseline.
+  versus the same-worktree `origin/main` baseline, especially for marker-free
+  `m/M`-only text that cannot contain a `mo` marker.
 - The PR-scoped performance workflow completes successfully before merge.

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -26,7 +26,7 @@ def _payload(index: int) -> tuple[dict[str, Any], int]:
     if mode == 2:
         return {"cardData": {}, "readme": f"README\nMODEL SIZE | {value} kb\nother metadata"}, value * 1024
     if mode == 3:
-        return {"cardData": {}, "description": f"description only {value} MB"}, 0
+        return {"cardData": {}, "description": f"massive weights {value} MB"}, 0
     return {
         "cardData": {"description": f"training corpus {value} kb"},
         "description": f"tokenizer assets {value} MB",

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -500,7 +500,7 @@ def test_size_hint_model_marker_scan_preserves_case_insensitive_pairs() -> None:
         "prefix MO suffix",
     ):
         assert hub_catalog_module._may_contain_model_marker(text) is True
-    for text in ("", "m", "M", "metadata only", "adapter notes"):
+    for text in ("", "m", "M", "metadata only", "adapter notes", "massive weights"):
         assert hub_catalog_module._may_contain_model_marker(text) is False
 
 

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -1066,7 +1066,7 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
 
 
 def _may_contain_model_marker(text: str) -> bool:
-    return ("m" in text or "M" in text) and (
+    return ("m" in text or "M" in text) and ("o" in text or "O" in text) and (
         "MO" in text or "Mo" in text or "mo" in text or "mO" in text
     )
 


### PR DESCRIPTION
## Summary
- Add an `o/O` presence guard to Hub catalog model-marker screening before the existing `MO`/`Mo`/`mo`/`mO` pair scans.
- Extend the focused probe payload and regression test to cover marker-free `m/M`-only text (`massive weights ...`) that cannot contain a model marker.
- Update the governing performance plan with the dual-character guard scope.

## Plan or Spec
- Updated `docs/plans/2026-07-08-hub-size-marker-presence-guard.md`.
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` (existing entry with focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-size-marker-o-guard-base-20260709 --head-repo "$PWD" --output .runtime/hub-size-marker-o-guard-pr-scoped-fair.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `94 passed in 1.37s`.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Direct local registered probe (head): `elapsed_ms_mean=1281.2969038030133`, `payload_compatibility_elapsed_ms_mean=204.93426760658622`.
- Fair local PR-scoped comparison using the head probe script for both repos:
  - base `elapsed_ms_mean=1288.6182125890628`
  - head `elapsed_ms_mean=1268.3852769900113`
  - delta `-20.2329355990515 ms` (~1.57% lower is better)
  - base `payload_compatibility_elapsed_ms_mean=192.14198320405558`
  - head `payload_compatibility_elapsed_ms_mean=195.23847898235545` (informational/non-target compatibility path, +1.61%, within registered 5% warning threshold)

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior changed.
- GitHub Actions PR-scoped performance report is still required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally with base/head comparison.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
