### PR TITLE
perf(tool-registry): seed local compute selection directly

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -210,6 +210,28 @@ Expected effect:
 - leave vector, keyword, whitespace, max-capacity, registry selection, OpenAI
   schema generation, and protobuf config materialization unchanged.
 
+## Follow-up Slice: Local Compute Seed Fast Path
+
+The 2026-07-09 follow-up keeps non-policy agentic tool selection receipts
+unchanged, but seeds the built-in always-available `local_compute` selection
+state directly after the early always-only exits. The selector already requires
+`local_compute` as the sole always-available tool and `max_selected_tools > 1` at
+that point, so this avoids one helper call, membership check, duplicate check,
+and whitespace normalization guard before vector or keyword tools are appended.
+Policy-aware selection keeps the generic helper path because it must still apply
+network/tool policy receipts and denied-tool bookkeeping.
+
+Expected effect:
+
+- reduce `tool-registry-select-name-index-cache`
+  `selector_planning_elapsed_ms_mean` and
+  `current_capacity_planning_elapsed_ms_mean` for non-policy selections that add
+  vector or keyword tools;
+- preserve selected registry identity, selected tool order, selected schema
+  bytes, full schema bytes, and receipt fields;
+- leave policy-aware selection, registry selection, OpenAI schema generation,
+  and protobuf config materialization unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.
@@ -218,7 +240,9 @@ Expected effect:
 3. Run the registered probe command locally before and after the slice and
    compare the relevant registered metric (`schema_payload_elapsed_ms_mean` for
    schema-payload slices, `elapsed_ms_mean` for the OpenAI tool payload slice,
-   or `no_keyword_fallback_planning_elapsed_ms_mean` for the no-keyword
-   fallback slice) over repeated samples.
+   `no_keyword_fallback_planning_elapsed_ms_mean` for the no-keyword fallback
+   slice, or `selector_planning_elapsed_ms_mean` and
+   `current_capacity_planning_elapsed_ms_mean` for the local-compute seed slice)
+   over repeated samples.
 4. Push only if local evidence is neutral-to-improved and rely on the GitHub
    PR-scoped performance workflow as the merge gate.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -818,6 +818,53 @@ def test_tool_registry_worker_tool_config_reuses_cached_serialized_snapshot(
     assert registry.as_worker_tool_config().tools[0].name == "image_crop"
 
 
+def test_agentic_tool_selection_seeds_local_compute_without_append_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    appended_tool_names: list[str] = []
+    original_append_selected_tool = tool_registry_module._append_selected_tool
+
+    def tracking_append_selected_tool(
+        selected_names: list[str],
+        selected_sources: dict[str, str],
+        selected_tools: list[dict[str, str]],
+        tool_name: str,
+        source: str,
+        max_selected_tools: int,
+    ) -> bool:
+        appended_tool_names.append(tool_name)
+        return original_append_selected_tool(
+            selected_names,
+            selected_sources,
+            selected_tools,
+            tool_name,
+            source,
+            max_selected_tools,
+        )
+
+    monkeypatch.setattr(
+        tool_registry_module,
+        "_append_selected_tool",
+        tracking_append_selected_tool,
+    )
+
+    result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Search the local corpus, then calculate the answer.",
+            vector_selected_tool_ids=("text_search",),
+            vector_available=True,
+            max_selected_tools=3,
+        )
+    )
+
+    assert result.registry.names() == ("local_compute", "text_search")
+    assert result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"},
+        {"tool_id": "text_search", "source": "vector"},
+    ]
+    assert appended_tool_names == ["text_search"]
+
+
 def test_agentic_tool_selection_preserves_always_available_tools_with_vector_hits() -> None:
     result = select_agentic_tools_for_turn(
         ToolSelectionInput(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -632,22 +632,13 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
                     )
             else:
                 return _build_always_only_tool_selection_result(registry, selection_input)
-    selected_sources: dict[str, str] = {}
-    selected_names: list[str] = []
-    selected_tools: list[dict[str, str]] = []
+    selected_name = "local_compute"
+    selected_sources: dict[str, str] = {selected_name: "always"}
+    selected_names: list[str] = [selected_name]
+    selected_tools: list[dict[str, str]] = [{"tool_id": selected_name, "source": "always"}]
     append_selected_tool = _append_selected_tool
     has_vector_selection = False
     has_keyword_selection = False
-
-    for tool_name in ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES:
-        append_selected_tool(
-            selected_names,
-            selected_sources,
-            selected_tools,
-            tool_name,
-            "always",
-            max_selected_tools,
-        )
 
     selection_mode = "fallback"
     fallback_reason = "no_keyword_match"


### PR DESCRIPTION
## Summary
- Seed the built-in non-policy `local_compute` selection state directly before vector/keyword tool appends.
- Add a regression test proving `local_compute` is present without routing through the append helper.
- Update the tool-registry performance plan with the local-compute seed slice and expected metrics.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`
- Registered probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_seeds_local_compute_without_append_helper services/mlx-worker-python/tests/test_tool_registry.py::test_agentic_tool_selection_preserves_always_available_tools_with_vector_hits`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=100000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- Candidate probe on this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TOOL_REGISTRY_SELECT_ITERATIONS=100000 MELIX_TOOL_REGISTRY_SELECT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused regression tests: `2 passed in 0.26s`.
- Registered focused tests: `117 passed in 1.33s`.
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Local registered probe (`tool_registry_select_probe.py`, 100000 iterations, 5 samples):
  - `selector_planning_elapsed_ms_mean`: baseline `40.45544859254733`, candidate `38.95764739718288` (delta `-1.4978011953644454 ms`, `3.70%` faster).
  - `current_capacity_planning_elapsed_ms_mean`: baseline `37.92607499053702`, candidate `36.31911661941558` (delta `-1.6069583711214364 ms`, `4.24%` faster).
  - `elapsed_ms_mean`: baseline `28.08550698682666`, candidate `27.499205817002803` (delta `-0.5863011698238558 ms`, `2.09%` faster).
- CI PR-scoped performance is required as the merge gate for the registered probe report.

## Known Gaps
- Local validation was Linux-only. This slice changes Python worker code only, so local Linux verification covers the affected runtime path.
- Some adjacent probe metrics vary with noise; merge is gated on the registered GitHub Actions PR-scoped performance workflow.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally before and after the slice.
- [ ] GitHub Actions checks passed.
- [ ] PR-scoped performance workflow completed successfully.
