### PR TITLE
perf(model-registry): bound Gemma4 README marker validation

### DIFF
--- a/docs/plans/2026-07-09-gemma4-readme-quoted-marker-window.md
+++ b/docs/plans/2026-07-09-gemma4-readme-quoted-marker-window.md
@@ -1,0 +1,22 @@
+# Gemma4 README quoted-marker search window performance slice
+
+## Scope
+
+This Python-only performance slice is limited to the Gemma4 QAT README `base_model:` extraction helper in `services/mlx-worker-python/worker/model_registry/catalog.py`.
+
+The behavior remains unchanged: an earlier valid unquoted `base_model:` line still takes precedence over a later quoted YAML list-style marker, invalid marker prefixes are ignored, and the existing model-size fallback remains intact.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `model-registry-readme-source-fastpath` in `infra/perf/pr_scoped_probes.json`. The registry entry provides focused `test_command`, `coverage_command`, and `probe_command` entries for the model registry README source path.
+
+## Slice plan
+
+1. Keep the existing quoted-marker fast path, but bound the preliminary earlier-marker validation search to the text before the quoted marker.
+2. Preserve fallback scanning for READMEs with an earlier valid marker or invalid marker prefixes.
+3. Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before opening the PR.
+4. Use GitHub Actions PR-scoped performance as the merge gate for the registered probe report.
+
+## Metrics
+
+Primary metric: `new_elapsed_ms_mean` from `scripts/model_registry_readme_source_probe.py`; lower is better. The probe also reports `speedup`, `delta_ms`, and peak bytes against the legacy line-splitting source extraction baseline.

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -2036,13 +2036,13 @@ def _gemma4_qat_source_model(
     quoted_marker_index = readme_text.find(_GEMMA4_QAT_QUOTED_BASE_MODEL_MARKER)
     if quoted_marker_index >= 0:
         quoted_marker_start = quoted_marker_index + len("\n  '")
-        marker_index = readme_text.find(marker)
-        while 0 <= marker_index < quoted_marker_start:
+        marker_index = readme_text.find(marker, 0, quoted_marker_start)
+        while marker_index >= 0:
             line_start = readme_text.rfind("\n", 0, marker_index) + 1
             if not readme_text[line_start:marker_index].strip(" \t\r'\""):
                 break
-            marker_index = readme_text.find(marker, marker_index + 1)
-        if marker_index != quoted_marker_start:
+            marker_index = readme_text.find(marker, marker_index + 1, quoted_marker_start)
+        if marker_index >= 0:
             quoted_marker_index = -1
     if quoted_marker_index >= 0:
         value_start = quoted_marker_index + _GEMMA4_QAT_QUOTED_BASE_MODEL_MARKER_LEN


### PR DESCRIPTION
## Summary
- Bounds Gemma4 QAT README quoted `base_model:` validation to the prefix before the quoted marker.
- Preserves precedence for earlier valid markers and fallback handling for invalid marker prefixes.

## Plan or Spec
- `docs/plans/2026-07-09-gemma4-readme-quoted-marker-window.md`
- Registered PR-scoped probe: `model-registry-readme-source-fastpath`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_keeps_gemma4_qat_target_when_readme_mentions_assistant services/mlx-worker-python/tests/test_model_registry_catalog.py::test_gemma4_qat_source_model_rejects_non_marker_prefix_without_prefix_strip services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_readme_source_probe_command_emits_metrics
# 3 passed in 5.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_raw_model_spec_loads_config_payload_when_not_supplied services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_direct_mlx_signal_accepts_exact_and_normalized_values services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_has_mlx_signal_skips_json_for_direct_metadata services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_has_mlx_signal_does_not_request_sorted_json services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_text_has_mlx_signal_short_circuits_negative_metadata services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_keeps_gemma4_qat_target_when_readme_mentions_assistant services/mlx-worker-python/tests/test_model_registry_catalog.py::test_gemma4_qat_source_model_rejects_non_marker_prefix_without_prefix_strip services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_marks_gemma4_qat_assistant_as_draft_companion services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_readme_source_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 13 passed in 4.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_registry/catalog.py services/mlx-worker-python/tests/test_model_registry_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_registry_readme_source_probe.py
# 13 passed in 4.53s; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_registry_readme_source_probe.py
# run 1: new_elapsed_ms_mean=0.0909245065, speedup=29.1186266, delta_ms=-2.55667225, new_peak_bytes_mean=413
# run 2: new_elapsed_ms_mean=0.0933307128, speedup=28.6817496, delta_ms=-2.58355743, new_peak_bytes_mean=413
# run 3: new_elapsed_ms_mean=0.0890903312, speedup=29.5338897, delta_ms=-2.54209368, new_peak_bytes_mean=413

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# local direct old-vs-new helper harness
PY
# old=(0.0908989613 ms/call, 473 peak bytes); new=(0.0896182491 ms/call, 445 peak bytes)

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered local probe (3 runs): `new_elapsed_ms_mean` = 0.0909245065 / 0.0933307128 / 0.0890903312 ms; `new_peak_bytes_mean=413`; speedup vs legacy line-splitting baseline = 29.12x / 28.68x / 29.53x.
- Direct old-vs-new helper harness for this slice: old `0.0908989613 ms/call`, new `0.0896182491 ms/call` (~1.4% lower); old peak `473`, new peak `445`.
- CI PR-scoped performance report is required before merge and is the registered probe validation source.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime effect is claimed.
- The direct old-vs-new improvement is intentionally small; CI registered probe must confirm no regression before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode changes.
- [x] Deferred work and known gaps are stated explicitly.
