### PR TITLE
Record native MTP policy decisions

### DIFF
--- a/docs/plans/2026-07-09-issue-2602-native-mtp-family-device-batch-policy.md
+++ b/docs/plans/2026-07-09-issue-2602-native-mtp-family-device-batch-policy.md
@@ -1,0 +1,200 @@
+# Issue 2602 Native MTP Family, Device, And Batch Policy
+
+## Goal
+
+Move native-MTP admission from a Qwen-only shape check to a declarative
+capability policy that can recognize additional native-head families, records
+device and batch-state decisions in the receipt, and fails closed when the
+runtime patch for a recognized family is not yet available.
+
+## Governing Issue
+
+- GitHub issue: `#2602`
+- Prior slices:
+  - `docs/plans/2026-07-08-issue-2602-native-mtp-capability-registry.md`
+  - `docs/plans/2026-07-08-issue-2602-native-mtp-capability-receipt-object.md`
+
+## End-State Architecture
+
+The Python worker should resolve native-MTP capability through registered family
+records rather than inline Qwen predicates. Each record declares config fields,
+weight prefixes, cache shape, patch support, batch-state policy, and hardware
+policy inputs. The preload path then consumes one
+`NativeMTPCapabilityDecision`: patchable Qwen native heads can activate as they
+do today, while recognized DeepSeek-V3-style native heads produce a typed
+receipt and refuse runtime activation until a matching model patch exists.
+
+Device policy is evaluated before patch activation. The default policy is
+conservative: existing Qwen behavior remains admitted on unknown or unclassified
+hardware, known lower-end M1/M2 classes are disabled when auto policy is in
+force, and operator metadata can force enable or disable with the override
+recorded in the receipt.
+
+Batch-state policy is explicit in the same receipt. This slice does not replace
+the scheduler with full batched verify-forward execution. It records that the
+current implementation can preserve a singleton timeline through `filter` when
+the same uid remains, reconciles then drops state on `extend`, and refuses
+multi-row decode as `multi_row_decode_unsupported` rather than silently treating
+it as general batched MTP.
+
+## Scope
+
+- Replace the hard-coded Qwen compatibility predicate in
+  `worker.runtime.native_mtp.capability` with registered capability specs.
+- Add DeepSeek-V3-style detection for `num_nextn_predict_layers` plus
+  `model.layers.*.shared_head.*` / `model.layers.*.eh_proj.*` native-head
+  weights, producing `family=deepseek_v3_nextn`.
+- Add typed refusal `patch_unsupported` for recognized families whose runtime
+  patch is not implemented yet.
+- Add hardware policy metadata and receipt fields:
+  `hardware_gate`, `hardware_policy`, `hardware_policy_reason`,
+  `hardware_policy_source`, and `operator_override`.
+- Add a pure device-policy helper with deterministic tests for unknown hardware,
+  M1/M2 auto-disable, and operator force-enable/force-disable metadata.
+- Add batch-state metadata and receipt fields that distinguish
+  `singleton_filter_preserved`, `reconcile_on_extend`, and
+  `multi_row_decode_unsupported`.
+- Keep the existing public metadata keys stable for Qwen native heads.
+
+## Non-Goals
+
+- No DeepSeek native-head model patch or live DeepSeek execution path in this
+  slice.
+- No full batched verify-forward implementation.
+- No public HTTP, CLI, or protobuf schema change.
+- No new assistant-sidecar serving surface.
+
+## Performance Probes
+
+Measurement points:
+
+- registry resolution remains a preload-only operation;
+- weight-map scans remain a single pass over the index keys;
+- device policy must not invoke telemetry sampling during model load;
+- Qwen patch calls remain skipped for refused DeepSeek and sidecar decisions.
+
+Success metrics:
+
+- focused native-MTP capability and backend tests pass;
+- changed-scope coverage for touched Python files remains at or above
+  95 percent;
+- native-MTP loader performance probe reports status `ok` with regressions `0`;
+- full local pre-commit gate passes before committing on this host.
+
+## Implementation Plan
+
+1. Write failing tests in
+   `services/mlx-worker-python/tests/test_native_mtp_capability.py` for:
+   - Qwen receipt now exposing the new hardware and batch-state fields while
+     preserving existing flat keys;
+   - DeepSeek-V3-style config plus native-head weights resolving to
+     `family=deepseek_v3_nextn`, `compatible=true`,
+     `resolution=refused`, `reason=patch_unsupported`, and no patch call;
+   - missing DeepSeek native-head weights resolving to
+     `missing_mtp_weights`;
+   - operator `melix.native_mtp.device_policy=force_on` and `force_off`
+     overriding the auto policy with receipt evidence;
+   - injected hardware profiles for M2 and M3/M4 class devices producing the
+     expected auto policy decision.
+2. Write failing batch-policy tests in
+   `services/mlx-worker-python/tests/test_native_mtp_capability.py` for the
+   pure helpers that report singleton-filter preservation and multi-row decode
+   refusal.
+3. Implement capability specs and a deterministic hardware-policy helper in
+   `worker.runtime.native_mtp.capability`.
+4. Extend `NativeMTPCapabilityReceipt` and flat metadata projection with the new
+   device and batch-state fields.
+5. Update preload decision logic so `patch_applied` is attempted only when the
+   family spec is patchable and the device policy admits activation.
+6. Update `batch_generator` helper names and ineligibility reasons to match the
+   explicit batch-state policy without changing token-generation semantics.
+7. Run focused tests and changed-scope coverage.
+8. Run the native-MTP loader performance probe and full local gate.
+
+## Verification Plan
+
+Focused tests:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q \
+  services/mlx-worker-python/tests/test_native_mtp_capability.py \
+  services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp'
+```
+
+Changed-scope coverage:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q \
+  services/mlx-worker-python/tests/test_native_mtp_capability.py \
+  services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp' && \
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && \
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json \
+  services/mlx-worker-python/worker/runtime/native_mtp/capability.py \
+  services/mlx-worker-python/worker/runtime/native_mtp/preload.py \
+  services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py \
+  services/mlx-worker-python/tests/test_native_mtp_capability.py \
+  services/mlx-worker-python/tests/test_mlx_backend.py
+```
+
+Performance probe:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" \
+  uv run --project services/mlx-worker-python --extra mlx bash -c 'python3 scripts/native_mtp_loader_safetensor_scandir_probe.py'
+```
+
+Full gate:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+.githooks/pre-commit
+```
+
+## Verification Results
+
+- Red tests were added before implementation. The first focused run failed as
+  expected on the missing DeepSeek registry entry, new hardware-policy receipt
+  fields, preload refusal behavior, and batch-state receipt helper.
+- Focused native-MTP tests passed:
+  `39 passed, 58 deselected, 2 warnings in 4.50s`.
+- Adjacent VLM native-MTP preload tests passed:
+  `2 passed in 0.38s`.
+- `git diff --check` passed.
+- Changed-scope coverage passed with aggregate changed-scope coverage at
+  97 percent.
+- Native-MTP loader safetensor scandir probe passed with speedup metrics:
+  `speedup=1.0083192988453773`,
+  `extra_speedup=7.147455764233157`,
+  `model_listing_speedup=2.259606022679985`, and
+  `weight_load_speedup=1.2590202577768717`.
+- `make swift-test` passed. The final macOS menubar stage reported
+  `834 tests in 25 suites passed`.
+- `make py-test` passed:
+  `4841 passed, 14 skipped, 2 warnings in 184.09s`.
+- `make integration-test` passed:
+  `123 passed, 1 skipped in 728.07s`.
+
+## Metrics Report
+
+Changed-scope coverage:
+
+- `services/mlx-worker-python/worker/runtime/native_mtp/capability.py`:
+  95.43 percent.
+- `services/mlx-worker-python/worker/runtime/native_mtp/preload.py`:
+  100.00 percent.
+- `services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py`:
+  100.00 percent.
+- Changed test lines:
+  100.00 percent.
+- Aggregate changed scope:
+  97 percent.
+
+Pre-commit performance report:
+
+- `.githooks/pre-commit` passed on the final staged code snapshot.
+- Report status: `ok`.
+- Selected probes: `0`.
+- Report path:
+  `.runtime/pre-commit-performance/20260709-014710-519f6176/report/report.md`.

--- a/docs/plans/2026-07-09-issue-2602-native-mtp-family-device-batch-policy.md
+++ b/docs/plans/2026-07-09-issue-2602-native-mtp-family-device-batch-policy.md
@@ -25,9 +25,10 @@ do today, while recognized DeepSeek-V3-style native heads produce a typed
 receipt and refuse runtime activation until a matching model patch exists.
 
 Device policy is evaluated before patch activation. The default policy is
