### PR TITLE
feat(agent): add network tool consent receipt

### DIFF
--- a/docs/plans/2026-07-09-issue-1382-network-tool-consent.md
+++ b/docs/plans/2026-07-09-issue-1382-network-tool-consent.md
@@ -1,0 +1,111 @@
+# Issue 1382 Network Tool Consent Slice
+
+## Goal
+
+Add an explicit network-tool consent boundary to agentic tool selection so a
+session-level web deny wins over prompt-inferred browsing intent before any
+network-capable schema reaches the model-visible registry.
+
+## Governing Documents
+
+- `AGENTS.md`
+- `docs/unified-agentic-tool-runtime-contract.md`
+- `docs/plans/2026-06-23-issue-1382-tool-registry-parity.md`
+
+## Scope
+
+This slice covers:
+
+- a request-local `allow_web` policy input for deterministic agentic tool
+  selection;
+- a machine-readable tool policy receipt that records explicit web allow/deny,
+  disabled tool IDs, and denied requested tool IDs without raw prompt text;
+- fail-closed selection behavior for `visit` when `allow_web=false`;
+- focused Python tests proving explicit deny beats keyword and vector routing.
+
+This slice does not add live web adapters, outbound HTTP, MCP policy, UI
+controls, or general agent framework behavior. The existing deterministic
+runtime still executes only the selected registry allowlist.
+
+## Architecture
+
+The best end state is one effective tool policy contract shared by CLI, app,
+worker, and future agent sessions. The contract should distinguish a missing
+setting from an explicit operator deny, and selection receipts should explain
+which model-visible tools were disabled before generation.
+
+This PR implements the first worker-owned slice at the existing selector
+boundary:
+
+- `ToolSelectionInput.allow_web` is `None` when no explicit operator choice was
+  supplied, `true` for explicit allow, and `false` for explicit deny.
+- `visit` is treated as the current network-capable agentic tool because it can
+  represent browser/page fetch behavior. Local compute, workspace files, and
+  local corpus lookup remain available.
+- `select_agentic_tools_for_turn(...)` computes disabled tools once, filters
+  keyword and vector-selected tools through the same policy gate, and adds a
+  `melix.agentic_tool_policy.v1` receipt only when an explicit web policy is
+  present or a disabled tool was requested.
+- `DeterministicAgenticToolRuntime` continues to use the selected registry as
+  the execution allowlist, so a denied `visit` call remains an unknown-tool
+  failure instead of attempting any adapter work.
+
+## Performance Probes And Metrics
+
+Selection cost remains bounded by the existing constant-size tool catalog. The
+new policy gate is a set membership check per candidate tool and does not scan
+raw prompt text beyond the existing keyword matcher.
+
+Local metrics for this slice:
+
+- explicit deny with keyword browse intent selects only `local_compute`;
+- explicit deny with vector-selected `visit` selects only `local_compute`;
+- explicit allow keeps existing `visit` selection behavior;
+- policy receipts contain tool IDs and policy decisions, not URLs or prompt
+  content;
+- changed-scope coverage for `tool_registry.py`, `agentic_tools.py`, and their
+  focused tests is at least 95 percent before commit.
+
+## TDD Plan
+
+1. Add failing selector tests in
+   `services/mlx-worker-python/tests/test_tool_registry.py` for
+   `allow_web=false` keyword and vector paths, plus `allow_web=true` receipt
+   visibility.
+2. Add a failing runtime allowlist test in
+   `services/mlx-worker-python/tests/test_agentic_tools.py` proving a denied
+   `visit` call is not executable when the selected registry was built under
+   `allow_web=false`.
+3. Run the focused tests and confirm they fail because `ToolSelectionInput` does
+   not yet accept `allow_web`.
+4. Implement the minimal selector policy fields and receipt in
+   `services/mlx-worker-python/worker/runtime/tool_registry.py`.
+5. Update `docs/unified-agentic-tool-runtime-contract.md` with the request-local
+   tool policy receipt contract.
+6. Run focused tests, changed-scope coverage, `git diff --check`, the relevant
+   tool-registry probe, and the full versioned pre-commit hook before commit.
+
+## Verification Commands
+
+Focused red/green:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_explicit_web_deny_blocks_keyword_visit_with_policy_receipt services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_explicit_web_deny_blocks_vector_visit_with_policy_receipt services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_explicit_web_allow_records_policy_without_disabling_visit services/mlx-worker-python/tests/test_agentic_tools.py::test_agentic_tool_runtime_web_deny_keeps_visit_out_of_execution_allowlist
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_agentic_tools.py
+```
+
+Changed-scope coverage:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_agentic_tools.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
+UV_PYTHON=3.12 uv run python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_agentic_tools.py
+```
+
+Metrics and general checks:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx python3 scripts/tool_registry_select_probe.py
+git diff --check
+.githooks/pre-commit
+```

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -163,6 +163,30 @@ the selector receipt inside its `melix.agentic_tool_run.v1` registry receipt
 when a caller provides a selection input, and the selected registry is the
 execution allowlist for that run.
 
+Request-local tool policy is part of the same selector boundary. The selector
+accepts `allow_web = null|true|false`, where `null` means no explicit operator
+choice was supplied, `true` means web-capable tools are explicitly allowed, and
+`false` means web-capable tools are explicitly denied even when the prompt asks
+to browse, visit, fetch, or open a page. The current network-capable v1 tool is
+`visit`; local compute, workspace-file operations, and local fixture/corpus
+lookup remain separate local capabilities.
+
+When an explicit web policy is present, or when a candidate tool is disabled by
+policy, the selector receipt includes `tool_policy_receipt` with:
+
+- `schema_version = melix.agentic_tool_policy.v1`
+- `allow_web`
+- `explicit_allows[]`
+- `explicit_denies[]`
+- `resolved_disabled_tools[]`
+- `requested_tools[]`
+
+The policy receipt contains only policy states and tool IDs. It must not include
+raw prompts, URLs, tool arguments, account identifiers, or workspace paths. A
+tool that is disabled by policy must be omitted from the selected registry, so
+the deterministic runtime cannot execute it through a later model-emitted tool
+call.
+
 ## Observation Contract
 
 Every emitted observation must include:

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -272,6 +272,38 @@ def test_agentic_tool_runtime_rejects_tool_dropped_by_selection() -> None:
         )
 
 
+def test_agentic_tool_runtime_web_deny_keeps_visit_out_of_execution_allowlist() -> None:
+    tool_selection = ToolSelectionInput(
+        current_user_turn="Visit fixture://page-1 and summarize it.",
+        vector_available=False,
+        max_selected_tools=4,
+        allow_web=False,
+    )
+    run = execute_agentic_tool_calls(
+        [{"id": "compute-1", "name": "local_compute", "arguments": {"code": "1 + 1"}}],
+        tool_selection=tool_selection,
+    )
+
+    selection_receipt = run.registry_receipt["tool_selection_receipt"]
+
+    assert run.registry_receipt["tools"] == ["local_compute"]
+    assert selection_receipt["tool_policy_receipt"] == {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": False,
+        "explicit_allows": [],
+        "explicit_denies": ["web"],
+        "resolved_disabled_tools": ["visit"],
+        "requested_tools": ["visit"],
+    }
+
+    with pytest.raises(AgenticToolRuntimeError, match="Unknown agentic tool requested: visit"):
+        execute_agentic_tool_calls(
+            [{"id": "visit-1", "name": "visit", "arguments": {"url": "fixture://page-1"}}],
+            fixture_context={"pages": {"fixture://page-1": "secret page"}},
+            tool_selection=tool_selection,
+        )
+
+
 @pytest.mark.parametrize(("tool_name", "arguments"), _BUILT_IN_TOOL_CALLS)
 @pytest.mark.parametrize(
     ("override", "expected_status", "expected_failure_stage", "expected_cancelled"),

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -1134,6 +1134,279 @@ def test_agentic_tool_selection_uses_keyword_fallback_when_vector_unavailable() 
     ]
 
 
+def test_agentic_tool_selection_explicit_web_deny_blocks_keyword_visit_with_policy_receipt() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Visit https://example.com/docs and summarize the page.",
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=False,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+    assert result.receipt["fallback_reason"] == "policy_disabled"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"}
+    ]
+    assert result.receipt["tool_policy_receipt"] == {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": False,
+        "explicit_allows": [],
+        "explicit_denies": ["web"],
+        "resolved_disabled_tools": ["visit"],
+        "requested_tools": ["visit"],
+    }
+    assert "https://example.com" not in json.dumps(result.receipt)
+
+
+def test_agentic_policy_append_rejects_invalid_duplicate_and_denied_tools() -> None:
+    selected_names: list[str] = []
+    selected_sources: dict[str, str] = {}
+    selected_tools: list[dict[str, str]] = []
+    denied_tool_names: list[str] = []
+
+    assert not tool_registry_module._append_policy_selected_tool(
+        selected_names,
+        selected_sources,
+        selected_tools,
+        "",
+        "vector",
+        4,
+        frozenset({"visit"}),
+        denied_tool_names,
+    )
+    assert not tool_registry_module._append_policy_selected_tool(
+        selected_names,
+        selected_sources,
+        selected_tools,
+        " \t ",
+        "vector",
+        4,
+        frozenset({"visit"}),
+        denied_tool_names,
+    )
+    assert not tool_registry_module._append_policy_selected_tool(
+        selected_names,
+        selected_sources,
+        selected_tools,
+        "missing_tool",
+        "vector",
+        4,
+        frozenset({"visit"}),
+        denied_tool_names,
+    )
+    assert tool_registry_module._append_policy_selected_tool(
+        selected_names,
+        selected_sources,
+        selected_tools,
+        "local_compute",
+        "always",
+        4,
+        frozenset({"visit"}),
+        denied_tool_names,
+    )
+    assert not tool_registry_module._append_policy_selected_tool(
+        selected_names,
+        selected_sources,
+        selected_tools,
+        "local_compute",
+        "keyword",
+        4,
+        frozenset({"visit"}),
+        denied_tool_names,
+    )
+    assert not tool_registry_module._append_policy_selected_tool(
+        selected_names,
+        selected_sources,
+        selected_tools,
+        " visit ",
+        "keyword",
+        4,
+        frozenset({"visit"}),
+        denied_tool_names,
+    )
+
+    assert selected_names == ["local_compute"]
+    assert selected_tools == [{"tool_id": "local_compute", "source": "always"}]
+    assert denied_tool_names == ["visit"]
+
+
+def test_agentic_tool_policy_receipt_is_absent_without_explicit_policy() -> None:
+    assert (
+        tool_registry_module._agentic_tool_policy_receipt(
+            ToolSelectionInput(current_user_turn="Search local evidence."),
+            None,
+            None,
+        )
+        is None
+    )
+
+
+def test_agentic_tool_selection_explicit_web_deny_max_always_only_records_policy() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Visit https://example.com/docs and summarize the page.",
+            vector_selected_tool_ids=("visit",),
+            vector_available=True,
+            max_selected_tools=1,
+            allow_web=False,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"}
+    ]
+    assert result.receipt["tool_policy_receipt"] == {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": False,
+        "explicit_allows": [],
+        "explicit_denies": ["web"],
+        "resolved_disabled_tools": ["visit"],
+        "requested_tools": [],
+    }
+
+
+def test_agentic_tool_selection_explicit_web_deny_blocks_vector_visit_with_policy_receipt() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Summarize the cited page.",
+            vector_selected_tool_ids=("visit",),
+            vector_available=True,
+            max_selected_tools=4,
+            allow_web=False,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+    assert result.receipt["fallback_reason"] == "policy_disabled"
+    assert result.receipt["tool_policy_receipt"] == {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": False,
+        "explicit_allows": [],
+        "explicit_denies": ["web"],
+        "resolved_disabled_tools": ["visit"],
+        "requested_tools": ["visit"],
+    }
+
+
+def test_agentic_tool_selection_explicit_web_allow_whitespace_turn_records_policy() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn=" \t\n  ",
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=True,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["selection_mode"] == "fallback"
+    assert result.receipt["fallback_reason"] == "no_keyword_match"
+    assert result.receipt["tool_policy_receipt"]["explicit_allows"] == ["web"]
+
+
+def test_agentic_tool_selection_explicit_web_allow_no_keyword_current_falls_back() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer the researcher briefly about cropland.",
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=True,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["fallback_reason"] == "no_keyword_match"
+    assert result.receipt["tool_policy_receipt"]["allow_web"] is True
+
+
+def test_agentic_tool_selection_explicit_web_allow_context_without_keywords_falls_back() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer the researcher briefly about cropland.",
+            recent_user_turns=("Prior note without tool hints.",),
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=True,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute",)
+    assert result.receipt["fallback_reason"] == "no_keyword_match"
+    assert result.receipt["tool_policy_receipt"]["allow_web"] is True
+
+
+def test_agentic_tool_selection_explicit_web_allow_recent_context_keyword_selects_tool() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Use two results this time.",
+            recent_user_turns=("Search the local text evidence.",),
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=True,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selection_mode"] == "keyword"
+    assert result.receipt["fallback_reason"] == "vector_unavailable"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "text_search", "source": "keyword_context"},
+    ]
+    assert result.receipt["tool_policy_receipt"]["allow_web"] is True
+
+
+def test_agentic_tool_selection_explicit_web_allow_vector_selection_returns_vector() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Summarize the cited evidence.",
+            vector_selected_tool_ids=("text_search",),
+            vector_available=True,
+            max_selected_tools=4,
+            allow_web=True,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selection_mode"] == "vector"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "text_search", "source": "vector"},
+    ]
+    assert result.receipt["tool_policy_receipt"]["explicit_allows"] == ["web"]
+
+
+def test_agentic_tool_selection_explicit_web_allow_records_policy_without_disabling_visit() -> None:
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Visit fixture://docs/provider-contract and summarize the page.",
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=True,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "visit")
+    assert result.receipt["selection_mode"] == "keyword"
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "visit", "source": "keyword"},
+    ]
+    assert result.receipt["tool_policy_receipt"] == {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": True,
+        "explicit_allows": ["web"],
+        "explicit_denies": [],
+        "resolved_disabled_tools": [],
+        "requested_tools": [],
+    }
+
+
 def test_agentic_tool_selection_whitespace_turn_skips_casefold() -> None:
     class CasefoldFailingWhitespace(str):
         def casefold(self) -> str:  # pragma: no cover - must not be called

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -72,6 +72,9 @@ SELECTABLE_AGENTIC_TOOL_NAMES = (
 )
 _BUILTIN_AGENTIC_TOOL_NAME_SET = frozenset(SELECTABLE_AGENTIC_TOOL_NAMES)
 ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES = ("local_compute",)
+_EMPTY_AGENTIC_TOOL_NAME_SET: frozenset[str] = frozenset()
+NETWORK_CAPABLE_AGENTIC_TOOL_NAMES = ("visit",)
+_NETWORK_CAPABLE_AGENTIC_TOOL_NAME_SET = frozenset(NETWORK_CAPABLE_AGENTIC_TOOL_NAMES)
 _KEYWORD_MATCHABLE_TOOL_NAMES = tuple(
     tool_name
     for tool_name in SELECTABLE_AGENTIC_TOOL_NAMES
@@ -218,6 +221,7 @@ class ToolSelectionInput:
     vector_selected_tool_ids: tuple[str, ...] = ()
     vector_available: bool = False
     max_selected_tools: int = len(SELECTABLE_AGENTIC_TOOL_NAMES)
+    allow_web: bool | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -567,10 +571,44 @@ def _append_selected_tool(
     return True
 
 
+def _append_policy_selected_tool(
+    selected_names: list[str],
+    selected_sources: dict[str, str],
+    selected_tools: list[dict[str, str]],
+    tool_name: str,
+    source: str,
+    max_selected_tools: int,
+    disabled_tool_names: frozenset[str] | None,
+    denied_tool_names: list[str] | None,
+) -> bool:
+    if len(selected_names) >= max_selected_tools or not tool_name:
+        return False
+    if tool_name[0].isspace() or tool_name[-1].isspace():
+        normalized_name = tool_name.strip()
+        if not normalized_name:
+            return False
+    else:
+        normalized_name = tool_name
+    if normalized_name in selected_sources:
+        return False
+    if normalized_name not in _BUILTIN_AGENTIC_TOOL_NAME_SET:
+        return False
+    if disabled_tool_names is not None and normalized_name in disabled_tool_names:
+        if denied_tool_names is not None and normalized_name not in denied_tool_names:
+            denied_tool_names.append(normalized_name)
+        return False
+    selected_sources[normalized_name] = source
+    selected_names.append(normalized_name)
+    selected_tools.append({"tool_id": normalized_name, "source": source})
+    return True
+
+
 def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSelectionResult:
+    if selection_input.allow_web is not None:
+        return _select_agentic_tools_for_turn_with_policy(selection_input)
     registry = agentic_tool_catalog_registry()
-    max_selected_tools = max(1, selection_input.max_selected_tools)
-    if max_selected_tools == 1:
+    max_selected_tools = selection_input.max_selected_tools
+    if max_selected_tools <= 1:
         return _build_always_only_tool_selection_result(registry, selection_input)
     current_user_turn = selection_input.current_user_turn
     if (
@@ -689,9 +727,196 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
     )
 
 
+def _select_agentic_tools_for_turn_with_policy(selection_input: ToolSelectionInput) -> ToolSelectionResult:
+    registry = agentic_tool_catalog_registry()
+    max_selected_tools = selection_input.max_selected_tools
+    allow_web = selection_input.allow_web
+    disabled_tool_names = _disabled_agentic_tool_names(selection_input) if allow_web is False else None
+    denied_tool_names: list[str] | None = [] if allow_web is False else None
+    allowed_policy_receipt = (
+        _agentic_tool_policy_receipt(selection_input, _EMPTY_AGENTIC_TOOL_NAME_SET, None)
+        if allow_web is True
+        else None
+    )
+    if max_selected_tools <= 1:
+        return _build_always_only_tool_selection_result(
+            registry,
+            selection_input,
+            tool_policy_receipt=(
+                _agentic_tool_policy_receipt(selection_input, disabled_tool_names, denied_tool_names)
+                if allow_web is False
+                else allowed_policy_receipt
+            ),
+        )
+    current_user_turn = selection_input.current_user_turn
+    if (
+        not selection_input.vector_selected_tool_ids
+        and not selection_input.recent_user_turns
+        and (not current_user_turn or current_user_turn.isspace())
+    ):
+        return _build_always_only_tool_selection_result(
+            registry,
+            selection_input,
+            tool_policy_receipt=(
+                _agentic_tool_policy_receipt(selection_input, disabled_tool_names, denied_tool_names)
+                if allow_web is False
+                else allowed_policy_receipt
+            ),
+        )
+    current_matches: tuple[str, ...] | None = None
+    context_matches: tuple[str, ...] | None = None
+    if not selection_input.vector_selected_tool_ids:
+        current_matches = _keyword_tool_matches(current_user_turn)
+        if not current_matches:
+            if selection_input.recent_user_turns:
+                context_matches = _keyword_tool_matches(
+                    _recent_user_turns_keyword_context(selection_input.recent_user_turns)
+                )
+                if not context_matches:
+                    return _build_always_only_tool_selection_result(
+                        registry,
+                        selection_input,
+                        tool_policy_receipt=(
+                            _agentic_tool_policy_receipt(
+                                selection_input, disabled_tool_names, denied_tool_names
+                            )
+                            if allow_web is False
+                            else allowed_policy_receipt
+                        ),
+                    )
+            else:
+                return _build_always_only_tool_selection_result(
+                    registry,
+                    selection_input,
+                    tool_policy_receipt=(
+                        _agentic_tool_policy_receipt(
+                            selection_input, disabled_tool_names, denied_tool_names
+                        )
+                        if allow_web is False
+                        else allowed_policy_receipt
+                    ),
+                )
+    selected_sources: dict[str, str] = {}
+    selected_names: list[str] = []
+    selected_tools: list[dict[str, str]] = []
+    append_selected_tool = _append_policy_selected_tool
+    has_vector_selection = False
+    has_keyword_selection = False
+
+    for tool_name in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES:
+        append_selected_tool(
+            selected_names,
+            selected_sources,
+            selected_tools,
+            tool_name,
+            "always",
+            max_selected_tools,
+            disabled_tool_names,
+            denied_tool_names,
+        )
+
+    selection_mode = "fallback"
+    fallback_reason = "no_keyword_match"
+
+    if selection_input.vector_available and selection_input.vector_selected_tool_ids:
+        for tool_name in selection_input.vector_selected_tool_ids:
+            if append_selected_tool(
+                selected_names,
+                selected_sources,
+                selected_tools,
+                tool_name,
+                "vector",
+                max_selected_tools,
+                disabled_tool_names,
+                denied_tool_names,
+            ):
+                has_vector_selection = True
+        if has_vector_selection:
+            return _build_tool_selection_result(
+                registry,
+                selected_names,
+                selected_tools,
+                selection_input,
+                "vector",
+                "",
+                tool_policy_receipt=(
+                    _agentic_tool_policy_receipt(
+                        selection_input, disabled_tool_names, denied_tool_names
+                    )
+                    if allow_web is False
+                    else allowed_policy_receipt
+                ),
+            )
+
+    if selection_mode != "vector":
+        if current_matches is None:
+            current_matches = _keyword_tool_matches(selection_input.current_user_turn)
+        for tool_name in current_matches:
+            if append_selected_tool(
+                selected_names,
+                selected_sources,
+                selected_tools,
+                tool_name,
+                "keyword",
+                max_selected_tools,
+                disabled_tool_names,
+                denied_tool_names,
+            ):
+                has_keyword_selection = True
+        if selection_input.recent_user_turns and len(selected_names) < max_selected_tools:
+            if context_matches is None:
+                context_matches = _keyword_tool_matches(
+                    _recent_user_turns_keyword_context(selection_input.recent_user_turns)
+                )
+            for tool_name in context_matches:
+                if append_selected_tool(
+                    selected_names,
+                    selected_sources,
+                    selected_tools,
+                    tool_name,
+                    "keyword_context",
+                    max_selected_tools,
+                    disabled_tool_names,
+                    denied_tool_names,
+                ):
+                    has_keyword_selection = True
+        if has_keyword_selection:
+            selection_mode = "keyword"
+            fallback_reason = "vector_unavailable" if not selection_input.vector_available else "vector_no_match"
+
+    if not has_vector_selection and not has_keyword_selection:
+        return _build_always_only_tool_selection_result(
+            registry,
+            selection_input,
+            fallback_reason=_policy_fallback_reason(denied_tool_names),
+            tool_policy_receipt=(
+                _agentic_tool_policy_receipt(selection_input, disabled_tool_names, denied_tool_names)
+                if allow_web is False
+                else allowed_policy_receipt
+            ),
+        )
+
+    return _build_tool_selection_result(
+        registry,
+        selected_names,
+        selected_tools,
+        selection_input,
+        selection_mode,
+        fallback_reason,
+        tool_policy_receipt=(
+            _agentic_tool_policy_receipt(selection_input, disabled_tool_names, denied_tool_names)
+            if allow_web is False
+            else allowed_policy_receipt
+        ),
+    )
+
+
 def _build_always_only_tool_selection_result(
     registry: ToolRegistry,
     selection_input: ToolSelectionInput,
+    *,
+    fallback_reason: str = "no_keyword_match",
+    tool_policy_receipt: dict[str, Any] | None = None,
 ) -> ToolSelectionResult:
     selected_name = "local_compute"
     if registry is _AGENTIC_TOOL_CATALOG_REGISTRY:
@@ -704,20 +929,20 @@ def _build_always_only_tool_selection_result(
         registry_metrics = registry.metrics()
         selected_metrics = selected_registry.metrics()
         dropped_tool_count = max(0, registry_metrics.tool_count - selected_metrics.tool_count)
-    return ToolSelectionResult(
-        registry=selected_registry,
-        receipt={
-            "schema_version": "melix.agentic_tool_selection.v1",
-            "toolset_version": BUILTIN_TOOLSET_VERSION,
-            "selection_mode": "fallback",
-            "vector_available": selection_input.vector_available,
-            "fallback_reason": "no_keyword_match",
-            "selected_tools": [{"tool_id": selected_name, "source": "always"}],
-            "dropped_tool_count": dropped_tool_count,
-            "full_schema_bytes": registry_metrics.schema_bytes,
-            "selected_schema_bytes": selected_metrics.schema_bytes,
-        },
-    )
+    receipt = {
+        "schema_version": "melix.agentic_tool_selection.v1",
+        "toolset_version": BUILTIN_TOOLSET_VERSION,
+        "selection_mode": "fallback",
+        "vector_available": selection_input.vector_available,
+        "fallback_reason": fallback_reason,
+        "selected_tools": [{"tool_id": selected_name, "source": "always"}],
+        "dropped_tool_count": dropped_tool_count,
+        "full_schema_bytes": registry_metrics.schema_bytes,
+        "selected_schema_bytes": selected_metrics.schema_bytes,
+    }
+    if tool_policy_receipt is not None:
+        receipt["tool_policy_receipt"] = tool_policy_receipt
+    return ToolSelectionResult(registry=selected_registry, receipt=receipt)
 
 
 def _build_tool_selection_result(
@@ -727,6 +952,8 @@ def _build_tool_selection_result(
     selection_input: ToolSelectionInput,
     selection_mode: str,
     fallback_reason: str,
+    *,
+    tool_policy_receipt: dict[str, Any] | None = None,
 ) -> ToolSelectionResult:
     if len(selected_names) == 1:
         selected_name = selected_names[0]
@@ -747,7 +974,41 @@ def _build_tool_selection_result(
         "full_schema_bytes": registry_metrics.schema_bytes,
         "selected_schema_bytes": selected_metrics.schema_bytes,
     }
+    if tool_policy_receipt is not None:
+        receipt["tool_policy_receipt"] = tool_policy_receipt
     return ToolSelectionResult(registry=selected_registry, receipt=receipt)
+
+
+def _disabled_agentic_tool_names(selection_input: ToolSelectionInput) -> frozenset[str]:
+    if selection_input.allow_web is False:
+        return _NETWORK_CAPABLE_AGENTIC_TOOL_NAME_SET
+    return _EMPTY_AGENTIC_TOOL_NAME_SET
+
+
+def _policy_fallback_reason(denied_tool_names: list[str] | None) -> str:
+    return "policy_disabled" if denied_tool_names else "no_keyword_match"
+
+
+def _agentic_tool_policy_receipt(
+    selection_input: ToolSelectionInput,
+    disabled_tool_names: frozenset[str] | None,
+    denied_tool_names: list[str] | None,
+) -> dict[str, Any] | None:
+    if selection_input.allow_web is None and not disabled_tool_names and not denied_tool_names:
+        return None
+    disabled_tool_names = disabled_tool_names or _EMPTY_AGENTIC_TOOL_NAME_SET
+    disabled = [
+        tool_name for tool_name in SELECTABLE_AGENTIC_TOOL_NAMES if tool_name in disabled_tool_names
+    ]
+    requested = list(dict.fromkeys(denied_tool_names or ()))
+    return {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": selection_input.allow_web,
+        "explicit_allows": ["web"] if selection_input.allow_web is True else [],
+        "explicit_denies": ["web"] if selection_input.allow_web is False else [],
+        "resolved_disabled_tools": disabled,
+        "requested_tools": requested,
+    }
 
 
 def _recent_user_turns_keyword_context(recent_user_turns: tuple[str, ...]) -> str:
@@ -1105,6 +1366,7 @@ __all__ = [
     "BUILTIN_TOOLSET_VERSION",
     "DEFAULT_TOOL_PARSER",
     "DEFAULT_TOOL_PARSER_CONTRACT_VERSION",
+    "NETWORK_CAPABLE_AGENTIC_TOOL_NAMES",
     "SELECTABLE_AGENTIC_TOOL_NAMES",
     "TOOL_REGISTRY_SCHEMA_VERSION",
     "ToolArgumentDescriptor",


### PR DESCRIPTION
## Summary
- Adds a request-local `allow_web` policy input to agentic tool selection and treats `visit` as the first network-capable tool.
- Emits sanitized `melix.agentic_tool_policy.v1` receipts when web access is explicitly allowed or denied, without echoing prompts, URLs, paths, account IDs, or tool arguments.
- Keeps policy-disabled network tools out of the selected runtime registry and updates the governing plan/spec plus selector/runtime tests.

Refs #1382

## Plan or Spec
- `docs/plans/2026-07-09-issue-1382-network-tool-consent.md`
- `docs/unified-agentic-tool-runtime-contract.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_agentic_tools.py
=> 217 passed in 0.19s

