### PR TITLE
perf: scan hub MLX tags once

### DIFF
--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -495,10 +495,10 @@ def _is_mlx_atom(value: str) -> bool:
 
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if type(value) is list:
-        if "MLX" in value or "mlx" in value:
-            return True
         for item in value:
-            if type(item) is str and len(item) == 3 and _is_mlx_atom(item):
+            if type(item) is str and (
+                item == "MLX" or item == "mlx" or (len(item) == 3 and _is_mlx_atom(item))
+            ):
                 return True
         return False
     if isinstance(value, list):


### PR DESCRIPTION
## Summary
- Scan exact-list Hub tag payloads once when detecting MLX compatibility.
- Preserve the existing exact `MLX`/`mlx` fast path while avoiding a second list traversal for negative or mixed-case tag lists.

## Plan or Spec
- N/A: local hot-path implementation slice for an existing registered PR-scoped probe; no user-visible behavior, protocol, or workflow contract changes.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 96 passed in 1.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 96 passed in 0.56s; changed-line coverage TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# Baseline before change: payload_compatibility_elapsed_ms_mean=197.85241759382188, elapsed_ms_mean=1296.5687558054924
# Head samples after change: payload_compatibility_elapsed_ms_mean=195.34008840564638, 193.03323500789702, 191.19114538189024, 191.06605839915574

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 1 0 100%`).
- Registered probe: `hub-catalog-size-hint-regex-precompile` covers `services/mlx-worker-python/worker/model_ops/hub_catalog.py` with focused test, coverage, and probe commands.
- Targeted metric delta: `payload_compatibility_elapsed_ms_mean` baseline `197.8524 ms`; post-change mean across four local runs `192.6576 ms`; delta `-5.1948 ms` (`-2.63%`, lower is better).
- Overall size-hint loop metric is not targeted by this slice and stayed within local noise / under the registered 5% warning threshold.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this Linux slice used the registered focused Python probe and tests. GitHub Actions is required for the full PR gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. N/A: no behavior or workflow contract change.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