-conservative: existing Qwen behavior remains admitted on unknown or unclassified
-hardware, known lower-end M1/M2 classes are disabled when auto policy is in
-force, and operator metadata can force enable or disable with the override
+conservative: existing Qwen behavior remains admitted on non-Apple unknown or
+unclassified hardware, known lower-end M1/M2 classes are disabled when auto
+policy is in force, Darwin/arm64 hardware that cannot be classified fails
+closed, and operator metadata can force enable or disable with the override
 recorded in the receipt.
 
 Batch-state policy is explicit in the same receipt. This slice does not replace
@@ -49,8 +50,9 @@ it as general batched MTP.
 - Add hardware policy metadata and receipt fields:
   `hardware_gate`, `hardware_policy`, `hardware_policy_reason`,
   `hardware_policy_source`, and `operator_override`.
-- Add a pure device-policy helper with deterministic tests for unknown hardware,
-  M1/M2 auto-disable, and operator force-enable/force-disable metadata.
+- Add a pure device-policy helper with deterministic tests for non-Apple unknown
+  hardware, M1/M2 auto-disable, M3/M4 admission, Darwin/arm64 probe failure, and
+  operator force-enable/force-disable metadata.
 - Add batch-state metadata and receipt fields that distinguish
   `singleton_filter_preserved`, `reconcile_on_extend`, and
   `multi_row_decode_unsupported`.
@@ -95,7 +97,9 @@ Success metrics:
    - operator `melix.native_mtp.device_policy=force_on` and `force_off`
      overriding the auto policy with receipt evidence;
    - injected hardware profiles for M2 and M3/M4 class devices producing the
-     expected auto policy decision.
+     expected auto policy decision;
+   - the production Darwin/arm64 hardware-detection fallback caching sysctl
+     results and failing closed when the chip probe times out.
 2. Write failing batch-policy tests in
    `services/mlx-worker-python/tests/test_native_mtp_capability.py` for the
    pure helpers that report singleton-filter preservation and multi-row decode
@@ -175,21 +179,33 @@ make integration-test
   `4841 passed, 14 skipped, 2 warnings in 184.09s`.
 - `make integration-test` passed:
   `123 passed, 1 skipped in 728.07s`.
+- Review follow-up tests were added for production Darwin/arm64 hardware
+  detection, module-level hardware-profile caching, Darwin/arm64 probe-timeout
+  fail-closed behavior, and the M3/M4 auto-admit branch. The first focused run
+  failed as expected because `_CACHED_HARDWARE_PROFILE` did not exist yet.
+- Review follow-up focused native-MTP and adjacent VLM tests passed:
+  `59 passed, 172 deselected, 2 warnings in 1.01s`.
+- Review follow-up changed-scope coverage passed with aggregate changed-scope
+  coverage at 99 percent.
 
 ## Metrics Report
 
-Changed-scope coverage:
+Changed-scope coverage after review follow-up:
 
 - `services/mlx-worker-python/worker/runtime/native_mtp/capability.py`:
-  95.43 percent.
+  100.00 percent.
 - `services/mlx-worker-python/worker/runtime/native_mtp/preload.py`:
   100.00 percent.
 - `services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py`:
   100.00 percent.
