### PR TITLE
perf(hub): fast path exact MLX library names

### DIFF
--- a/docs/plans/2026-07-09-hub-catalog-library-mlx-exact-fastpath.md
+++ b/docs/plans/2026-07-09-hub-catalog-library-mlx-exact-fastpath.md
@@ -1,0 +1,22 @@
+# Hub catalog library MLX exact fast path
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog` MLX compatibility checks.
+
+## Scope
+
+The common Hugging Face metadata cases already report `library_name` as exactly `"mlx"` or `"MLX"`. This slice adds an exact-value guard before falling back to the mixed-case three-character `_is_mlx_atom(...)` helper in `_payload_is_mlx_compatible(...)` and `_is_mlx_compatible(...)`.
+
+Behavior is unchanged for:
+
+- exact `"mlx"` and `"MLX"` library names,
+- mixed-case three-character variants such as `"MlX"`,
+- card-level `library_name` fallback,
+- tag and repository-id compatibility checks.
+
+## Registered performance probe
+
+The affected path is covered by the existing registered PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. That registry entry includes focused `test_command`, `coverage_command`, and `probe_command` fields and reports `payload_compatibility_elapsed_ms_mean` for `_payload_is_mlx_compatible(...)`.
+
+## Validation plan
+
+Run the registered focused test command, changed-scope coverage command, and local registered probe on Linux before opening the PR. Use the GitHub PR-scoped performance workflow as the merge gate after the PR is opened.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -118,6 +118,41 @@ def test_mlx_library_atom_detection_preserves_mixed_case_without_lowercase_copy(
     ) is True
 
 
+def test_mlx_library_exact_detection_skips_atom_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    from worker.model_ops import hub_catalog
+
+    calls = 0
+    original = hub_catalog._is_mlx_atom
+
+    def counted_is_mlx_atom(value: str) -> bool:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(hub_catalog, "_is_mlx_atom", counted_is_mlx_atom)
+
+    assert hub_catalog._payload_is_mlx_compatible(
+        {"id": "plain/model", "library_name": "mlx", "tags": ["Text-Generation"]}
+    ) is True
+    assert hub_catalog._is_mlx_compatible(
+        repo_id="plain/model",
+        tags=["Text-Generation"],
+        library_name="MLX",
+        card_data={},
+        lowered_tags={"text-generation"},
+    ) is True
+    assert calls == 0
+
+    assert hub_catalog._payload_is_mlx_compatible(
+        {
+            "id": "plain/model",
+            "tags": ["Text-Generation"],
+            "cardData": {"library_name": "MlX"},
+        }
+    ) is True
+    assert calls == 1
+
+
 def test_mlx_repo_id_detection_preserves_case_insensitive_matches() -> None:
     assert _repo_id_contains_mlx("plain/model") is False
     assert _repo_id_contains_mlx("owner/model-mlx-suffix") is True

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -77,6 +77,7 @@ _COMMON_4BIT_OPTIQ_EXCLUDED_TAGS = {
     "float16",
     "qat",
 }
+_EXACT_MLX_LIBRARY_NAMES = frozenset({"MLX", "mlx"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -570,7 +571,9 @@ def _repo_id_contains_mlx(repo_id: str) -> bool:
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     raw_library_name = payload.get("library_name")
     library_name = raw_library_name if isinstance(raw_library_name, str) else ""
-    if library_name and _is_mlx_atom(library_name):
+    if library_name in _EXACT_MLX_LIBRARY_NAMES or (
+        library_name and _is_mlx_atom(library_name)
+    ):
         return True
     raw_repo_id = payload.get("id") or payload.get("modelId")
     repo_id = raw_repo_id if isinstance(raw_repo_id, str) else ""
@@ -582,7 +585,14 @@ def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     if not isinstance(card_data, dict):
         return False
     raw_card_library_name = card_data.get("library_name")
-    if not library_name and isinstance(raw_card_library_name, str) and _is_mlx_atom(raw_card_library_name):
+    if (
+        not library_name
+        and isinstance(raw_card_library_name, str)
+        and (
+            raw_card_library_name in _EXACT_MLX_LIBRARY_NAMES
+            or _is_mlx_atom(raw_card_library_name)
+        )
+    ):
         return True
     card_tags = card_data.get("tags")
     if not card_tags:
@@ -601,7 +611,7 @@ def _is_mlx_compatible(
     lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
     if "mlx" in lowered_tags:
         return True
-    if _is_mlx_atom(library_name):
+    if library_name in _EXACT_MLX_LIBRARY_NAMES or _is_mlx_atom(library_name):
         return True
     if _repo_id_contains_mlx(repo_id):
         return True


### PR DESCRIPTION
## Summary
- Fast-path exact `"mlx"` / `"MLX"` Hub `library_name` compatibility checks before the mixed-case atom helper.
- Add a regression test proving exact library names do not call `_is_mlx_atom(...)` while mixed-case card fallback still does.
- Document the slice and registered probe gate in `docs/plans/2026-07-09-hub-catalog-library-mlx-exact-fastpath.md`.

## Plan or Spec
- `docs/plans/2026-07-09-hub-catalog-library-mlx-exact-fastpath.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- Baseline local probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- Branch local probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `96 passed in 0.37s`.
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Baseline local registered probe (`origin/main`, default 200k iterations, 5 samples): `elapsed_ms_mean=1298.9355459925719`, `payload_compatibility_elapsed_ms_mean=190.95665297936648`.
- Branch local registered probe (default 200k iterations, 5 samples): `elapsed_ms_mean=1290.193361416459`, `payload_compatibility_elapsed_ms_mean=181.76959300180897`.
- Local delta: `elapsed_ms_mean -8.742184576112966 ms` (~0.67% faster), `payload_compatibility_elapsed_ms_mean -9.18705997755751 ms` (~4.81% faster).

## Known Gaps
- Linux local probe validates the Python path only. GitHub PR-scoped performance CI is still required as the registered merge gate.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before the slice.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% for touched files.
- [x] Registered probe was run locally against baseline and branch.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
