### PR TITLE
perf(prefix): scan cold index sidecars directly

### DIFF
--- a/docs/plans/2026-07-09-prefix-cold-index-scandir-performance.md
+++ b/docs/plans/2026-07-09-prefix-cold-index-scandir-performance.md
@@ -1,0 +1,43 @@
+# Prefix cold index scandir performance slice
+
+## Context
+
+The native MTP prompt-prefix cold tier reloads `.meta.json` sidecars when a
+`ColdPrefixStore` is first consulted after worker startup. The previous reload
+path used `Path.glob("*.meta.json")`, which allocates glob machinery and `Path`
+objects before filtering entries. The reload only needs one non-recursive pass
+over the cold tier root.
+
+## Scope
+
+This slice covers only `services/mlx-worker-python/worker/runtime/prefix_block_store.py`'s
+cold prefix sidecar index load. It does not change hot prefix matching,
+demotion/promotion semantics, snapshot serialization, or active KV quantization
+matching.
+
+## Probe registration
+
+The slice registers `prefix-cold-index-scandir` in
+`infra/perf/pr_scoped_probes.json` with focused test, coverage, and command-json
+probe commands. The probe builds a synthetic cold tier, reloads the sidecar index
+multiple times, and records elapsed time plus traversal call counts.
+
+## Implementation plan
+
+1. Add a regression test proving cold sidecar index load uses a single
+   `os.scandir` pass without `Path.glob` while preserving reload behavior.
+2. Replace the non-recursive `Path.glob("*.meta.json")` reload with an explicit
+   `os.scandir` pass that keeps hot traversal state as strings, ignores entries
+   with transient metadata errors, and preserves deterministic sorted processing.
+3. Add and register the focused cold-index reload performance probe.
+4. Validate with focused tests, changed-scope coverage, and the registered probe
+   locally on Linux; rely on PR-scoped CI to replay the registered probe.
+
+## Success metrics
+
+- Behavior parity: valid cold entries reload, orphaned sidecars are still pruned,
+  and cold hits still promote back to the hot tier.
+- Coverage: changed-scope coverage for the touched helper, tests, registry, and
+  probe remains at or above 95%.
+- Performance: registered probe `elapsed_ms_mean` is lower than the pre-change
+  glob baseline, and `path_glob_calls_mean` drops to zero.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6851,5 +6851,61 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "prefix-cold-index-scandir",
+    "name": "Prefix cold index scandir",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/prefix_block_store.py",
+      "services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/prefix_cold_index_scandir_probe.py",
+      "infra/perf/pr_scoped_probes.json"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_drops_orphaned_meta services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_tolerates_scandir_failure services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_skips_entries_with_metadata_errors services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_hit_promotes_back_to_hot services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cold_index_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_drops_orphaned_meta services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_tolerates_scandir_failure services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_skips_entries_with_metadata_errors services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_hit_promotes_back_to_hot services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cold_index_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cold_index_scandir_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_PREFIX_COLD_INDEX_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/prefix_cold_index_scandir_probe.py\"; for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "entry_count",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "loaded_count_mean",
+        "unit": "items",
+        "direction": "informational"
+      },
+      {
+        "key": "path_glob_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "scandir_calls_mean",
+        "unit": "calls",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/prefix_cold_index_scandir_probe.py
+++ b/scripts/prefix_cold_index_scandir_probe.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(os.environ.get("MELIX_PREFIX_COLD_INDEX_REPO_ROOT", Path.cwd()))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime import prefix_block_store as target  # noqa: E402
+from worker.runtime.prefix_block_store import ColdPrefixStore  # noqa: E402
+
+
+def _fake_serializer(cache_snapshot: Any, path: Path) -> None:
+    path.write_text(json.dumps(cache_snapshot), encoding="utf-8")
+
+
+def _fake_deserializer(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _build_cold_index(root: Path, *, entry_count: int) -> None:
+    cold = ColdPrefixStore(root, serializer=_fake_serializer, deserializer=_fake_deserializer)
+    for index in range(entry_count):
+        ok = cold.store(
+            session_id=f"session-{index:05d}",
+            token_ids=[index, index + 1, index + 2, index + 3],
+            cache_snapshot=[{"data": index}],
+            cache_mode="CACHE_MODE_TIERED",
+            model_id="m1",
+            model_revision="r1",
+            block_size=4,
+            acceleration_mode="",
+        )
+        if not ok:
+            raise RuntimeError(f"failed to build cold entry {index}")
+    (root / "ignored.tmp").write_text("ignored\n", encoding="utf-8")
+    (root / "nested.meta.json").mkdir()
+
+
+def measure(*, entry_count: int, samples: int) -> dict[str, float]:
+    elapsed_ms: list[float] = []
+    loaded_counts: list[float] = []
+    scandir_calls: list[float] = []
+    path_glob_calls: list[float] = []
+    original_scandir = target.os.scandir
+    original_glob = target.Path.glob
+
+    with tempfile.TemporaryDirectory(prefix="melix-prefix-cold-index-") as tmp:
+        root = Path(tmp) / "cold"
+        _build_cold_index(root, entry_count=entry_count)
+        try:
+            for _ in range(samples):
+                sample_scandir_calls = 0
+                sample_path_glob_calls = 0
+
+                def counted_scandir(path: str | os.PathLike[str]):
+                    nonlocal sample_scandir_calls
+                    sample_scandir_calls += 1
+                    return original_scandir(path)
+
+                def counted_glob(self: Path, pattern: str):
+                    nonlocal sample_path_glob_calls
+                    sample_path_glob_calls += 1
+                    return original_glob(self, pattern)
+
+                target.os.scandir = counted_scandir
+                target.Path.glob = counted_glob
+                cold = ColdPrefixStore(root, serializer=_fake_serializer, deserializer=_fake_deserializer)
+                started = time.perf_counter()
+                loaded = cold.entry_count()
+                elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+                loaded_counts.append(float(loaded))
+                scandir_calls.append(float(sample_scandir_calls))
+                path_glob_calls.append(float(sample_path_glob_calls))
+                if loaded != entry_count:
+                    raise RuntimeError(f"unexpected loaded count: {loaded} != {entry_count}")
+        finally:
+            target.os.scandir = original_scandir
+            target.Path.glob = original_glob
+
+    return {
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "elapsed_ms_min": min(elapsed_ms),
+        "elapsed_ms_p95": sorted(elapsed_ms)[int((len(elapsed_ms) - 1) * 0.95)],
+        "entry_count": float(entry_count),
+        "loaded_count_mean": statistics.fmean(loaded_counts),
+        "path_glob_calls_mean": statistics.fmean(path_glob_calls),
+        "sample_count": float(samples),
+        "scandir_calls_mean": statistics.fmean(scandir_calls),
+    }
+
+
+def main() -> int:
+    entry_count = int(os.environ.get("MELIX_PREFIX_COLD_INDEX_PROBE_ENTRIES", "600"))
+    samples = int(os.environ.get("MELIX_PREFIX_COLD_INDEX_PROBE_SAMPLES", "7"))
+    print(json.dumps(measure(entry_count=entry_count, samples=samples), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -528,6 +528,33 @@ def test_scope_report_selects_retrieval_context_projection_probe() -> None:
     assert _selected_probe_ids(scope) == ["retrieval-context-projection-fastpath"]
 
 
+def test_scope_report_selects_prefix_cold_index_probe() -> None:
+    scope = build_scope_report(
+        registry_path=REGISTRY_PATH,
+        changed_files=["services/mlx-worker-python/worker/runtime/prefix_block_store.py"],
+    )
+    assert "prefix-cold-index-scandir" in _selected_probe_ids(scope)
+
+
+def test_prefix_cold_index_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_PREFIX_COLD_INDEX_PROBE_ENTRIES", "5")
+    monkeypatch.setenv("MELIX_PREFIX_COLD_INDEX_PROBE_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/prefix_cold_index_scandir_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["entry_count"] == 5.0
+    assert metrics["loaded_count_mean"] == 5.0
+    assert metrics["path_glob_calls_mean"] == 0.0
+    assert metrics["sample_count"] == 1.0
+    assert metrics["scandir_calls_mean"] == 1.0
+
+
 def test_retrieval_context_projection_probe_script_emits_metrics(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -4240,6 +4267,7 @@ def test_text_family_config_probe_script_emits_metrics(
 
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
+        "prefix-cold-index-scandir",
         "dataset-registry-limited-read-streaming",
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",

--- a/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
+++ b/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -362,6 +363,122 @@ def test_cold_store_index_reload_drops_orphaned_meta(tmp_path: Path) -> None:
     assert meta is None
     # The orphaned sidecar is removed so restarts stop rescanning it.
     assert list((tmp_path / "cold").glob("*.meta.json")) == []
+
+
+def test_cold_store_index_load_uses_scandir_without_path_glob(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cold = _make_cold(tmp_path)
+    assert cold.store(
+        session_id="s1",
+        token_ids=[1, 2, 3, 4],
+        cache_snapshot=_make_snapshot("s1"),
+        cache_mode="CACHE_MODE_TIERED",
+        model_id="m1",
+        model_revision="r1",
+        block_size=4,
+        acceleration_mode="",
+    )
+
+    def fail_glob(self: Path, pattern: str):  # pragma: no cover - regression guard
+        raise AssertionError(
+            f"ColdPrefixStore index load should use os.scandir, not Path.glob({pattern!r})"
+        )
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    original_scandir = os.scandir
+    scandir_calls = 0
+
+    def counted_scandir(path: str | os.PathLike[str]):
+        nonlocal scandir_calls
+        scandir_calls += 1
+        return original_scandir(path)
+
+    monkeypatch.setattr("worker.runtime.prefix_block_store.os.scandir", counted_scandir)
+
+    reloaded = ColdPrefixStore(
+        tmp_path / "cold",
+        serializer=_fake_serializer,
+        deserializer=_fake_deserializer,
+    )
+    assert reloaded.entry_count() == 1
+    assert scandir_calls == 1
+
+
+def test_cold_store_index_load_tolerates_scandir_failure(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cold = _make_cold(tmp_path)
+    assert cold.store(
+        session_id="s1",
+        token_ids=[1, 2, 3, 4],
+        cache_snapshot=_make_snapshot("s1"),
+        cache_mode="CACHE_MODE_TIERED",
+        model_id="m1",
+        model_revision="r1",
+        block_size=4,
+        acceleration_mode="",
+    )
+
+    def fail_scandir(path: Path):  # pragma: no cover - regression guard
+        raise OSError(f"scan denied: {path!s}")
+
+    monkeypatch.setattr("worker.runtime.prefix_block_store.os.scandir", fail_scandir)
+
+    reloaded = ColdPrefixStore(
+        tmp_path / "cold",
+        serializer=_fake_serializer,
+        deserializer=_fake_deserializer,
+    )
+    assert reloaded.entry_count() == 0
+
+
+def test_cold_store_index_load_skips_entries_with_metadata_errors(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    cold = _make_cold(tmp_path)
+    assert cold.store(
+        session_id="s1",
+        token_ids=[1, 2, 3, 4],
+        cache_snapshot=_make_snapshot("s1"),
+        cache_mode="CACHE_MODE_TIERED",
+        model_id="m1",
+        model_revision="r1",
+        block_size=4,
+        acceleration_mode="",
+    )
+
+    class BadEntry:
+        name = "bad.meta.json"
+        path = str(tmp_path / "cold" / "bad.meta.json")
+
+        def is_file(self, *, follow_symlinks: bool = True) -> bool:
+            raise OSError("metadata denied")
+
+    original_scandir = os.scandir
+
+    class FakeScandir:
+        def __enter__(self):
+            with original_scandir(tmp_path / "cold") as entries:
+                return [BadEntry(), *list(entries)]
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "worker.runtime.prefix_block_store.os.scandir",
+        lambda path: FakeScandir(),
+    )
+
+    reloaded = ColdPrefixStore(
+        tmp_path / "cold",
+        serializer=_fake_serializer,
+        deserializer=_fake_deserializer,
+    )
+    assert reloaded.entry_count() == 1
 
 
 def test_promotion_accounts_live_bytes_not_file_size(tmp_path: Path) -> None:

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -338,7 +338,22 @@ class ColdPrefixStore:
         self._loaded = True
         if not self._root.is_dir():
             return
-        for meta_path in sorted(self._root.glob("*.meta.json")):
+        meta_paths: list[str] = []
+        try:
+            with os.scandir(self._root) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_file(follow_symlinks=False) and entry.name.endswith(
+                            ".meta.json"
+                        ):
+                            meta_paths.append(entry.path)
+                    except OSError:
+                        continue
+        except OSError:
+            return
+        meta_paths.sort()
+        for meta_path_string in meta_paths:
+            meta_path = Path(meta_path_string)
             try:
                 payload = json.loads(meta_path.read_text(encoding="utf-8"))
                 session_id = str(payload["session_id"])


### PR DESCRIPTION
## Summary
- Register a focused `prefix-cold-index-scandir` PR-scoped performance probe for cold prefix sidecar index reloads.
- Replace the cold index reload `Path.glob("*.meta.json")` pass with a single `os.scandir` traversal that preserves deterministic sorted sidecar processing.
- Add regression coverage for no-`Path.glob`, scan failure tolerance, and entry metadata error tolerance.

## Plan or Spec
- `docs/plans/2026-07-09-prefix-cold-index-scandir-performance.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_drops_orphaned_meta services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_tolerates_scandir_failure services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_skips_entries_with_metadata_errors services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_hit_promotes_back_to_hot services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cold_index_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 9 passed in 0.23s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_drops_orphaned_meta services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_tolerates_scandir_failure services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_skips_entries_with_metadata_errors services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_hit_promotes_back_to_hot services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cold_index_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cold_index_scandir_probe.py
# 9 passed in 0.32s; changed-scope coverage TOTAL 67 0 100%

MELIX_PREFIX_COLD_INDEX_REPO_ROOT=/root/.hermes/profiles/coder/workspace/melix PYTHONPATH="/root/.hermes/profiles/coder/workspace/melix:/root/.hermes/profiles/coder/workspace/melix/services/mlx-worker-python" uv run --project /root/.hermes/profiles/coder/workspace/melix/services/mlx-worker-python python3 scripts/prefix_cold_index_scandir_probe.py
# base: elapsed_ms_mean=36.137925, path_glob_calls_mean=1.0, scandir_calls_mean=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_COLD_INDEX_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cold_index_scandir_probe.py
# head: elapsed_ms_mean=33.215614, path_glob_calls_mean=0.0, scandir_calls_mean=1.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 67 0 100%`).
- Local Linux probe: base `elapsed_ms_mean=36.137925ms`; head `elapsed_ms_mean=33.215614ms`; delta `-2.922311ms`; speedup `1.087980x`; improvement `8.087%`.
- Traversal counters: `path_glob_calls_mean` dropped from `1.0` to `0.0`; `scandir_calls_mean` remained `1.0`.
- CI PR-scoped performance workflow is required to replay the registered probe on GitHub before merge.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime path is changed.
- The exact registry `probe_command` uses the CI shell fallback path; locally I ran the same probe script directly after the shell-wrapped command was not executable in this environment.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
