### PR TITLE
perf(quantized): normalize safetensor header keys once

### DIFF
--- a/docs/plans/2026-06-26-quantized-high-precision-segment-scan.md
+++ b/docs/plans/2026-06-26-quantized-high-precision-segment-scan.md
@@ -44,3 +44,9 @@ The probe entry already has focused `test_command`, `coverage_command`, and `pro
 A later Python-only performance slice keeps the same registered probe and narrows the changed behavior to `quantized_scales_present(...)` when callers pass an empty materialized `weights` mapping. In metadata-prepass decision loops, the quantized scale answer is already fully determined by `QuantizedTensorMetadata`, so the helper can skip the redundant `scales_key in weights` lookup for empty mappings while preserving non-empty materialized-weight fallback behavior.
 
 The `quantized-tensor-metadata-prepass` probe already covers this path through `metadata_decision_elapsed_ms_mean` and `metadata_decision_peak_bytes_mean`, with the existing focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Follow-up slice: safetensors header key normalization once
+
+This Python-only follow-up stays inside `worker.runtime.quantized_tensor_metadata` and the registered `quantized-tensor-metadata-prepass` probe. The safetensors header parser now normalizes each non-`__metadata__` JSON key to `str` once before appending it to the returned tensor-name tuple. Behavior is unchanged for empty names and metadata entries, while the header scan avoids the previous generator expression's duplicate `str(key)` conversion in the hot header prepass.
+
+Validation remains the focused registered test command, changed-scope coverage command, local Linux registered probe, and GitHub Actions PR-scoped performance report.

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -195,6 +195,7 @@ def _write_fake_safetensors_header(path: Path, tensor_names: tuple[str, ...]) ->
         }
         for tensor_name in tensor_names
     }
+    header["__metadata__"] = {"format": "pt"}
     payload = json.dumps(header, sort_keys=True).encode("utf-8")
     path.write_bytes(len(payload).to_bytes(8, "little") + payload)
 

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -290,8 +290,12 @@ def _safetensors_header_tensor_names(path: Path) -> tuple[str, ...]:
         return ()
     if not isinstance(header, dict):
         return ()
-    return tuple(
-        str(key)
-        for key in header
-        if key != "__metadata__" and str(key)
-    )
+    tensor_names: list[str] = []
+    append_tensor_name = tensor_names.append
+    for key in header:
+        if key == "__metadata__":
+            continue
+        tensor_name = str(key)
+        if tensor_name:
+            append_tensor_name(tensor_name)
+    return tuple(tensor_names)


### PR DESCRIPTION
## Summary
- Normalize safetensors header tensor keys exactly once while filtering `__metadata__` in `worker.runtime.quantized_tensor_metadata`.
- Extend the existing fake safetensors test helper with a `__metadata__` header entry so the metadata skip path is covered.
- Document this Python-only follow-up slice under the existing quantized tensor metadata performance plan.

## Plan or Spec
- `docs/plans/2026-06-26-quantized-high-precision-segment-scan.md`
- Registered PR-scoped probe: `quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_merges_cross_shard_index_and_headers services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_normalizes_index_keys_once services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_tensor_metadata_model_dir_scans_top_level_headers_and_bad_entries services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_quantized_scales_present_skips_empty_weight_lookup services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_multimodal_high_precision_module_segment_scan_preserves_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_quantized_tensor_metadata_prepass_probe_base_fallback services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
.......... [100%]
10 passed in 1.02s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,*/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py,*/scripts/quantized_tensor_metadata_prepass_probe.py' -m pytest -q ... && coverage json && python3 scripts/changed_scope_coverage.py ...
.......... [100%]
10 passed in 0.55s
TOTAL 10 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantized_tensor_metadata_prepass_probe.py
ok; local head metrics emitted as JSON

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id quantized-tensor-metadata-prepass --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/quantized-header-key-normalize-once-probe.json
30 passed in 0.80s; changed-scope coverage TOTAL 10 0 100%; base/head probe ok

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%` from the registered probe runner coverage command.
- Local Linux registered probe (`quantized-tensor-metadata-prepass`) base vs head from `/tmp/quantized-header-key-normalize-once-probe.json`:
  - `header_elapsed_ms_mean`: base `45.346625`, head `44.597092`, delta `-0.749533 ms` (`-1.65%`).
  - `metadata_decision_elapsed_ms_mean`: base `29.980916`, head `30.346125`, delta `+0.365209 ms` (`+1.22%`, below 5% warn threshold).
  - `high_precision_decision_elapsed_ms_mean`: base `70.833802`, head `71.327468`, delta `+0.493666 ms` (`+0.70%`, below 5% warn threshold).
  - `tensor_names_access_elapsed_ms_mean`: base `20.477413`, head `17.649132`, delta `-2.828281 ms` (`-13.81%`).
- Registered GitHub Actions PR-scoped performance report is required as the merge gate.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- Local probe has expected micro-benchmark noise in unrelated decision metrics; the registered CI report remains the final gate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
