### PR TITLE
perf(evaluation): slot final result records

### DIFF
--- a/docs/plans/2026-07-09-evaluation-final-result-slotted-records.md
+++ b/docs/plans/2026-07-09-evaluation-final-result-slotted-records.md
@@ -1,0 +1,26 @@
+# Evaluation final result slotted records
+
+## Goal
+
+Reduce per-record Python allocation overhead on the evaluation final-result path by making the immutable request, source, and result records slotted. The behavior stays unchanged: extraction, scoring, materialization request wiring, and Hugging Face source defaults remain the same.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `evaluation-final-result-json-typed-score-aggregate` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_evaluation_final_result.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/evaluation_json_typed_score_probe.py`
+
+The probe reports elapsed time and peak bytes for repeated JSON typed scoring against a deterministic nested payload.
+
+## Slice
+
+- Add `slots=True` to immutable evaluation final-result dataclasses.
+- Add a regression test proving the public records do not expose per-instance `__dict__` while preserving extraction, scoring, request, materialization, and HF source behavior.
+- Do not change extraction heuristics, scoring semantics, cache keys, file formats, or probe behavior.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before opening the PR. GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -14,6 +14,7 @@ from worker.productization.evaluation_final_result import (
     HFEvaluationDatasetSource,
     EvaluationMaterializationRequest,
     EvaluationProfileDefinition,
+    MaterializedEvaluationDataset,
     _local_source_metadata,
     _last_nonblank_text_line,
     _json_typed_score,
@@ -22,6 +23,59 @@ from worker.productization.evaluation_final_result import (
     materialize_local_evaluation_dataset,
     score_final_result,
 )
+
+
+def test_evaluation_final_result_records_are_slotted_without_behavior_drift(
+    tmp_path: Path,
+) -> None:
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="heuristic_final",
+        scoring_mode="json_typed",
+        threshold=0.8,
+        output_schema={"type": "object"},
+        ignored_paths=("metadata.confidence",),
+    )
+    field_mapping = EvaluationFieldMapping(
+        system_path="meta.system",
+        input_text_path="payload.question",
+        target_path="payload.answer",
+        sample_id_path="id",
+    )
+    request = EvaluationMaterializationRequest(
+        source_kind="local_jsonl",
+        source_path=tmp_path / "source.jsonl",
+        profile=profile,
+        field_mapping=field_mapping,
+        dataset_id="dataset-a",
+        suite_id="suite-a",
+    )
+    materialized = MaterializedEvaluationDataset(
+        package_path=tmp_path / "package",
+        cache_key="cache-key",
+        cache_hit=False,
+    )
+    hf_source = HFEvaluationDatasetSource("org/dataset", dataset_name="config", split="test")
+    extracted = extract_final_result(
+        raw_response='```json\n{"answer": "Paris"}\n```',
+        result_kind="json",
+        extraction_mode="heuristic_final",
+    )
+    scored = score_final_result(
+        extracted_result='{"answer": "Paris", "metadata": {"confidence": 0.1}}',
+        target='{"answer": "Paris", "metadata": {"confidence": 0.9}}',
+        profile=profile,
+    )
+
+    records = (profile, field_mapping, request, materialized, hf_source, extracted, scored)
+    assert all(not hasattr(record, "__dict__") for record in records)
+    assert request.field_mapping.target_path == "payload.answer"
+    assert materialized.cache_hit is False
+    assert hf_source.dataset_revision == "main"
+    assert extracted.extraction_status == "extracted"
+    assert scored.validation_status == "validated"
+    assert scored.typed_score == 1.0
 
 
 def test_json_typed_score_short_circuits_exact_root_match_before_child_iteration() -> None:

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -38,7 +38,7 @@ _HF_DATASETS_SERVER_URL = "https://datasets-server.huggingface.co"
 HFEvaluationDatasetFetcher = Callable[[str, dict[str, str]], dict[str, Any]]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EvaluationProfileDefinition:
     profile_type: str
     result_kind: str
@@ -49,7 +49,7 @@ class EvaluationProfileDefinition:
     ignored_paths: tuple[str, ...] = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EvaluationFieldMapping:
     system_path: str = ""
     input_text_path: str = ""
@@ -57,7 +57,7 @@ class EvaluationFieldMapping:
     sample_id_path: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EvaluationMaterializationRequest:
     source_kind: str
     source_path: Path
@@ -67,14 +67,14 @@ class EvaluationMaterializationRequest:
     suite_id: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MaterializedEvaluationDataset:
     package_path: Path
     cache_key: str
     cache_hit: bool
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HFEvaluationDatasetSource:
     dataset_path: str
     dataset_name: str = ""
@@ -82,14 +82,14 @@ class HFEvaluationDatasetSource:
     split: str = "train"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ExtractionOutcome:
     extracted_result: str
     extraction_status: str
     failure_reason: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ScoringOutcome:
     typed_score: float
     validation_status: str


### PR DESCRIPTION
## Summary
- Add `slots=True` to immutable evaluation final-result records to remove per-instance `__dict__` allocation on the scoring/materialization path.
- Add a regression test that covers slotted record layout while preserving extraction, scoring, materialization request, and HF source defaults.
- Document the optimization slice and registered probe coverage under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-07-09-evaluation-final-result-slotted-records.md`
- Registered PR-scoped probe: `evaluation-final-result-json-typed-score-aggregate`

## Commands Run
```text
# Baseline probe on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
# exit 0; {"elapsed_ms_mean": 13.641064800322056, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713689.8, "score_checksum": 35.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::test_evaluation_final_result_records_are_slotted_without_behavior_drift
# exit 0; 1 passed in 0.17s

# Registered probe test_command for evaluation-final-result-json-typed-score-aggregate
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# exit 0; 44 passed in 1.24s

# Registered probe coverage_command for evaluation-final-result-json-typed-score-aggregate
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
# exit 0; changed_line_coverage=100.00%; TOTAL 23 0 100%

# Registered probe_command after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_json_typed_score_probe.py
# exit 0; {"elapsed_ms_mean": 13.595498795621097, "iteration_count": 40.0, "key_count": 2000.0, "peak_bytes_mean": 713689.8, "score_checksum": 35.0}

# Three-repeat comparison, base then head
# base elapsed_ms_mean: 13.274913211353123, 14.159818599000573, 13.43421438941732
# head elapsed_ms_mean: 13.726937386672944, 13.228498783428222, 13.784809596836567
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 23 0 100%`.
- Primary local registered probe: `evaluation-final-result-json-typed-score-aggregate`.
- One-shot local metrics: baseline `elapsed_ms_mean=13.641064800322056`, head `elapsed_ms_mean=13.595498795621097`, delta `-0.04556600470095873 ms` (`~0.33%` faster); `peak_bytes_mean=713689.8` unchanged; `score_checksum=35.0` unchanged.
- Three-repeat local means: base mean `13.623 ms`, head mean `13.580 ms`, delta `-0.043 ms` (`~0.32%` faster). The local Linux signal is small; CI PR-scoped performance is the merge gate.

## Known Gaps
- Local validation is Linux/Python-only. CI must complete the registered PR-scoped performance workflow before merge.
- No protocol, dependency, generated protobuf, Swift, or macOS runtime changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
