### PR TITLE
perf(dataset): streamline source record classification

### DIFF
--- a/docs/plans/2026-07-09-dataset-source-kind-record-fastpath.md
+++ b/docs/plans/2026-07-09-dataset-source-kind-record-fastpath.md
@@ -1,0 +1,46 @@
+# Dataset Source Kind and Record Fast Path Slice
+
+## Scope
+
+This Python performance slice is limited to the dataset ingest source-record hot path in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+The slice keeps dataset ingest behavior unchanged while trimming per-file overhead in the
+registered source-record probe:
+
+- use direct `str.endswith(...)` checks for the common lowercase source suffix fast path;
+- avoid rebinding `hashlib.sha256` for each `_record(...)` call before computing the
+  source-id digest.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry
+includes focused `test_command`, `coverage_command`, and `probe_command` commands and
+watches this source file, `test_dataset_preparation_ingest.py`,
+`test_pr_scoped_performance.py`, and `scripts/dataset_source_records_probe.py`.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered probe on
+Linux before opening the PR. The probe reports path discovery, source-kind classification,
+and record materialization timings for a 7k-file synthetic source tree.
+
+Baseline sampled locally before the change:
+
+```text
+elapsed_ms_mean=12.051951822782444
+source_kind_elapsed_ms_mean=19.16712398683144
+record_elapsed_ms_mean=17.576634539926257
+```
+
+Post-change sampled locally three times:
+
+```text
+run1 elapsed_ms_mean=11.367001459637487 source_kind_elapsed_ms_mean=18.949219819412313 record_elapsed_ms_mean=18.316107913216744
+run2 elapsed_ms_mean=11.179960459809411 source_kind_elapsed_ms_mean=17.782539912414823 record_elapsed_ms_mean=17.2133029978299
+run3 elapsed_ms_mean=11.004839457613839 source_kind_elapsed_ms_mean=17.584661275825717 record_elapsed_ms_mean=16.922688185745344
+```
+
+Decision: accept only if focused tests and changed-scope coverage pass and the registered
+CI probe also completes successfully without an in-scope regression.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1278,28 +1278,28 @@ def _classify_source_kind_name(name: str) -> str | None:
         return None
     last_char = name[-1]
     if last_char == "t":
-        if name[-4:] == ".txt":
+        if name.endswith(".txt"):
             if len(name) >= 8 and name[-8] == "." and name[-7:-4].lower() == "pdf":
                 return "pdf"
             if len(name) >= 9 and name[-9] == "." and name[-8:-4].lower() == "docx":
                 return "docx"
             return "text"
-        if name[-5:] == ".text":
+        if name.endswith(".text"):
             return "text"
     elif last_char == "d":
-        if name[-3:] == ".md":
+        if name.endswith(".md"):
             return "markdown"
     elif last_char == "y":
-        if name[-3:] == ".py":
+        if name.endswith(".py"):
             return "code"
     elif last_char == "l":
-        if name[-6:] == ".jsonl":
+        if name.endswith(".jsonl"):
             return "structured_data"
     elif last_char == "n":
-        if name[-5:] == ".json":
+        if name.endswith(".json"):
             return "structured_data"
     elif last_char == "v":
-        if name[-4:] in (".csv", ".tsv"):
+        if name.endswith((".csv", ".tsv")):
             return "structured_data"
 
     dot_index = name.rfind(".")
@@ -1516,11 +1516,10 @@ def _record(
     normalized_text = text if normalized else _normalize_line_endings(text)
     content_sha256, byte_size = _record_content_digest_and_size(normalized_text)
     record_metadata = dict(metadata) if metadata else {}
-    sha256 = hashlib.sha256
     path_name = path.name
     path_key = str(path).encode("utf-8")
     return {
-        "source_id": sha256(path_key).hexdigest()[:16],
+        "source_id": hashlib.sha256(path_key).hexdigest()[:16],
         "source_uri": path_name,
         "source_kind": source_kind,
         "content_sha256": content_sha256,


### PR DESCRIPTION
## Summary
- Streamline the dataset source-record ingest hot path in `dataset_preparation.py`.
- Use direct suffix predicates for common source-kind names and avoid a per-record local `sha256` rebinding.
- Keep the slice covered by the existing registered `dataset-source-records-scandir` PR-scoped probe.

## Plan or Spec
- `docs/plans/2026-07-09-dataset-source-kind-record-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 47 passed in 0.56s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 47 passed in 1.15s; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# {"elapsed_ms_mean": 11.620821817566387, "elapsed_ms_min": 10.894948965869844, "elapsed_ms_p95": 12.937218009028584, "file_count_mean": 7000.0, "record_elapsed_ms_mean": 17.201614455023613, "record_elapsed_ms_min": 16.43234200309962, "record_elapsed_ms_p95": 18.15010199788958, "source_kind_elapsed_ms_mean": 18.446342993146654, "source_kind_elapsed_ms_min": 17.70216302247718, "source_kind_elapsed_ms_p95": 19.023840955924243}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%`.
- Registered probe: `dataset-source-records-scandir`.
- Local baseline from the plan: `elapsed_ms_mean=12.051951822782444`, `source_kind_elapsed_ms_mean=19.16712398683144`, `record_elapsed_ms_mean=17.576634539926257`.
- Local post-change run: `elapsed_ms_mean=11.620821817566387` (delta `-0.4311300052160573 ms`, ~`3.58%` faster), `source_kind_elapsed_ms_mean=18.446342993146654` (delta `-0.7207809936847863 ms`), `record_elapsed_ms_mean=17.201614455023613` (delta `-0.375020084902644 ms`).
- CI PR-scoped performance is required for final registered-probe validation before merge.

## Known Gaps
- Linux local checks validate the Python path only; final acceptance requires the GitHub Actions PR-scoped performance report to complete successfully.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
