### PR TITLE
perf(embedding): normalize digest defaults without enumerate

### DIFF
--- a/docs/plans/2026-07-09-embedding-project-digest-direct8-performance.md
+++ b/docs/plans/2026-07-09-embedding-project-digest-direct8-performance.md
@@ -1,0 +1,45 @@
+# Embedding Project Digest Direct 8-Dimension Normalization Performance
+
+## Context
+
+The deterministic embedding project-digest probe covers `services/mlx-worker-python/worker/runtime/embedding_backends.py` through the registered PR-scoped probe `deterministic-embedding-project-digest-allocation`. The probe measures both expanded vectors and the default eight-dimensional projection hot path.
+
+## Slice
+
+This slice keeps the existing projection semantics and changes only the eight-dimensional normalization loop in `DeterministicEmbeddingBackend._project_digest`.
+
+## Plan
+
+1. Preserve legacy projection parity with the existing embedding runtime tests.
+2. Replace the `enumerate` mutation loop for the fixed eight-value vector with direct slot assignments, avoiding iterator/tuple churn while still reusing the existing `base_values` list.
+3. Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux.
+4. Use the PR-scoped performance CI report as the registered probe validation before merge.
+
+## Metrics
+
+Baseline local probe on Linux before the code change:
+
+- `elapsed_ms_mean`: 19.093115 ms
+- `default_dimension_elapsed_ms_mean`: 121.791777 ms
+- `peak_bytes_mean`: 74840.888889 bytes
+- `default_dimension_peak_bytes_mean`: 989.333333 bytes
+
+Post-change local registered probe on Linux:
+
+- `elapsed_ms_mean`: 17.643934 ms
+- `default_dimension_elapsed_ms_mean`: 111.710206 ms
+- `peak_bytes_mean`: 74840.888889 bytes
+- `default_dimension_peak_bytes_mean`: 933.333333 bytes
+
+Local probe deltas:
+
+- `elapsed_ms_mean`: -1.449181 ms (-7.590%)
+- `default_dimension_elapsed_ms_mean`: -10.081571 ms (-8.278%)
+- `peak_bytes_mean`: unchanged
+- `default_dimension_peak_bytes_mean`: -56 bytes (-5.660%)
+
+## Verification
+
+- Focused embedding/runtime tests from the registered probe.
+- Changed-scope coverage from the registered probe.
+- `scripts/deterministic_embedding_project_digest_probe.py` via the registered probe command.

--- a/services/mlx-worker-python/worker/runtime/embedding_backends.py
+++ b/services/mlx-worker-python/worker/runtime/embedding_backends.py
@@ -80,8 +80,14 @@ class DeterministicEmbeddingBackend:
             if l2_norm == 0.0:
                 return [0.0] * 8
             inverse_l2_norm = 1.0 / l2_norm
-            for index, value in enumerate(base_values):
-                base_values[index] = _round(value * inverse_l2_norm, 6)
+            base_values[0] = _round(base_values[0] * inverse_l2_norm, 6)
+            base_values[1] = _round(base_values[1] * inverse_l2_norm, 6)
+            base_values[2] = _round(base_values[2] * inverse_l2_norm, 6)
+            base_values[3] = _round(base_values[3] * inverse_l2_norm, 6)
+            base_values[4] = _round(base_values[4] * inverse_l2_norm, 6)
+            base_values[5] = _round(base_values[5] * inverse_l2_norm, 6)
+            base_values[6] = _round(base_values[6] * inverse_l2_norm, 6)
+            base_values[7] = _round(base_values[7] * inverse_l2_norm, 6)
             return base_values
         return self._project_digest_expanded(base_values, dimensions)
 


### PR DESCRIPTION
## Summary
- Optimize the deterministic embedding eight-dimensional digest projection by replacing the fixed-size `enumerate` mutation loop with direct slot assignments.
- Preserve the existing digest projection values while reducing iterator overhead on the registered project-digest hot path.

## Plan or Spec
- `docs/plans/2026-07-09-embedding-project-digest-direct8-performance.md`
- Registered PR-scoped probe: `deterministic-embedding-project-digest-allocation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe before code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# exit 0; elapsed_ms_mean=19.093115, default_dimension_elapsed_ms_mean=121.791777, peak_bytes_mean=74840.888889, default_dimension_peak_bytes_mean=989.333333

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke
# exit 0; 21 passed in 19.03s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_project_digest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_smokes_return_metrics_against_current_repo services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_project_digest_probe_script_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/embedding_backends.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_project_digest_probe.py
# exit 0; 21 passed in 51.64s; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_PROJECT_DIGEST_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_project_digest_probe.py
# exit 0; elapsed_ms_mean=17.643934, default_dimension_elapsed_ms_mean=111.710206, peak_bytes_mean=74840.888889, default_dimension_peak_bytes_mean=933.333333

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Local registered probe delta versus pre-change baseline:
  - `elapsed_ms_mean`: 19.093115 -> 17.643934 ms (-1.449181 ms, -7.590%).
  - `default_dimension_elapsed_ms_mean`: 121.791777 -> 111.710206 ms (-10.081571 ms, -8.278%).
  - `peak_bytes_mean`: 74840.888889 -> 74840.888889 bytes (unchanged).
  - `default_dimension_peak_bytes_mean`: 989.333333 -> 933.333333 bytes (-56 bytes, -5.660%).
- CI is required for final registered PR-scoped probe validation before merge.

## Known Gaps
- Linux local verification covers Python behavior and the registered Python probe only.
- Awaiting GitHub Actions / PR-scoped performance workflow report for repository-required validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe only; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