-- Changed test lines:
+- `services/mlx-worker-python/tests/test_native_mtp_capability.py`:
+  98.61 percent.
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`:
   100.00 percent.
+- Changed test lines:
+  98.61 percent.
 - Aggregate changed scope:
-  97 percent.
+  99 percent.
 
 Pre-commit performance report:
 

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -3125,7 +3125,10 @@ def test_native_mtp_preload_patch_detects_qwen36_mtp_weights(
 
     metadata = maybe_apply_native_mtp_preload_patches(
         str(model_dir),
-        metadata={"melix.native_mtp.enabled": "true"},
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.native_mtp.device_policy": "force_on",
+        },
     )
 
     assert metadata["melix.native_mtp.compatible"] == "true"

--- a/services/mlx-worker-python/tests/test_native_mtp_capability.py
+++ b/services/mlx-worker-python/tests/test_native_mtp_capability.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from worker.runtime.mlx_text_runtime import maybe_apply_native_mtp_text_preload_patches
 from worker.runtime.mlx_vlm_runtime import maybe_apply_native_mtp_preload_patches
-from worker.runtime.native_mtp.capability import NativeMTPCapabilityDecision, resolve_native_mtp_capability
+from worker.runtime.native_mtp.capability import (
+    NativeMTPCapabilityDecision,
+    resolve_native_mtp_capability,
+)
 
 
 def _write_model(
@@ -64,7 +68,29 @@ def _native_mtp_receipt(metadata: dict[str, str]) -> dict[str, object]:
     assert str(receipt["effective_depth"]) == metadata["melix.native_mtp.receipt.effective_depth"]
     assert receipt["depth_source"] == metadata["melix.native_mtp.receipt.depth_source"]
     assert receipt["batch_shape"] == metadata["melix.native_mtp.receipt.batch_shape"]
+    assert (
+        receipt["batch_filter_policy"]
+        == metadata["melix.native_mtp.receipt.batch_filter_policy"]
+    )
+    assert (
+        receipt["batch_extend_policy"]
+        == metadata["melix.native_mtp.receipt.batch_extend_policy"]
+    )
+    assert (
+        receipt["batch_multi_row_policy"]
+        == metadata["melix.native_mtp.receipt.batch_multi_row_policy"]
+    )
     assert receipt["hardware_gate"] == metadata["melix.native_mtp.receipt.hardware_gate"]
+    assert receipt["hardware_policy"] == metadata["melix.native_mtp.receipt.hardware_policy"]
+    assert (
+        receipt["hardware_policy_reason"]
+        == metadata["melix.native_mtp.receipt.hardware_policy_reason"]
+    )
+    assert (
+        receipt["hardware_policy_source"]
+        == metadata["melix.native_mtp.receipt.hardware_policy_source"]
+    )
+    assert receipt["operator_override"] == metadata["melix.native_mtp.receipt.operator_override"]
     assert receipt["request_gate"] == metadata["melix.native_mtp.receipt.request_gate"]
     assert receipt["runtime_scope"] == metadata["melix.native_mtp.receipt.runtime_scope"]
     assert str(receipt["weights_present"]).lower() == metadata["melix.native_mtp.receipt.weights_present"]
@@ -75,6 +101,18 @@ def _native_mtp_receipt(metadata: dict[str, str]) -> dict[str, object]:
         == metadata["melix.native_mtp.receipt.target_decode_started"]
     )
     return receipt
+
+
+def test_batch_generator_declares_batch_state_policy() -> None:
+    from worker.runtime.native_mtp import batch_generator
+
+    assert batch_generator.batch_state_policy_receipt() == {
+        "batch_shape": "singleton_only",
+        "batch_state_policy": "singleton_timeline_safe",
+        "batch_filter_policy": "preserve_when_singleton_uid_matches",
+        "batch_extend_policy": "reconcile_then_drop",
+        "batch_multi_row_policy": "multi_row_decode_unsupported",
+    }
 
 
 def test_registry_accepts_qwen_native_head_shape(tmp_path: Path) -> None:
@@ -97,6 +135,7 @@ def test_registry_accepts_qwen_native_head_shape(tmp_path: Path) -> None:
     decision = resolve_native_mtp_capability(
         model_dir,
         metadata={"melix.native_mtp.enabled": "true"},
+        hardware_profile=SimpleNamespace(),
     )
     metadata = decision.to_metadata(patch_applied=True, active=True)
 
@@ -113,7 +152,7 @@ def test_registry_accepts_qwen_native_head_shape(tmp_path: Path) -> None:
     assert metadata["melix.native_mtp.source"] == "native_head"
     assert metadata["melix.native_mtp.head_count"] == "1"
     assert metadata["melix.native_mtp.batch_shape"] == "singleton_only"
-    assert metadata["melix.native_mtp.hardware_gate"] == "not_evaluated"
+    assert metadata["melix.native_mtp.hardware_gate"] == "admitted"
     assert metadata["melix.native_mtp.resolution"] == "accepted"
     assert metadata["melix.native_mtp.refusal_reason"] == ""
     assert metadata["melix.native_mtp.receipt.schema"] == "melix.native_mtp.capability.v1"
@@ -139,8 +178,15 @@ def test_registry_accepts_qwen_native_head_shape(tmp_path: Path) -> None:
         "depth_source": "native_head",
         "cache_shape": "qwen3_5_native_mtp",
         "batch_shape": "singleton_only",
-        "batch_state_policy": "drop_on_extend_or_filter",
-        "hardware_gate": "not_evaluated",
+        "batch_state_policy": "singleton_timeline_safe",
+        "batch_filter_policy": "preserve_when_singleton_uid_matches",
+        "batch_extend_policy": "reconcile_then_drop",
+        "batch_multi_row_policy": "multi_row_decode_unsupported",
+        "hardware_gate": "admitted",
+        "hardware_policy": "auto",
+        "hardware_policy_reason": "unclassified_device",
+        "hardware_policy_source": "auto",
+        "operator_override": "",
         "request_gate": "native_mtp_enabled",
         "runtime_scope": "text_only_singleton",
         "patch_applied": True,
@@ -168,6 +214,7 @@ def test_registry_refuses_assistant_sidecar_shape(tmp_path: Path) -> None:
             "melix.speculative.role": "assistant",
             "melix.speculative.kind": "mtp",
         },
+        hardware_profile=SimpleNamespace(),
     )
     metadata = decision.to_metadata(patch_applied=False, active=False)
 
@@ -199,7 +246,14 @@ def test_registry_refuses_assistant_sidecar_shape(tmp_path: Path) -> None:
         "cache_shape": "none",
         "batch_shape": "unsupported",
         "batch_state_policy": "none",
-        "hardware_gate": "not_evaluated",
+        "batch_filter_policy": "none",
+        "batch_extend_policy": "none",
+        "batch_multi_row_policy": "none",
+        "hardware_gate": "admitted",
+        "hardware_policy": "auto",
+        "hardware_policy_reason": "unclassified_device",
+        "hardware_policy_source": "auto",
+        "operator_override": "",
         "request_gate": "assistant_sidecar_refused",
         "runtime_scope": "none",
         "patch_applied": False,
@@ -264,6 +318,175 @@ def test_registry_reports_missing_native_head_weights(tmp_path: Path) -> None:
     assert decision.refusal_reason == "missing_mtp_weights"
     assert metadata["melix.native_mtp.reason"] == "missing_mtp_weights"
     assert metadata["melix.native_mtp.receipt.request_gate"] == "missing_native_head_weights"
+
+
+def test_registry_recognizes_deepseek_v3_nextn_and_fails_closed_until_patch_exists(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "deepseek-v3-nextn"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "deepseek_v3",
+            "num_nextn_predict_layers": 2,
+        },
+        weight_map={
+            "model.layers.0.shared_head.head.weight": "nextn.safetensors",
+            "model.layers.0.eh_proj.weight": "nextn.safetensors",
+            "model.embed_tokens.weight": "model.safetensors",
+        },
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+    receipt = _native_mtp_receipt(metadata)
+
+    assert decision.compatible is True
+    assert decision.patchable is False
+    assert decision.family == "deepseek_v3_nextn"
+    assert decision.source == "native_head"
+    assert decision.head_count == 2
+    assert decision.weights_present is True
+    assert decision.weight_count == 2
+    assert decision.resolution == "refused"
+    assert decision.refusal_reason == "patch_unsupported"
+    assert metadata["melix.native_mtp.reason"] == "patch_unsupported"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "patch_unsupported"
+    assert receipt["family"] == "deepseek_v3_nextn"
+    assert receipt["cache_shape"] == "deepseek_v3_nextn_native_mtp"
+    assert receipt["effective_depth"] == 0
+    assert receipt["draft_supported"] is False
+
+
+def test_registry_reports_missing_deepseek_nextn_weights(tmp_path: Path) -> None:
+    model_dir = tmp_path / "deepseek-v3-missing-nextn"
+    _write_model(
+        model_dir,
+        config={
+            "model_type": "deepseek_v3",
+            "num_nextn_predict_layers": 2,
+        },
+        weight_map={"model.embed_tokens.weight": "model.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+
+    assert decision.compatible is True
+    assert decision.patchable is False
+    assert decision.weights_present is False
+    assert decision.refusal_reason == "missing_mtp_weights"
+    assert metadata["melix.native_mtp.reason"] == "missing_mtp_weights"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "missing_native_head_weights"
+
+
+def test_registry_device_policy_auto_disables_lower_end_m2(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-m2"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+        hardware_profile=SimpleNamespace(
+            system="Darwin",
+            machine="arm64",
+            chip_family="Apple M2 Pro",
+            model_identifier="Mac14,7",
+        ),
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+    receipt = _native_mtp_receipt(metadata)
+
+    assert decision.compatible is True
+    assert decision.patchable is True
+    assert decision.refusal_reason == "device_policy_disabled"
+    assert metadata["melix.native_mtp.hardware_gate"] == "disabled"
+    assert metadata["melix.native_mtp.reason"] == "device_policy_disabled"
+    assert metadata["melix.native_mtp.receipt.request_gate"] == "device_policy_disabled"
+    assert receipt["hardware_policy"] == "auto"
+    assert receipt["hardware_policy_reason"] == "m1_m2_compute_bound"
+    assert receipt["hardware_policy_source"] == "auto"
+
+
+def test_registry_device_policy_force_on_overrides_lower_end_m2(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-force-on"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.native_mtp.device_policy": "force_on",
+        },
+        hardware_profile=SimpleNamespace(
+            system="Darwin",
+            machine="arm64",
+            chip_family="Apple M2 Pro",
+            model_identifier="Mac14,7",
+        ),
+    )
+    metadata = decision.to_metadata(patch_applied=True, active=True)
+    receipt = _native_mtp_receipt(metadata)
+
+    assert metadata["melix.native_mtp.hardware_gate"] == "admitted"
+    assert metadata["melix.native_mtp.reason"] == ""
+    assert receipt["hardware_policy"] == "force_on"
+    assert receipt["hardware_policy_reason"] == "operator_force_on"
+    assert receipt["hardware_policy_source"] == "operator"
+    assert receipt["operator_override"] == "force_on"
+
+
+def test_registry_device_policy_force_off_refuses_even_capable_qwen(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-force-off"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.native_mtp.device_policy": "force_off",
+        },
+        hardware_profile=SimpleNamespace(
+            system="Darwin",
+            machine="arm64",
+            chip_family="Apple M4 Max",
+            model_identifier="Mac16,5",
+        ),
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+    receipt = _native_mtp_receipt(metadata)
+
+    assert decision.refusal_reason == "device_policy_disabled"
+    assert metadata["melix.native_mtp.hardware_gate"] == "disabled"
+    assert metadata["melix.native_mtp.reason"] == "device_policy_disabled"
+    assert receipt["hardware_policy"] == "force_off"
+    assert receipt["hardware_policy_reason"] == "operator_force_off"
+    assert receipt["hardware_policy_source"] == "operator"
+    assert receipt["operator_override"] == "force_off"
 
 
 def test_registry_reports_unsupported_enabled_model(tmp_path: Path) -> None:
@@ -470,6 +693,35 @@ def test_text_preload_routes_through_registry_and_refuses_sidecar(
 
     assert metadata["melix.native_mtp.resolution"] == "refused"
     assert metadata["melix.native_mtp.reason"] == "assistant_sidecar"
+    assert ("patch", True) not in calls
+    assert calls[-1] == ("active", False)
+
+
+def test_text_preload_refuses_deepseek_nextn_without_runtime_patch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "text-deepseek-nextn"
+    _write_model(
+        model_dir,
+        config={"model_type": "deepseek_v3", "num_nextn_predict_layers": 2},
+        weight_map={
+            "model.layers.0.shared_head.head.weight": "nextn.safetensors",
+            "model.layers.0.eh_proj.weight": "nextn.safetensors",
+        },
+    )
+    calls: list[tuple[str, bool]] = []
+    _install_fake_native_mtp(monkeypatch, calls)
+
+    metadata = maybe_apply_native_mtp_text_preload_patches(
+        str(model_dir),
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert metadata["melix.native_mtp.compatible"] == "true"
+    assert metadata["melix.native_mtp.family"] == "deepseek_v3_nextn"
+    assert metadata["melix.native_mtp.resolution"] == "refused"
+    assert metadata["melix.native_mtp.reason"] == "patch_unsupported"
     assert ("patch", True) not in calls
     assert calls[-1] == ("active", False)
 

--- a/services/mlx-worker-python/tests/test_native_mtp_capability.py
+++ b/services/mlx-worker-python/tests/test_native_mtp_capability.py
@@ -310,6 +310,7 @@ def test_registry_reports_missing_native_head_weights(tmp_path: Path) -> None:
     decision = resolve_native_mtp_capability(
         model_dir,
         metadata={"melix.native_mtp.enabled": "true"},
+        hardware_profile=SimpleNamespace(),
     )
     metadata = decision.to_metadata(patch_applied=True, active=False)
 
@@ -536,6 +537,7 @@ def test_registry_reports_patch_failure_for_native_head(tmp_path: Path) -> None:
     decision = resolve_native_mtp_capability(
         model_dir,
         metadata={"melix.native_mtp.enabled": "true"},
+        hardware_profile=SimpleNamespace(),
     )
     metadata = decision.to_metadata(patch_applied=False, active=False)
 
@@ -660,7 +662,10 @@ def test_text_preload_routes_through_registry_receipt(
 
     metadata = maybe_apply_native_mtp_text_preload_patches(
         str(model_dir),
-        metadata={"melix.native_mtp.enabled": "true"},
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.native_mtp.device_policy": "force_on",
+        },
     )
 
     assert metadata["melix.native_mtp.active"] == "true"
@@ -750,7 +755,10 @@ def test_vlm_preload_routes_through_registry_receipt(
 
     metadata = maybe_apply_native_mtp_preload_patches(
         str(model_dir),
-        metadata={"melix.native_mtp.enabled": "true"},
+        metadata={
+            "melix.native_mtp.enabled": "true",
+            "melix.native_mtp.device_policy": "force_on",
+        },
     )
 
     assert metadata["melix.native_mtp.active"] == "true"

--- a/services/mlx-worker-python/tests/test_native_mtp_capability.py
+++ b/services/mlx-worker-python/tests/test_native_mtp_capability.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from worker.runtime.native_mtp import capability as native_mtp_capability
 from worker.runtime.mlx_text_runtime import maybe_apply_native_mtp_text_preload_patches
 from worker.runtime.mlx_vlm_runtime import maybe_apply_native_mtp_preload_patches
 from worker.runtime.native_mtp.capability import (
@@ -490,6 +492,165 @@ def test_registry_device_policy_force_off_refuses_even_capable_qwen(
     assert receipt["operator_override"] == "force_off"
 
 
+def test_registry_device_policy_auto_admits_supported_apple_silicon(
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-m4"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+        hardware_profile=SimpleNamespace(
+            system="Darwin",
+            machine="arm64",
+            chip_family="Apple M4 Max",
+            model_identifier="Mac16,5",
+        ),
+    )
+    metadata = decision.to_metadata(patch_applied=True, active=True)
+    receipt = _native_mtp_receipt(metadata)
+
+    assert decision.refusal_reason == ""
+    assert metadata["melix.native_mtp.hardware_gate"] == "admitted"
+    assert metadata["melix.native_mtp.reason"] == ""
+    assert receipt["hardware_policy"] == "auto"
+    assert receipt["hardware_policy_reason"] == "supported_apple_silicon"
+    assert receipt["hardware_policy_source"] == "auto"
+
+
+def test_registry_detects_darwin_arm64_hardware_once_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-detected-m4"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+    calls: list[str] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+    ) -> SimpleNamespace:
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        assert timeout == 5
+        calls.append(command[-1])
+        stdout = (
+            "Apple M4 Max\n"
+            if command[-1] == "machdep.cpu.brand_string"
+            else "Mac16,5\n"
+        )
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(native_mtp_capability, "_CACHED_HARDWARE_PROFILE", None)
+    monkeypatch.setattr(native_mtp_capability.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(native_mtp_capability.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(native_mtp_capability.subprocess, "run", fake_run)
+
+    first = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    second = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert first.hardware_gate == "admitted"
+    assert first.hardware_policy_reason == "supported_apple_silicon"
+    assert second.hardware_gate == "admitted"
+    assert calls == ["machdep.cpu.brand_string", "hw.model"]
+
+
+def test_registry_detects_non_darwin_hardware_once_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-linux"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+    calls = 0
+
+    def fake_run(*args: object, **kwargs: object) -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(native_mtp_capability, "_CACHED_HARDWARE_PROFILE", None)
+    monkeypatch.setattr(native_mtp_capability.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(native_mtp_capability.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(native_mtp_capability.subprocess, "run", fake_run)
+
+    first = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    second = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+
+    assert first.hardware_gate == "admitted"
+    assert first.hardware_policy_reason == "unclassified_device"
+    assert second.hardware_gate == "admitted"
+    assert calls == 0
+
+
+def test_registry_fails_closed_when_darwin_arm64_hardware_probe_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "qwen-native-head-timeout"
+    _write_model(
+        model_dir,
+        config={"model_type": "qwen3_5_text", "mtp_num_hidden_layers": 1},
+        weight_map={"mtp.fc.weight": "mtp.safetensors"},
+    )
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+    ) -> SimpleNamespace:
+        raise subprocess.TimeoutExpired(command, timeout)
+
+    monkeypatch.setattr(native_mtp_capability, "_CACHED_HARDWARE_PROFILE", None)
+    monkeypatch.setattr(native_mtp_capability.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(native_mtp_capability.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(native_mtp_capability.subprocess, "run", fake_run)
+
+    decision = resolve_native_mtp_capability(
+        model_dir,
+        metadata={"melix.native_mtp.enabled": "true"},
+    )
+    metadata = decision.to_metadata(patch_applied=False, active=False)
+    receipt = _native_mtp_receipt(metadata)
+
+    assert decision.refusal_reason == "device_policy_disabled"
+    assert metadata["melix.native_mtp.hardware_gate"] == "disabled"
+    assert metadata["melix.native_mtp.reason"] == "device_policy_disabled"
+    assert receipt["hardware_policy_reason"] == "unclassified_apple_silicon"
+    assert receipt["hardware_policy_source"] == "auto"
+
+
 def test_registry_reports_unsupported_enabled_model(tmp_path: Path) -> None:
     model_dir = tmp_path / "unsupported"
     _write_model(
@@ -640,11 +801,14 @@ def test_registry_receipt_supports_empty_fallback_reason() -> None:
     )
 
     metadata = decision.to_metadata(patch_applied=False, active=False, reason="")
+    fallback_metadata = decision.to_metadata(patch_applied=False, active=False)
 
     assert metadata["melix.native_mtp.reason"] == ""
     assert metadata["melix.native_mtp.resolution"] == "fallback"
     assert metadata["melix.native_mtp.receipt.status"] == "fallback"
     assert metadata["melix.native_mtp.receipt.request_gate"] == "not_admitted"
+    assert fallback_metadata["melix.native_mtp.reason"] == ""
+    assert fallback_metadata["melix.native_mtp.receipt.status"] == "fallback"
 
 
 def test_text_preload_routes_through_registry_receipt(

--- a/services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py
@@ -17,9 +17,10 @@ sequences in continuous batching. We patch:
   MTP-head forward at the bonus position (accept) or confirmed position
   (reject), refilling the queue from the verify outputs.
 
-- ``GenerationBatch.extend`` / ``filter`` — drop MTP state whenever continuous
-  batching reshapes ownership. MTP state belongs to one uid in one singleton
-  timeline; it must not survive standard batched decoding.
+- ``GenerationBatch.extend`` / ``filter`` — preserve MTP state only while the
+  same uid remains a singleton timeline. ``extend`` reconciles to a standard
+  resumable cache then drops state before multi-row decode; ``filter`` keeps
+  state when it filters back to the same singleton uid and drops otherwise.
 
 The throughput math (greedy, accept rate p):
   - Cost per *cycle*: 1× backbone (2-token verify) + 1× MTP head ≈ 1.15
@@ -77,6 +78,14 @@ from typing import Any, Deque, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 _PATCHED = False
+
+_BATCH_STATE_POLICY_RECEIPT = {
+    "batch_shape": "singleton_only",
+    "batch_state_policy": "singleton_timeline_safe",
+    "batch_filter_policy": "preserve_when_singleton_uid_matches",
+    "batch_extend_policy": "reconcile_then_drop",
+    "batch_multi_row_policy": "multi_row_decode_unsupported",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -158,6 +167,11 @@ def apply() -> bool:
     GenerationBatch._melix_mtp_patched = True
     _PATCHED = True
     return True
+
+
+def batch_state_policy_receipt() -> dict[str, str]:
+    """Return the batch-state contract implemented by this patch."""
+    return dict(_BATCH_STATE_POLICY_RECEIPT)
 
 
 def _model_has_mtp_module(model: Any) -> bool:

--- a/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
@@ -12,6 +12,7 @@ NATIVE_MTP_ENABLED_EXT_KEY = "melix.native_mtp.enabled"
 NATIVE_MTP_DEVICE_POLICY_EXT_KEY = "melix.native_mtp.device_policy"
 NATIVE_MTP_RECEIPT_SCHEMA = "melix.native_mtp.capability.v1"
 NATIVE_MTP_RECEIPT_JSON_KEY = "melix.native_mtp.receipt_json"
+_SYSCTL_TIMEOUT_SECONDS = 5
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,6 +21,9 @@ class NativeMTPHardwareProfile:
     machine: str = ""
     chip_family: str = ""
     model_identifier: str = ""
+
+
+_CACHED_HARDWARE_PROFILE: NativeMTPHardwareProfile | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -271,12 +275,12 @@ class NativeMTPCapabilityDecision:
             draft_supported=bool(self.compatible and self.source == "native_head" and active),
             effective_depth=self.head_count if active else 0,
             depth_source=self.source if active else "none",
-            cache_shape=self._cache_shape(active=active),
+            cache_shape=self._cache_shape(),
             batch_shape=self.batch_shape,
-            batch_state_policy=self._batch_state_policy(active=active),
-            batch_filter_policy=self._batch_filter_policy(active=active),
-            batch_extend_policy=self._batch_extend_policy(active=active),
-            batch_multi_row_policy=self._batch_multi_row_policy(active=active),
+            batch_state_policy=self._batch_state_policy(),
+            batch_filter_policy=self._batch_filter_policy(),
+            batch_extend_policy=self._batch_extend_policy(),
+            batch_multi_row_policy=self._batch_multi_row_policy(),
             hardware_gate=self.hardware_gate,
             hardware_policy=self.hardware_policy,
             hardware_policy_reason=self.hardware_policy_reason,
@@ -299,7 +303,7 @@ class NativeMTPCapabilityDecision:
             return self.refusal_reason
         if self.patchable and not patch_applied:
             return "patch_failed"
-        return self.refusal_reason
+        return ""
 
     def _resolution(self, *, active: bool, reason: str) -> str:
         if active:
@@ -336,27 +340,27 @@ class NativeMTPCapabilityDecision:
             return reason
         return "not_admitted"
 
-    def _cache_shape(self, *, active: bool) -> str:
+    def _cache_shape(self) -> str:
         if self.source == "native_head" and self.compatible:
             return self.cache_shape
         return "none"
 
-    def _batch_state_policy(self, *, active: bool) -> str:
+    def _batch_state_policy(self) -> str:
         if self.compatible and self.batch_shape == "singleton_only":
             return self.batch_state_policy
         return "none"
 
-    def _batch_filter_policy(self, *, active: bool) -> str:
+    def _batch_filter_policy(self) -> str:
         if self.compatible and self.batch_shape == "singleton_only":
             return self.batch_filter_policy
         return "none"
 
-    def _batch_extend_policy(self, *, active: bool) -> str:
+    def _batch_extend_policy(self) -> str:
         if self.compatible and self.batch_shape == "singleton_only":
             return self.batch_extend_policy
         return "none"
 
-    def _batch_multi_row_policy(self, *, active: bool) -> str:
+    def _batch_multi_row_policy(self) -> str:
         if self.compatible and self.batch_shape == "singleton_only":
             return self.batch_multi_row_policy
         return "none"
@@ -629,6 +633,13 @@ def _resolve_native_mtp_hardware_policy(
             reason="supported_apple_silicon",
             source="auto",
         )
+    if _is_unclassified_apple_silicon(profile):
+        return _NativeMTPHardwareDecision(
+            gate="disabled",
+            policy="auto",
+            reason="unclassified_apple_silicon",
+            source="auto",
+        )
     return _NativeMTPHardwareDecision(
         gate="admitted",
         policy="auto",
@@ -662,16 +673,22 @@ def _coerce_hardware_profile(profile: Any | None) -> NativeMTPHardwareProfile | 
 
 
 def _detect_native_mtp_hardware_profile() -> NativeMTPHardwareProfile:
+    global _CACHED_HARDWARE_PROFILE
+    if _CACHED_HARDWARE_PROFILE is not None:
+        return _CACHED_HARDWARE_PROFILE
+
     system = platform.system()
     machine = platform.machine()
     if system != "Darwin" or machine not in {"arm64", "aarch64"}:
-        return NativeMTPHardwareProfile(system=system, machine=machine)
-    return NativeMTPHardwareProfile(
+        _CACHED_HARDWARE_PROFILE = NativeMTPHardwareProfile(system=system, machine=machine)
+        return _CACHED_HARDWARE_PROFILE
+    _CACHED_HARDWARE_PROFILE = NativeMTPHardwareProfile(
         system=system,
         machine=machine,
         chip_family=_sysctl_string("machdep.cpu.brand_string"),
         model_identifier=_sysctl_string("hw.model"),
     )
+    return _CACHED_HARDWARE_PROFILE
 
 
 def _sysctl_string(name: str) -> str:
@@ -681,7 +698,7 @@ def _sysctl_string(name: str) -> str:
             check=False,
             capture_output=True,
             text=True,
-            timeout=0.1,
+            timeout=_SYSCTL_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.SubprocessError):
         return ""
@@ -706,6 +723,12 @@ def _is_high_end_apple_silicon(profile: NativeMTPHardwareProfile) -> bool:
     if "m3" in chip or "m4" in chip:
         return True
     return ("m1" in chip or "m2" in chip) and ("max" in chip or "ultra" in chip)
+
+
+def _is_unclassified_apple_silicon(profile: NativeMTPHardwareProfile) -> bool:
+    if profile.system != "Darwin":
+        return False
+    return profile.machine in {"arm64", "aarch64"} and not profile.chip_family
 
 
 def _native_head_refusal_reason(

--- a/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/capability.py
@@ -2,15 +2,82 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
+import platform
 from pathlib import Path
+import subprocess
 from typing import Any, Mapping
 
 
 NATIVE_MTP_ENABLED_EXT_KEY = "melix.native_mtp.enabled"
+NATIVE_MTP_DEVICE_POLICY_EXT_KEY = "melix.native_mtp.device_policy"
 NATIVE_MTP_RECEIPT_SCHEMA = "melix.native_mtp.capability.v1"
 NATIVE_MTP_RECEIPT_JSON_KEY = "melix.native_mtp.receipt_json"
-_QWEN_NATIVE_MTP_MODEL_TYPES = frozenset(("qwen3_5", "qwen3_5_text"))
-_MTP_WEIGHT_PREFIXES = ("language_model.mtp.", "mtp.")
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPHardwareProfile:
+    system: str = ""
+    machine: str = ""
+    chip_family: str = ""
+    model_identifier: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class _NativeMTPHardwareDecision:
+    gate: str
+    policy: str
+    reason: str
+    source: str
+    operator_override: str = ""
+
+    @property
+    def admitted(self) -> bool:
+        return self.gate == "admitted"
+
+
+@dataclass(frozen=True, slots=True)
+class _NativeMTPCapabilitySpec:
+    family: str
+    model_types: frozenset[str]
+    layer_count_keys: tuple[str, ...]
+    text_layer_count_keys: tuple[str, ...]
+    weight_prefixes: tuple[str, ...]
+    weight_substrings: tuple[str, ...]
+    cache_shape: str
+    patchable: bool
+    batch_shape: str = "singleton_only"
+    batch_state_policy: str = "singleton_timeline_safe"
+    batch_filter_policy: str = "preserve_when_singleton_uid_matches"
+    batch_extend_policy: str = "reconcile_then_drop"
+    batch_multi_row_policy: str = "multi_row_decode_unsupported"
+    source: str = "native_head"
+    runtime_scope: str = "text_only_singleton"
+
+
+_QWEN_NATIVE_MTP_SPEC = _NativeMTPCapabilitySpec(
+    family="qwen3_5",
+    model_types=frozenset(("qwen3_5", "qwen3_5_text")),
+    layer_count_keys=("mtp_num_hidden_layers",),
+    text_layer_count_keys=("mtp_num_hidden_layers",),
+    weight_prefixes=("language_model.mtp.", "mtp."),
+    weight_substrings=(),
+    cache_shape="qwen3_5_native_mtp",
+    patchable=True,
+)
+_DEEPSEEK_V3_NEXTN_MTP_SPEC = _NativeMTPCapabilitySpec(
+    family="deepseek_v3_nextn",
+    model_types=frozenset(("deepseek_v3", "deepseek-v3", "deepseek_v3_text")),
+    layer_count_keys=("num_nextn_predict_layers",),
+    text_layer_count_keys=("num_nextn_predict_layers",),
+    weight_prefixes=(),
+    weight_substrings=(".shared_head.", ".eh_proj."),
+    cache_shape="deepseek_v3_nextn_native_mtp",
+    patchable=False,
+)
+_NATIVE_MTP_CAPABILITY_SPECS = (
+    _QWEN_NATIVE_MTP_SPEC,
+    _DEEPSEEK_V3_NEXTN_MTP_SPEC,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,7 +98,14 @@ class NativeMTPCapabilityReceipt:
     cache_shape: str
     batch_shape: str
     batch_state_policy: str
+    batch_filter_policy: str
+    batch_extend_policy: str
+    batch_multi_row_policy: str
     hardware_gate: str
+    hardware_policy: str
+    hardware_policy_reason: str
+    hardware_policy_source: str
+    operator_override: str
     request_gate: str
     runtime_scope: str
     patch_applied: bool
@@ -57,7 +131,14 @@ class NativeMTPCapabilityReceipt:
             "cache_shape": self.cache_shape,
             "batch_shape": self.batch_shape,
             "batch_state_policy": self.batch_state_policy,
+            "batch_filter_policy": self.batch_filter_policy,
+            "batch_extend_policy": self.batch_extend_policy,
+            "batch_multi_row_policy": self.batch_multi_row_policy,
             "hardware_gate": self.hardware_gate,
+            "hardware_policy": self.hardware_policy,
+            "hardware_policy_reason": self.hardware_policy_reason,
+            "hardware_policy_source": self.hardware_policy_source,
+            "operator_override": self.operator_override,
             "request_gate": self.request_gate,
             "runtime_scope": self.runtime_scope,
             "patch_applied": self.patch_applied,
@@ -83,7 +164,15 @@ class NativeMTPCapabilityReceipt:
             "melix.native_mtp.receipt.effective_depth": str(self.effective_depth),
             "melix.native_mtp.receipt.depth_source": self.depth_source,
             "melix.native_mtp.receipt.batch_shape": self.batch_shape,
+            "melix.native_mtp.receipt.batch_state_policy": self.batch_state_policy,
+            "melix.native_mtp.receipt.batch_filter_policy": self.batch_filter_policy,
+            "melix.native_mtp.receipt.batch_extend_policy": self.batch_extend_policy,
+            "melix.native_mtp.receipt.batch_multi_row_policy": self.batch_multi_row_policy,
             "melix.native_mtp.receipt.hardware_gate": self.hardware_gate,
+            "melix.native_mtp.receipt.hardware_policy": self.hardware_policy,
+            "melix.native_mtp.receipt.hardware_policy_reason": self.hardware_policy_reason,
+            "melix.native_mtp.receipt.hardware_policy_source": self.hardware_policy_source,
+            "melix.native_mtp.receipt.operator_override": self.operator_override,
             "melix.native_mtp.receipt.request_gate": self.request_gate,
             "melix.native_mtp.receipt.runtime_scope": self.runtime_scope,
             "melix.native_mtp.receipt.draft_loaded": _bool_string(self.draft_loaded),
@@ -107,6 +196,16 @@ class NativeMTPCapabilityDecision:
     hardware_gate: str
     resolution: str
     refusal_reason: str
+    cache_shape: str = "none"
+    batch_state_policy: str = "none"
+    batch_filter_policy: str = "none"
+    batch_extend_policy: str = "none"
+    batch_multi_row_policy: str = "none"
+    hardware_policy: str = "auto"
+    hardware_policy_reason: str = "unclassified_device"
+    hardware_policy_source: str = "auto"
+    operator_override: str = ""
+    runtime_scope: str = "text_only_singleton"
 
     def to_metadata(
         self,
@@ -133,7 +232,15 @@ class NativeMTPCapabilityDecision:
             "melix.native_mtp.source": self.source,
             "melix.native_mtp.head_count": str(self.head_count),
             "melix.native_mtp.batch_shape": self.batch_shape,
+            "melix.native_mtp.batch_state_policy": self.batch_state_policy,
+            "melix.native_mtp.batch_filter_policy": self.batch_filter_policy,
+            "melix.native_mtp.batch_extend_policy": self.batch_extend_policy,
+            "melix.native_mtp.batch_multi_row_policy": self.batch_multi_row_policy,
             "melix.native_mtp.hardware_gate": self.hardware_gate,
+            "melix.native_mtp.hardware_policy": self.hardware_policy,
+            "melix.native_mtp.hardware_policy_reason": self.hardware_policy_reason,
+            "melix.native_mtp.hardware_policy_source": self.hardware_policy_source,
+            "melix.native_mtp.operator_override": self.operator_override,
             "melix.native_mtp.resolution": self._resolution(active=active, reason=final_reason),
             "melix.native_mtp.refusal_reason": "" if active else final_reason,
             "melix.native_mtp.receipt.enabled": _bool_string(self.enabled),
@@ -167,9 +274,16 @@ class NativeMTPCapabilityDecision:
             cache_shape=self._cache_shape(active=active),
             batch_shape=self.batch_shape,
             batch_state_policy=self._batch_state_policy(active=active),
+            batch_filter_policy=self._batch_filter_policy(active=active),
+            batch_extend_policy=self._batch_extend_policy(active=active),
+            batch_multi_row_policy=self._batch_multi_row_policy(active=active),
             hardware_gate=self.hardware_gate,
+            hardware_policy=self.hardware_policy,
+            hardware_policy_reason=self.hardware_policy_reason,
+            hardware_policy_source=self.hardware_policy_source,
+            operator_override=self.operator_override,
             request_gate=self._request_gate(active=active, reason=final_reason),
-            runtime_scope="text_only_singleton" if active else "none",
+            runtime_scope=self.runtime_scope if active else "none",
             patch_applied=bool(patch_applied),
             draft_loaded=bool(active),
             target_decode_started=False,
@@ -181,6 +295,8 @@ class NativeMTPCapabilityDecision:
             return str(override or "")
         if active:
             return ""
+        if self.refusal_reason:
+            return self.refusal_reason
         if self.patchable and not patch_applied:
             return "patch_failed"
         return self.refusal_reason
@@ -212,18 +328,37 @@ class NativeMTPCapabilityDecision:
             return "assistant_sidecar_refused"
         if reason == "missing_mtp_weights":
             return "missing_native_head_weights"
+        if reason == "device_policy_disabled":
+            return "device_policy_disabled"
+        if reason == "patch_unsupported":
+            return "patch_unsupported"
         if reason in {"unsupported_model", "patch_failed", "patch_error"}:
             return reason
         return "not_admitted"
 
     def _cache_shape(self, *, active: bool) -> str:
-        if active and self.source == "native_head" and self.family == "qwen3_5":
-            return "qwen3_5_native_mtp"
+        if self.source == "native_head" and self.compatible:
+            return self.cache_shape
         return "none"
 
     def _batch_state_policy(self, *, active: bool) -> str:
-        if active and self.batch_shape == "singleton_only":
-            return "drop_on_extend_or_filter"
+        if self.compatible and self.batch_shape == "singleton_only":
+            return self.batch_state_policy
+        return "none"
+
+    def _batch_filter_policy(self, *, active: bool) -> str:
+        if self.compatible and self.batch_shape == "singleton_only":
+            return self.batch_filter_policy
+        return "none"
+
+    def _batch_extend_policy(self, *, active: bool) -> str:
+        if self.compatible and self.batch_shape == "singleton_only":
+            return self.batch_extend_policy
+        return "none"
+
+    def _batch_multi_row_policy(self, *, active: bool) -> str:
+        if self.compatible and self.batch_shape == "singleton_only":
+            return self.batch_multi_row_policy
         return "none"
 
 
@@ -231,13 +366,22 @@ def resolve_native_mtp_capability(
     model_path: str | Path,
     *,
     metadata: Mapping[str, str],
+    hardware_profile: Any | None = None,
 ) -> NativeMTPCapabilityDecision:
     model_dir = Path(model_path)
     config_payload = _load_json_payload(model_dir / "config.json")
     model_type = _native_mtp_model_type(config_payload)
-    head_count = _native_mtp_layer_count(config_payload)
-    weights_present, weight_count = _native_mtp_weight_presence(model_dir)
+    weight_map = _native_mtp_weight_map(model_dir)
+    spec, head_count = _resolve_native_mtp_spec(
+        model_type=model_type,
+        config_payload=config_payload,
+    )
+    weights_present, weight_count = _native_mtp_weight_presence(weight_map, spec=spec)
     enabled = _truthy_string(metadata.get(NATIVE_MTP_ENABLED_EXT_KEY, ""))
+    hardware = _resolve_native_mtp_hardware_policy(
+        metadata=metadata,
+        hardware_profile=hardware_profile,
+    )
 
     if _is_assistant_sidecar(metadata=metadata, config_payload=config_payload, model_type=model_type):
         return NativeMTPCapabilityDecision(
@@ -250,29 +394,54 @@ def resolve_native_mtp_capability(
             source="assistant_sidecar",
             head_count=head_count,
             batch_shape="unsupported",
-            hardware_gate="not_evaluated",
+            hardware_gate=hardware.gate,
             resolution="refused",
             refusal_reason="assistant_sidecar" if enabled else "disabled",
+            hardware_policy=hardware.policy,
+            hardware_policy_reason=hardware.reason,
+            hardware_policy_source=hardware.source,
+            operator_override=hardware.operator_override,
+            runtime_scope="none",
         )
 
-    compatible = model_type in _QWEN_NATIVE_MTP_MODEL_TYPES and head_count > 0
-    if compatible:
-        refusal_reason = _native_head_refusal_reason(enabled=enabled, weights_present=weights_present)
+    if spec is not None:
+        refusal_reason = _native_head_refusal_reason(
+            enabled=enabled,
+            weights_present=weights_present,
+            patchable=spec.patchable,
+            hardware_admitted=hardware.admitted,
+        )
+        resolution = (
+            "accepted"
+            if enabled and weights_present and spec.patchable and hardware.admitted
+            else "legacy_only" if not enabled else "refused"
+        )
         return NativeMTPCapabilityDecision(
             enabled=enabled,
             compatible=True,
-            patchable=True,
+            patchable=spec.patchable,
             weights_present=weights_present,
             weight_count=weight_count,
-            family="qwen3_5",
-            source="native_head",
+            family=spec.family,
+            source=spec.source,
             head_count=head_count,
-            batch_shape="singleton_only",
-            hardware_gate="not_evaluated",
-            resolution="accepted" if enabled and weights_present else "legacy_only" if not enabled else "refused",
+            batch_shape=spec.batch_shape,
+            hardware_gate=hardware.gate,
+            resolution=resolution,
             refusal_reason=refusal_reason,
+            cache_shape=spec.cache_shape,
+            batch_state_policy=spec.batch_state_policy,
+            batch_filter_policy=spec.batch_filter_policy,
+            batch_extend_policy=spec.batch_extend_policy,
+            batch_multi_row_policy=spec.batch_multi_row_policy,
+            hardware_policy=hardware.policy,
+            hardware_policy_reason=hardware.reason,
+            hardware_policy_source=hardware.source,
+            operator_override=hardware.operator_override,
+            runtime_scope=spec.runtime_scope,
         )
 
+    head_count = _native_mtp_layer_count(config_payload)
     return NativeMTPCapabilityDecision(
         enabled=enabled,
         compatible=False,
@@ -283,9 +452,14 @@ def resolve_native_mtp_capability(
         source="none",
         head_count=head_count,
         batch_shape="unsupported",
-        hardware_gate="not_evaluated",
+        hardware_gate=hardware.gate,
         resolution="refused" if enabled else "legacy_only",
         refusal_reason="unsupported_model" if enabled else "disabled",
+        hardware_policy=hardware.policy,
+        hardware_policy_reason=hardware.reason,
+        hardware_policy_source=hardware.source,
+        operator_override=hardware.operator_override,
+        runtime_scope="none",
     )
 
 
@@ -306,12 +480,44 @@ def _native_mtp_model_type(config_payload: Mapping[str, Any]) -> str:
     return str(value or "").strip().lower()
 
 
-def _native_mtp_layer_count(config_payload: Mapping[str, Any]) -> int:
+def _resolve_native_mtp_spec(
+    *,
+    model_type: str,
+    config_payload: Mapping[str, Any],
+) -> tuple[_NativeMTPCapabilitySpec | None, int]:
+    for spec in _NATIVE_MTP_CAPABILITY_SPECS:
+        if model_type not in spec.model_types:
+            continue
+        layer_count = _native_mtp_layer_count(config_payload, spec=spec)
+        if layer_count > 0:
+            return spec, layer_count
+    return None, _native_mtp_layer_count(config_payload)
+
+
+def _native_mtp_layer_count(
+    config_payload: Mapping[str, Any],
+    *,
+    spec: _NativeMTPCapabilitySpec | None = None,
+) -> int:
     candidates: list[Any] = []
+    root_keys: tuple[str, ...]
+    text_keys: tuple[str, ...]
+    if spec is None:
+        root_keys = tuple(
+            dict.fromkeys(key for item in _NATIVE_MTP_CAPABILITY_SPECS for key in item.layer_count_keys)
+        )
+        text_keys = tuple(
+            dict.fromkeys(
+                key for item in _NATIVE_MTP_CAPABILITY_SPECS for key in item.text_layer_count_keys
+            )
+        )
+    else:
+        root_keys = spec.layer_count_keys
+        text_keys = spec.text_layer_count_keys
     text_config = config_payload.get("text_config")
     if isinstance(text_config, Mapping):
-        candidates.append(text_config.get("mtp_num_hidden_layers"))
-    candidates.append(config_payload.get("mtp_num_hidden_layers"))
+        candidates.extend(text_config.get(key) for key in text_keys)
+    candidates.extend(config_payload.get(key) for key in root_keys)
     for value in candidates:
         try:
             return max(0, int(value or 0))
@@ -320,13 +526,35 @@ def _native_mtp_layer_count(config_payload: Mapping[str, Any]) -> int:
     return 0
 
 
-def _native_mtp_weight_presence(model_dir: Path) -> tuple[bool, int]:
+def _native_mtp_weight_map(model_dir: Path) -> Mapping[Any, Any]:
     index_payload = _load_json_payload(model_dir / "model.safetensors.index.json")
     weight_map = index_payload.get("weight_map")
     if not isinstance(weight_map, Mapping):
-        return False, 0
-    count = sum(1 for key in weight_map if str(key).startswith(_MTP_WEIGHT_PREFIXES))
+        return {}
+    return weight_map
+
+
+def _native_mtp_weight_presence(
+    weight_map: Mapping[Any, Any],
+    *,
+    spec: _NativeMTPCapabilitySpec | None,
+) -> tuple[bool, int]:
+    count = sum(1 for key in weight_map if _is_native_mtp_weight_key(key, spec=spec))
     return count > 0, count
+
+
+def _is_native_mtp_weight_key(key: object, *, spec: _NativeMTPCapabilitySpec | None) -> bool:
+    key_str = str(key)
+    if spec is not None:
+        if spec.weight_prefixes and key_str.startswith(spec.weight_prefixes):
+            return True
+        return bool(spec.weight_substrings and any(part in key_str for part in spec.weight_substrings))
+    for candidate in _NATIVE_MTP_CAPABILITY_SPECS:
+        if candidate.weight_prefixes and key_str.startswith(candidate.weight_prefixes):
+            return True
+        if candidate.weight_substrings and any(part in key_str for part in candidate.weight_substrings):
+            return True
+    return False
 
 
 def _truthy_string(value: str | None) -> bool:
@@ -363,12 +591,138 @@ def _sidecar_family(*, metadata: Mapping[str, str], model_type: str) -> str:
     target_family = str(metadata.get("melix.speculative.target_family", "") or "").strip().lower()
     return target_family or model_type
 
+def _resolve_native_mtp_hardware_policy(
+    *,
+    metadata: Mapping[str, str],
+    hardware_profile: Any | None,
+) -> _NativeMTPHardwareDecision:
+    policy = _native_mtp_device_policy(metadata)
+    if policy == "force_on":
+        return _NativeMTPHardwareDecision(
+            gate="admitted",
+            policy="force_on",
+            reason="operator_force_on",
+            source="operator",
+            operator_override="force_on",
+        )
+    if policy == "force_off":
+        return _NativeMTPHardwareDecision(
+            gate="disabled",
+            policy="force_off",
+            reason="operator_force_off",
+            source="operator",
+            operator_override="force_off",
+        )
 
-def _native_head_refusal_reason(*, enabled: bool, weights_present: bool) -> str:
+    profile = _coerce_hardware_profile(hardware_profile) or _detect_native_mtp_hardware_profile()
+    if _is_lower_end_m1_m2(profile):
+        return _NativeMTPHardwareDecision(
+            gate="disabled",
+            policy="auto",
+            reason="m1_m2_compute_bound",
+            source="auto",
+        )
+    if _is_high_end_apple_silicon(profile):
+        return _NativeMTPHardwareDecision(
+            gate="admitted",
+            policy="auto",
+            reason="supported_apple_silicon",
+            source="auto",
+        )
+    return _NativeMTPHardwareDecision(
+        gate="admitted",
+        policy="auto",
+        reason="unclassified_device",
+        source="auto",
+    )
+
+
+def _native_mtp_device_policy(metadata: Mapping[str, str]) -> str:
+    value = str(
+        metadata.get(NATIVE_MTP_DEVICE_POLICY_EXT_KEY)
+        or metadata.get("melix.native_mtp.hardware_policy")
+        or "auto"
+    ).strip().lower()
+    if value in {"force_on", "on", "enabled", "always"}:
+        return "force_on"
+    if value in {"force_off", "off", "disabled", "never"}:
+        return "force_off"
+    return "auto"
+
+
+def _coerce_hardware_profile(profile: Any | None) -> NativeMTPHardwareProfile | None:
+    if profile is None:
+        return None
+    return NativeMTPHardwareProfile(
+        system=str(getattr(profile, "system", "") or ""),
+        machine=str(getattr(profile, "machine", "") or ""),
+        chip_family=str(getattr(profile, "chip_family", "") or ""),
+        model_identifier=str(getattr(profile, "model_identifier", "") or ""),
+    )
+
+
+def _detect_native_mtp_hardware_profile() -> NativeMTPHardwareProfile:
+    system = platform.system()
+    machine = platform.machine()
+    if system != "Darwin" or machine not in {"arm64", "aarch64"}:
+        return NativeMTPHardwareProfile(system=system, machine=machine)
+    return NativeMTPHardwareProfile(
+        system=system,
+        machine=machine,
+        chip_family=_sysctl_string("machdep.cpu.brand_string"),
+        model_identifier=_sysctl_string("hw.model"),
+    )
+
+
+def _sysctl_string(name: str) -> str:
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=0.1,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _is_lower_end_m1_m2(profile: NativeMTPHardwareProfile) -> bool:
+    chip = profile.chip_family.lower()
+    if not chip:
+        return False
+    if "m1" not in chip and "m2" not in chip:
+        return False
+    return "max" not in chip and "ultra" not in chip
+
+
+def _is_high_end_apple_silicon(profile: NativeMTPHardwareProfile) -> bool:
+    chip = profile.chip_family.lower()
+    if not chip:
+        return False
+    if "m3" in chip or "m4" in chip:
+        return True
+    return ("m1" in chip or "m2" in chip) and ("max" in chip or "ultra" in chip)
+
+
+def _native_head_refusal_reason(
+    *,
+    enabled: bool,
+    weights_present: bool,
+    patchable: bool,
+    hardware_admitted: bool,
+) -> str:
     if not enabled:
         return "disabled"
     if not weights_present:
         return "missing_mtp_weights"
+    if not patchable:
+        return "patch_unsupported"
+    if not hardware_admitted:
+        return "device_policy_disabled"
     return ""
 
 

--- a/services/mlx-worker-python/worker/runtime/native_mtp/preload.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/preload.py
@@ -20,10 +20,17 @@ def apply_native_mtp_preload_decision(
 
         native_mtp_module.set_mtp_active(False)
         native_mtp_module.set_mtp_weight_attachment(False)
-        if decision.patchable:
+        patch_allowed = (
+            decision.patchable
+            and decision.enabled
+            and decision.weights_present
+            and decision.refusal_reason == ""
+            and decision.hardware_gate == "admitted"
+        )
+        if patch_allowed:
             native_mtp_module.set_mtp_weight_attachment(decision.weights_present)
             patch_applied = native_mtp_module.apply_native_mtp_patches()
-            active = bool(patch_applied and decision.enabled and decision.weights_present)
+            active = bool(patch_applied)
         native_mtp_module.set_mtp_active(active)
     except Exception as exc:  # pragma: no cover - defensive runtime guard.
         if failure_logger is not None:


### PR DESCRIPTION
## Summary
- Adds a declarative native-MTP capability policy for Qwen native heads and recognized DeepSeek-V3-style nextn heads.
- Records hardware policy and batch-state policy decisions in native-MTP receipts while preserving existing Qwen metadata keys.
- Fails closed for recognized DeepSeek native heads with `patch_unsupported` until a matching runtime patch exists.
- Caches host hardware detection, uses the same 5s `sysctl` timeout as device identity, and fails closed when Darwin/arm64 hardware cannot be classified.
- Makes policy-route tests deterministic across local and lower-end M1/M2 CI runners by forcing hardware admission only where preload routing is under test.

## Plan or Spec
- `docs/plans/2026-07-09-issue-2602-native-mtp-family-device-batch-policy.md`
- Refs #2602.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp'
# 39 passed, 58 deselected, 2 warnings in 1.18s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py::test_registry_reports_patch_failure_for_native_head services/mlx-worker-python/tests/test_native_mtp_capability.py::test_text_preload_routes_through_registry_receipt services/mlx-worker-python/tests/test_native_mtp_capability.py::test_vlm_preload_routes_through_registry_receipt
# 3 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights
# 1 passed in 0.43s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_text_only_vlm_decode_adapter_exposes_native_mtp_methods
# 2 passed in 0.09s

git diff --check origin/main...HEAD
# passed

After merging `origin/main` at `0dd6c62b`:

git diff --check origin/main...HEAD
# passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_backend.py -k 'native_mtp'
# 39 passed, 58 deselected, 2 warnings in 1.06s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_text_only_vlm_decode_adapter_exposes_native_mtp_methods
# 2 passed in 0.09s

make bootstrap
# passed

make proto
# passed; no generated-artifact drift

make swift-test
# passed; final macOS menubar stage reported 834 tests in 25 suites passed

make py-test
# 4841 passed, 14 skipped, 2 warnings in 185.59s

make integration-test
# 123 passed, 1 skipped in 423.93s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python --extra mlx bash -c 'python3 scripts/native_mtp_loader_safetensor_scandir_probe.py'
# passed; speedup=1.0083192988453773, extra_speedup=7.147455764233157, model_listing_speedup=2.259606022679985, weight_load_speedup=1.2590202577768717

.githooks/pre-commit
# passed on the staged VLM CI determinism fix; swift-test, py-test, integration-test, and scoped performance report completed rc=0

Review follow-up:

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py -k 'auto_admits_supported_apple_silicon or detects_darwin_arm64_hardware_once_and_caches or fails_closed_when_darwin_arm64_hardware_probe_times_out'
# initial red: 2 failed, 1 passed, 21 deselected; missing _CACHED_HARDWARE_PROFILE before implementation
# after implementation: 3 passed, 21 deselected in 0.07s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py -k 'native_mtp or native_mtp_preload'
# 59 passed, 172 deselected, 2 warnings in 1.01s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage erase && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py -k 'native_mtp or native_mtp_preload' && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/capability.py services/mlx-worker-python/worker/runtime/native_mtp/preload.py services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py services/mlx-worker-python/tests/test_native_mtp_capability.py services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
# pytest: 59 passed, 172 deselected, 2 warnings in 2.35s; changed-scope coverage TOTAL 92 1 99%

git diff --check --cached
# passed

.githooks/pre-commit
# passed on staged review follow-up; swift-test, py-test, integration-test, and scoped performance report completed rc=0
# swift-test final macOS menubar stage: 834 tests in 25 suites passed
# py-test: 4850 passed, 14 skipped, 2 warnings in 184.49s
# integration-test: 123 passed, 1 skipped in 420.23s
```

