### PR TITLE
perf(hub): fast-path exact MLX tag detection

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
+++ b/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
@@ -21,6 +21,10 @@ Use the existing registered probe:
 
 The probe builds synthetic Hub catalog size-hint payloads and exercises both direct `cardData.model_size` parsing and labeled text parsing. The registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
 
+## 2026-07-09 exact MLX tag membership slice
+
+This follow-up Python-only slice stays within `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and the registered `hub-catalog-size-hint-regex-precompile` PR-scoped probe. It narrows `_tag_payload_contains_mlx(...)` by checking exact `"MLX"` / `"mlx"` list membership before falling back to per-item mixed-case atom checks. Behavior remains identical for exact tags, mixed-case tags, list subclasses, string payloads, and non-string tag payloads; the slice only avoids repeated Python-level tag iteration in the common exact-tag Hub compatibility path.
+
 ## Success Metrics
 
 - Focused Hub catalog tests pass.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -139,6 +139,30 @@ def test_payload_mlx_tag_detection_preserves_exact_list_and_subclass_semantics()
     ) is False
 
 
+def test_payload_mlx_tag_detection_fast_paths_exact_membership(monkeypatch: pytest.MonkeyPatch) -> None:
+    from worker.model_ops import hub_catalog
+
+    calls = 0
+    original = hub_catalog._is_mlx_atom
+
+    def counted_is_mlx_atom(value: str) -> bool:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(hub_catalog, "_is_mlx_atom", counted_is_mlx_atom)
+
+    assert hub_catalog._payload_is_mlx_compatible(
+        {"id": "plain/model", "tags": ["Text-Generation", "MLX", object()]}
+    ) is True
+    assert calls == 0
+
+    assert hub_catalog._payload_is_mlx_compatible(
+        {"id": "plain/model", "tags": ["Text-Generation", "mLx", object()]}
+    ) is True
+    assert calls == 1
+
+
 class FakeHTTPResponse:
     def __init__(self, payload: object):
         self._payload = json.dumps(payload).encode("utf-8")

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -494,10 +494,10 @@ def _is_mlx_atom(value: str) -> bool:
 
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if type(value) is list:
+        if "MLX" in value or "mlx" in value:
+            return True
         for item in value:
-            if type(item) is str and (
-                item == "MLX" or item == "mlx" or (len(item) == 3 and _is_mlx_atom(item))
-            ):
+            if type(item) is str and len(item) == 3 and _is_mlx_atom(item):
                 return True
         return False
     if isinstance(value, list):


### PR DESCRIPTION
## Summary
- Fast-path exact `MLX` / `mlx` Hub tag detection for plain list payloads before falling back to mixed-case atom checks.
- Add a regression test proving exact tags avoid `_is_mlx_atom(...)` while mixed-case tags still use the fallback.
- Update the Hub catalog performance plan with the 2026-07-09 exact-tag slice.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics` → 95 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py` → TOTAL 15 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py` → local head probe completed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-hub-exact-tag-20260709 --head-repo "$PWD" --output .runtime/hub-exact-tag-probe.json` → success
- `git diff --check` → passed

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 15 0 100%`).
- Local registered probe comparison (`hub-catalog-size-hint-regex-precompile`):
  - `elapsed_ms_mean`: base 1276.543 ms, head 1267.428 ms, delta -9.115 ms (~1.007x)
  - `payload_compatibility_elapsed_ms_mean`: base 186.256 ms, head 185.251 ms, delta -1.005 ms (~1.005x)
  - Guardrails unchanged: `payload_compatibility_matched_count=160000`, `payload_compatibility_calls_mean=200000`, `checksum=1545732096`
- CI PR-scoped performance workflow is required as the merge gate after PR creation.

## Known Gaps
- Local validation is Linux/Python-only. This slice does not touch Swift or macOS runtime behavior.
- The measured local improvement is intentionally small; the exact-tag path is a narrow hot-loop cleanup.

## Evidence Checklist
- [x] Governing plan/spec updated.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% requirement locally.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance report completed successfully.