.githooks/pre-commit via git commit
=> passed: make swift-test (rc=0, 495.9s); make py-test (4866 passed, 14 skipped, 2 warnings in 166.29s); make integration-test (123 passed, 1 skipped in 756.12s); scoped performance status ok

make swift-test
=> passed after merging origin/main

make py-test
=> 4867 passed, 14 skipped, 2 warnings in 168.04s

make integration-test
=> 123 passed, 1 skipped in 686.15s

make bootstrap
=> passed

make proto
=> passed

UV_PYTHON=3.12 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
from scripts.pre_commit_gate import run_performance_report
changed_files = [
    "docs/plans/2026-07-09-issue-1382-network-tool-consent.md",
    "docs/unified-agentic-tool-runtime-contract.md",
    "services/mlx-worker-python/tests/test_agentic_tools.py",
    "services/mlx-worker-python/tests/test_tool_registry.py",
    "services/mlx-worker-python/worker/runtime/tool_registry.py",
]
outcome = run_performance_report(Path.cwd(), changed_files, base_ref="origin/main")
print(f"PERF_STATUS={outcome.status}")
print(f"PERF_REPORT_DIR={outcome.report_dir}")
print(f"PERF_PROBE_COUNT={outcome.selected_probe_count}")
raise SystemExit(0 if outcome.status == "ok" else 1)
PY
=> PERF_STATUS=ok; PERF_PROBE_COUNT=5; report `.runtime/pre-commit-performance/20260709-132329-2659d7f5/report/report.md`
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 173 2 99%`.
- Scoped performance report: status `ok`, changed files `5`, selected probes `5`, regressions `0`, context regressions `0`, verification failures `0`.
- Tool registry select probe: `elapsed_ms_mean` base `10.780` ms, head `10.778` ms; selector planning base `12.419` ms, head `12.468` ms; all metrics neutral.
- Observability mode: `minimal`; policy receipts are request-local and sanitized.
- Probe overhead: covered by the scoped performance report above; no new production metrics, debug artifacts, or evidence-mode bundles are introduced.

## Known Gaps
- This slice wires selector/runtime policy enforcement and sanitized receipts for `visit`; request parsing, UI consent controls, and the final user-facing rescue/nudge copy remain follow-up work under #1382.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protobuf schema changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