## Coverage and Metrics
- Changed-scope coverage after review follow-up: aggregate 99 percent.
- Touched runtime files:
  - `services/mlx-worker-python/worker/runtime/native_mtp/capability.py`: 100.00 percent.
  - `services/mlx-worker-python/worker/runtime/native_mtp/preload.py`: 100.00 percent.
  - `services/mlx-worker-python/worker/runtime/native_mtp/batch_generator.py`: 100.00 percent.
- Changed test files:
  - `services/mlx-worker-python/tests/test_native_mtp_capability.py`: 98.61 percent.
  - `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`: 100.00 percent.
- Latest staged pre-commit performance report: status `ok`, changed files `3`, selected probes `0`, direct/gated probes `0`, regressions `0`, context regressions `0`, verification failures `0`.
- Latest staged pre-commit performance report path: `.runtime/pre-commit-performance/20260709-043901-d6782160/report/report.md`.
- Prior PR-scoped performance report after the VLM CI fix selected probes `7`, direct/gated probes `7`, regressions `0`, context regressions `0`, verification failures `0`.
- Observability mode: minimal existing model metadata receipt fields; no production telemetry sampling or new always-on probe was added.
- Probe overhead: N/A for runtime observability because the new device policy is metadata/config based and avoids telemetry sampling.

## Known Gaps
- DeepSeek native-head runtime patching is intentionally not implemented in this slice; recognized DeepSeek heads now refuse activation with `patch_unsupported`.
- Full batched verify-forward is intentionally not implemented in this slice; the receipt now reports singleton-safe filter/extend behavior and `multi_row_decode_unsupported`.
- No public HTTP, CLI, or protobuf schema change.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
