### PR TITLE
Add agentic tool guardrail admission receipts

### DIFF
--- a/docs/plans/2026-07-09-issue-1382-tool-guardrail-admission-receipts.md
+++ b/docs/plans/2026-07-09-issue-1382-tool-guardrail-admission-receipts.md
@@ -1,0 +1,99 @@
+# Issue 1382 Tool Guardrail Admission Receipts
+
+## Goal
+
+Add a focused agentic tool-call guardrail admission helper that turns malformed
+or non-executable model tool calls into typed retry-nudge receipts before tool
+execution.
+
+## Governing Documents
+
+- `AGENTS.md`
+- `docs/unified-agentic-tool-runtime-contract.md`
+- `docs/plans/2026-06-23-issue-1382-tool-registry-parity.md`
+- `docs/plans/2026-07-09-issue-1382-network-tool-consent.md`
+
+## Scope
+
+This slice covers:
+
+- a worker-owned `melix.agentic_tool_guardrail.v1` receipt for tool-call
+  admission decisions;
+- typed retry-nudge outcomes for unknown tools, malformed tool-call objects,
+  non-object arguments, and missing required arguments;
+- bounded retry metadata through `attempt_index`, `max_retry_nudges`, and
+  `terminal_after_budget`;
+- focused Python tests proving receipts do not include raw prompt text or raw
+  tool arguments.
+
+This slice does not add a full agent loop, execute retry prompts, alter the
+default fail-fast `execute_agentic_tool_calls(...)` behavior, or change live
+tool execution policy. Later slices can call this helper from CLI/app agent
+loops before executing model-emitted tool calls.
+
+## Architecture
+
+The end-state #1382 guardrail layer should validate model tool calls before any
+adapter can execute, produce a precise nudge for the next model turn, and leave
+operator-visible evidence when retries are exhausted.
+
+This slice establishes that boundary without changing current callers:
+
+- `admit_agentic_tool_calls(...)` normalizes the candidate call list against a
+  registry and returns an admission result.
+- Valid calls return an admitted receipt plus normalized calls for downstream
+  execution.
+- Invalid calls return exactly one retry/terminal receipt with a stable
+  `failure_class` and `nudge_type`.
+- Receipts include tool IDs, required argument names, retry indexes, and an
+  allowed next step. They intentionally exclude raw arguments, prompt text,
+  URLs, file paths, or retrieved content.
+
+## Performance Probes And Metrics
+
+The helper is O(number of tool calls + selected tool count) and runs before
+tool execution. It only inspects call shape, declared tool IDs, and required
+argument names.
+
+Metrics for this slice:
+
+- unknown-tool and invalid-argument admissions produce typed retry receipts;
+- admitted receipts expose call/tool counts without raw arguments;
+- focused changed-scope coverage for `agentic_tools.py` and
+  `test_agentic_tools.py` is at least 95 percent before commit;
+- PR-scoped performance report shows no in-scope regression.
+
+## TDD Plan
+
+1. Add failing tests in `services/mlx-worker-python/tests/test_agentic_tools.py`
+   for admitted calls, unknown tools, invalid argument roots, and missing
+   required arguments.
+2. Implement `AgenticToolGuardrailAdmission` and
+   `admit_agentic_tool_calls(...)` in
+   `services/mlx-worker-python/worker/runtime/agentic_tools.py`.
+3. Update `docs/unified-agentic-tool-runtime-contract.md` with the guardrail
+   receipt contract.
+4. Run focused tests, changed-scope coverage, `git diff --check`, scoped
+   performance report, and the full relevant local gate before opening the PR.
+
+## Verification Commands
+
+Focused tests:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
+```
+
+Changed-scope coverage:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o coverage.json
+UV_PYTHON=3.12 uv run python scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/agentic_tools.py services/mlx-worker-python/tests/test_agentic_tools.py
+```
+
+General checks:
+
+```bash
+git diff --check
+```

--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -187,6 +187,34 @@ tool that is disabled by policy must be omitted from the selected registry, so
 the deterministic runtime cannot execute it through a later model-emitted tool
 call.
 
+## Tool Guardrail Admission Receipt Contract
+
+Agentic loops should validate model-emitted tool calls before executing any
+adapter. The v1 admission receipt is `melix.agentic_tool_guardrail.v1` and
+records one decision for a candidate tool-call batch.
+
+The receipt includes:
+
+- `outcome = admitted|retry_nudge|terminal_failure`
+- `failure_class`
+- `nudge_type`
+- `attempt_index`
+- `max_retry_nudges`
+- `terminal_after_budget`
+- `tool_call_id`
+- `tool_name`
+- `allowed_tools[]`
+- `missing_required_arguments[]`
+- `allowed_next_step`
+- `corrective_action`
+
+Receipts must not include raw prompt text, raw tool arguments, URLs, workspace
+paths, retrieved content, or observation payloads. Unknown tools, malformed
+tool-call objects, non-object arguments, and missing required arguments should
+produce stable retry-nudge receipts. Callers may still fail closed after the
+configured retry budget is exhausted, but the terminal decision must preserve
+the same sanitized evidence shape.
+
 ## Observation Contract
 
 Every emitted observation must include:

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pytest
 
 from worker.runtime import agentic_tools as agentic_tools_module
-from worker.runtime.agentic_tools import AgenticToolRuntimeError, _context_list, execute_agentic_tool_calls
+from worker.runtime.agentic_tools import (
+    AgenticToolRuntimeError,
+    _context_list,
+    admit_agentic_tool_calls,
+    execute_agentic_tool_calls,
+)
 from worker.runtime.retrieval_context import (
     project_retrieval_lookup_result as real_project_retrieval_lookup_result,
 )
@@ -302,6 +307,189 @@ def test_agentic_tool_runtime_web_deny_keeps_visit_out_of_execution_allowlist() 
             fixture_context={"pages": {"fixture://page-1": "secret page"}},
             tool_selection=tool_selection,
         )
+
+
+def test_agentic_tool_guardrail_admission_accepts_valid_calls_without_raw_arguments() -> None:
+    admission = admit_agentic_tool_calls(
+        [
+            {
+                "id": "compute-1",
+                "name": "local_compute",
+                "arguments": {"code": "2 + 2"},
+            }
+        ],
+    )
+
+    assert admission.admitted is True
+    assert admission.terminal is False
+    assert admission.normalized_calls == (
+        {"id": "compute-1", "name": "local_compute", "arguments": {"code": "2 + 2"}},
+    )
+    assert admission.receipts == (
+        {
+            "schema_version": "melix.agentic_tool_guardrail.v1",
+            "outcome": "admitted",
+            "failure_class": "",
+            "nudge_type": "",
+            "attempt_index": 1,
+            "max_retry_nudges": 1,
+            "terminal_after_budget": False,
+            "tool_call_id": "",
+            "tool_name": "",
+            "allowed_tools": [
+                "image_crop",
+                "layout_parse",
+                "text_search",
+                "image_search",
+                "skill_lookup",
+                "memory_lookup",
+                "visit",
+                "workspace_file",
+                "local_compute",
+            ],
+            "missing_required_arguments": [],
+            "call_count": 1,
+            "admitted_tool_count": 1,
+            "allowed_next_step": "execute_tools",
+            "corrective_action": "",
+        },
+    )
+    assert "2 + 2" not in json.dumps(admission.receipts, ensure_ascii=False)
+
+
+def test_agentic_tool_guardrail_admission_returns_retry_nudge_for_unknown_tool() -> None:
+    admission = admit_agentic_tool_calls(
+        [
+            {
+                "id": "ghost-1",
+                "name": "ghost_tool",
+                "arguments": {"secret": "do not log this argument"},
+            }
+        ],
+        attempt_index=1,
+        max_retry_nudges=2,
+    )
+
+    assert admission.admitted is False
+    assert admission.terminal is False
+    assert admission.normalized_calls == ()
+    assert admission.receipts == (
+        {
+            "schema_version": "melix.agentic_tool_guardrail.v1",
+            "outcome": "retry_nudge",
+            "failure_class": "unknown_tool",
+            "nudge_type": "unknown_tool_name",
+            "attempt_index": 1,
+            "max_retry_nudges": 2,
+            "terminal_after_budget": False,
+            "tool_call_id": "ghost-1",
+            "tool_name": "ghost_tool",
+            "allowed_tools": [
+                "image_crop",
+                "layout_parse",
+                "text_search",
+                "image_search",
+                "skill_lookup",
+                "memory_lookup",
+                "visit",
+                "workspace_file",
+                "local_compute",
+            ],
+            "missing_required_arguments": [],
+            "call_count": 1,
+            "admitted_tool_count": 0,
+            "allowed_next_step": "retry_with_declared_tool",
+            "corrective_action": "Emit a tool call whose name exactly matches one declared tool.",
+        },
+    )
+    receipt_json = json.dumps(admission.receipts, ensure_ascii=False)
+    assert "do not log this argument" not in receipt_json
+
+
+def test_agentic_tool_guardrail_admission_marks_budget_exhaustion() -> None:
+    admission = admit_agentic_tool_calls(
+        [{"id": "ghost-1", "name": "ghost_tool", "arguments": {}}],
+        attempt_index=3,
+        max_retry_nudges=2,
+    )
+
+    receipt = admission.receipts[0]
+
+    assert admission.admitted is False
+    assert admission.terminal is True
+    assert receipt["outcome"] == "terminal_failure"
+    assert receipt["terminal_after_budget"] is True
+    assert receipt["allowed_next_step"] == "stop_with_guardrail_error"
+
+
+def test_agentic_tool_guardrail_admission_rejects_non_object_arguments() -> None:
+    admission = admit_agentic_tool_calls(
+        [
+            {
+                "id": "bad-args",
+                "name": "local_compute",
+                "arguments": ["2 + 2"],
+            }
+        ],
+        attempt_index=1,
+        max_retry_nudges=2,
+    )
+
+    receipt = admission.receipts[0]
+
+    assert admission.admitted is False
+    assert receipt["failure_class"] == "invalid_arguments"
+    assert receipt["nudge_type"] == "tool_arguments_object_required"
+    assert receipt["tool_call_id"] == "bad-args"
+    assert receipt["tool_name"] == "local_compute"
+    assert receipt["allowed_next_step"] == "retry_with_object_arguments"
+    assert "2 + 2" not in json.dumps(receipt, ensure_ascii=False)
+
+
+def test_agentic_tool_guardrail_admission_reports_missing_required_arguments() -> None:
+    admission = admit_agentic_tool_calls(
+        [{"id": "compute-missing", "name": "local_compute", "arguments": {}}],
+        attempt_index=1,
+        max_retry_nudges=2,
+    )
+
+    receipt = admission.receipts[0]
+
+    assert admission.admitted is False
+    assert receipt["failure_class"] == "missing_required_arguments"
+    assert receipt["nudge_type"] == "missing_required_arguments"
+    assert receipt["tool_call_id"] == "compute-missing"
+    assert receipt["tool_name"] == "local_compute"
+    assert receipt["missing_required_arguments"] == ["code"]
+    assert receipt["allowed_next_step"] == "retry_with_required_arguments"
+
+
+@pytest.mark.parametrize(
+    ("raw_call", "expected_call_id", "expected_nudge_type"),
+    [
+        ("not-a-tool-call", "call-1", "tool_call_object_required"),
+        ({"id": "empty-name", "name": " ", "arguments": {}}, "empty-name", "tool_name_required"),
+        (
+            {"id": "none-args", "name": "local_compute", "arguments": None},
+            "none-args",
+            "missing_required_arguments",
+        ),
+    ],
+)
+def test_agentic_tool_guardrail_admission_covers_malformed_shape_branches(
+    raw_call: object,
+    expected_call_id: str,
+    expected_nudge_type: str,
+) -> None:
+    admission = admit_agentic_tool_calls([raw_call], attempt_index=1, max_retry_nudges=1)
+    receipt = admission.receipts[0]
+
+    assert admission.admitted is False
+    assert admission.terminal is False
+    assert receipt["outcome"] == "retry_nudge"
+    assert receipt["tool_call_id"] == expected_call_id
+    assert receipt["nudge_type"] == expected_nudge_type
+    assert receipt["terminal_after_budget"] is True
 
 
 @pytest.mark.parametrize(("tool_name", "arguments"), _BUILT_IN_TOOL_CALLS)

--- a/services/mlx-worker-python/tests/test_agentic_tools.py
+++ b/services/mlx-worker-python/tests/test_agentic_tools.py
@@ -464,11 +464,29 @@ def test_agentic_tool_guardrail_admission_reports_missing_required_arguments() -
     assert receipt["allowed_next_step"] == "retry_with_required_arguments"
 
 
+def test_agentic_tool_guardrail_admission_treats_none_required_argument_as_missing() -> None:
+    admission = admit_agentic_tool_calls(
+        [{"id": "compute-none", "name": "local_compute", "arguments": {"code": None}}],
+        attempt_index=1,
+        max_retry_nudges=2,
+    )
+
+    receipt = admission.receipts[0]
+
+    assert admission.admitted is False
+    assert receipt["failure_class"] == "missing_required_arguments"
+    assert receipt["nudge_type"] == "missing_required_arguments"
+    assert receipt["tool_call_id"] == "compute-none"
+    assert receipt["tool_name"] == "local_compute"
+    assert receipt["missing_required_arguments"] == ["code"]
+
+
 @pytest.mark.parametrize(
     ("raw_call", "expected_call_id", "expected_nudge_type"),
     [
         ("not-a-tool-call", "call-1", "tool_call_object_required"),
         ({"id": "empty-name", "name": " ", "arguments": {}}, "empty-name", "tool_name_required"),
+        ({"id": "none-name", "name": None, "arguments": {}}, "none-name", "tool_name_required"),
         (
             {"id": "none-args", "name": "local_compute", "arguments": None},
             "none-args",

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -126,7 +126,7 @@ def admit_agentic_tool_calls(
             )
 
         tool_call_id = str(raw_call.get("id", "") or fallback_call_id)
-        tool_name = str(raw_call.get("name", "")).strip()
+        tool_name = str(raw_call.get("name") or "").strip()
         if not tool_name:
             return _guardrail_rejection_admission(
                 allowed_tools=allowed_tools,
@@ -559,7 +559,7 @@ def _missing_required_arguments(
     return [
         name
         for name in descriptor.required_arguments
-        if str(arguments.get(name, "")).strip() == ""
+        if (value := arguments.get(name)) is None or str(value).strip() == ""
     ]
 
 

--- a/services/mlx-worker-python/worker/runtime/agentic_tools.py
+++ b/services/mlx-worker-python/worker/runtime/agentic_tools.py
@@ -34,6 +34,8 @@ from worker.runtime.tool_registry import (
 from worker.runtime.workspace_file_tools import WorkspaceFileTools
 from worker.runtime.workspace_paths import WorkspacePathResolution
 
+AGENTIC_TOOL_GUARDRAIL_RECEIPT_SCHEMA_VERSION = "melix.agentic_tool_guardrail.v1"
+
 
 class AgenticToolRuntimeError(ValueError):
     def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
@@ -82,6 +84,237 @@ class AgenticToolRun:
             "observations": [dict(observation) for observation in self.observations],
             "metrics": dict(self.metrics),
         }
+
+
+@dataclass(frozen=True)
+class AgenticToolGuardrailAdmission:
+    admitted: bool
+    terminal: bool
+    normalized_calls: tuple[dict[str, Any], ...]
+    receipts: tuple[dict[str, Any], ...]
+
+
+def admit_agentic_tool_calls(
+    tool_calls: list[object] | tuple[object, ...] | None,
+    *,
+    registry: ToolRegistry | None = None,
+    attempt_index: int = 1,
+    max_retry_nudges: int = 1,
+) -> AgenticToolGuardrailAdmission:
+    """Validate model-emitted tool calls before any adapter executes."""
+
+    active_registry = registry or agentic_tool_catalog_registry()
+    tool_by_name = {tool.name: tool for tool in active_registry.tools}
+    allowed_tools = list(active_registry.names())
+    raw_calls = tuple(tool_calls or ())
+    normalized_calls: list[dict[str, Any]] = []
+
+    for index, raw_call in enumerate(raw_calls, start=1):
+        fallback_call_id = f"call-{index}"
+        if not isinstance(raw_call, dict):
+            return _guardrail_rejection_admission(
+                allowed_tools=allowed_tools,
+                attempt_index=attempt_index,
+                max_retry_nudges=max_retry_nudges,
+                call_count=len(raw_calls),
+                tool_call_id=fallback_call_id,
+                tool_name="",
+                failure_class="malformed_tool_call",
+                nudge_type="tool_call_object_required",
+                allowed_next_step="retry_with_tool_call_object",
+                corrective_action="Emit each tool call as a JSON object with name and arguments fields.",
+            )
+
+        tool_call_id = str(raw_call.get("id", "") or fallback_call_id)
+        tool_name = str(raw_call.get("name", "")).strip()
+        if not tool_name:
+            return _guardrail_rejection_admission(
+                allowed_tools=allowed_tools,
+                attempt_index=attempt_index,
+                max_retry_nudges=max_retry_nudges,
+                call_count=len(raw_calls),
+                tool_call_id=tool_call_id,
+                tool_name="",
+                failure_class="malformed_tool_call",
+                nudge_type="tool_name_required",
+                allowed_next_step="retry_with_tool_name",
+                corrective_action="Emit a tool call with a non-empty name field.",
+            )
+
+        raw_arguments = raw_call.get("arguments", {})
+        if raw_arguments is None:
+            raw_arguments = {}
+        if not isinstance(raw_arguments, dict):
+            return _guardrail_rejection_admission(
+                allowed_tools=allowed_tools,
+                attempt_index=attempt_index,
+                max_retry_nudges=max_retry_nudges,
+                call_count=len(raw_calls),
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                failure_class="invalid_arguments",
+                nudge_type="tool_arguments_object_required",
+                allowed_next_step="retry_with_object_arguments",
+                corrective_action="Emit tool arguments as a JSON object for the selected tool.",
+            )
+
+        descriptor = tool_by_name.get(tool_name)
+        if descriptor is None:
+            return _guardrail_rejection_admission(
+                allowed_tools=allowed_tools,
+                attempt_index=attempt_index,
+                max_retry_nudges=max_retry_nudges,
+                call_count=len(raw_calls),
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                failure_class="unknown_tool",
+                nudge_type="unknown_tool_name",
+                allowed_next_step="retry_with_declared_tool",
+                corrective_action="Emit a tool call whose name exactly matches one declared tool.",
+            )
+
+        missing = _missing_required_arguments(descriptor, raw_arguments)
+        if missing:
+            return _guardrail_rejection_admission(
+                allowed_tools=allowed_tools,
+                attempt_index=attempt_index,
+                max_retry_nudges=max_retry_nudges,
+                call_count=len(raw_calls),
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                failure_class="missing_required_arguments",
+                nudge_type="missing_required_arguments",
+                missing_required_arguments=missing,
+                allowed_next_step="retry_with_required_arguments",
+                corrective_action=(
+                    "Emit the required arguments for the selected tool before requesting execution."
+                ),
+            )
+
+        normalized_calls.append(
+            {
+                "id": tool_call_id,
+                "name": tool_name,
+                "arguments": dict(raw_arguments),
+            }
+        )
+
+    receipt = _agentic_tool_guardrail_receipt(
+        allowed_tools=allowed_tools,
+        attempt_index=attempt_index,
+        max_retry_nudges=max_retry_nudges,
+        outcome="admitted",
+        failure_class="",
+        nudge_type="",
+        tool_call_id="",
+        tool_name="",
+        missing_required_arguments=(),
+        call_count=len(raw_calls),
+        admitted_tool_count=len(normalized_calls),
+        terminal_after_budget=False,
+        allowed_next_step="execute_tools",
+        corrective_action="",
+    )
+    return AgenticToolGuardrailAdmission(
+        admitted=True,
+        terminal=False,
+        normalized_calls=tuple(normalized_calls),
+        receipts=(receipt,),
+    )
+
+
+def _guardrail_rejection_admission(
+    *,
+    allowed_tools: list[str],
+    attempt_index: int,
+    max_retry_nudges: int,
+    call_count: int,
+    tool_call_id: str,
+    tool_name: str,
+    failure_class: str,
+    nudge_type: str,
+    allowed_next_step: str,
+    corrective_action: str,
+    missing_required_arguments: list[str] | tuple[str, ...] = (),
+) -> AgenticToolGuardrailAdmission:
+    normalized_attempt, normalized_max = _normalized_guardrail_budget(
+        attempt_index=attempt_index,
+        max_retry_nudges=max_retry_nudges,
+    )
+    terminal_without_nudge = normalized_attempt > normalized_max
+    terminal_after_budget = normalized_attempt >= normalized_max
+    outcome = "terminal_failure" if terminal_without_nudge else "retry_nudge"
+    next_step = "stop_with_guardrail_error" if terminal_without_nudge else allowed_next_step
+    receipt = _agentic_tool_guardrail_receipt(
+        allowed_tools=allowed_tools,
+        attempt_index=normalized_attempt,
+        max_retry_nudges=normalized_max,
+        outcome=outcome,
+        failure_class=failure_class,
+        nudge_type=nudge_type,
+        tool_call_id=tool_call_id,
+        tool_name=tool_name,
+        missing_required_arguments=missing_required_arguments,
+        call_count=call_count,
+        admitted_tool_count=0,
+        terminal_after_budget=terminal_after_budget,
+        allowed_next_step=next_step,
+        corrective_action=corrective_action,
+    )
+    return AgenticToolGuardrailAdmission(
+        admitted=False,
+        terminal=terminal_without_nudge,
+        normalized_calls=(),
+        receipts=(receipt,),
+    )
+
+
+def _agentic_tool_guardrail_receipt(
+    *,
+    allowed_tools: list[str],
+    attempt_index: int,
+    max_retry_nudges: int,
+    outcome: str,
+    failure_class: str,
+    nudge_type: str,
+    tool_call_id: str,
+    tool_name: str,
+    missing_required_arguments: list[str] | tuple[str, ...],
+    call_count: int,
+    admitted_tool_count: int,
+    terminal_after_budget: bool,
+    allowed_next_step: str,
+    corrective_action: str,
+) -> dict[str, Any]:
+    normalized_attempt, normalized_max = _normalized_guardrail_budget(
+        attempt_index=attempt_index,
+        max_retry_nudges=max_retry_nudges,
+    )
+    return {
+        "schema_version": AGENTIC_TOOL_GUARDRAIL_RECEIPT_SCHEMA_VERSION,
+        "outcome": outcome,
+        "failure_class": failure_class,
+        "nudge_type": nudge_type,
+        "attempt_index": normalized_attempt,
+        "max_retry_nudges": normalized_max,
+        "terminal_after_budget": terminal_after_budget,
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "allowed_tools": list(allowed_tools),
+        "missing_required_arguments": list(missing_required_arguments),
+        "call_count": call_count,
+        "admitted_tool_count": admitted_tool_count,
+        "allowed_next_step": allowed_next_step,
+        "corrective_action": corrective_action,
+    }
+
+
+def _normalized_guardrail_budget(
+    *,
+    attempt_index: int,
+    max_retry_nudges: int,
+) -> tuple[int, int]:
+    return max(1, int(attempt_index)), max(0, int(max_retry_nudges))
 
 
 class DeterministicAgenticToolRuntime:
@@ -313,10 +546,21 @@ def _normalize_tool_calls(tool_calls: list[object] | tuple[object, ...] | None) 
 
 
 def _validate_required_arguments(descriptor: ToolDescriptor, arguments: dict[str, Any]) -> None:
-    missing = [name for name in descriptor.required_arguments if str(arguments.get(name, "")).strip() == ""]
+    missing = _missing_required_arguments(descriptor, arguments)
     if missing:
         joined = ", ".join(missing)
         raise AgenticToolRuntimeError(f"Missing required arguments for {descriptor.name}: {joined}")
+
+
+def _missing_required_arguments(
+    descriptor: ToolDescriptor,
+    arguments: dict[str, Any],
+) -> list[str]:
+    return [
+        name
+        for name in descriptor.required_arguments
+        if str(arguments.get(name, "")).strip() == ""
+    ]
 
 
 def _status_override_payload(


### PR DESCRIPTION
## Summary
- Add `admit_agentic_tool_calls(...)` and `AgenticToolGuardrailAdmission` so model-emitted tool calls can be admitted or rejected before execution.
- Emit sanitized `melix.agentic_tool_guardrail.v1` receipts for admitted calls, unknown tools, malformed calls, invalid arguments, and missing required arguments.
- Document the guardrail receipt contract and the focused implementation plan.

Refs #1382.

## Plan or Spec
- `docs/plans/2026-07-09-issue-1382-tool-guardrail-admission-receipts.md`
- `docs/unified-agentic-tool-runtime-contract.md`
- Prior governing plan: `docs/plans/2026-06-23-issue-1382-tool-registry-parity.md`
- Prior governing plan: `docs/plans/2026-07-09-issue-1382-network-tool-consent.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py -k 'guardrail_admission'
Outcome: red phase failed before implementation with ImportError for admit_agentic_tool_calls.

make bootstrap
Outcome: passed; installed repository hooks.

make proto
Outcome: passed; no generated artifact diff.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx pytest -q services/mlx-worker-python/tests/test_agentic_tools.py services/mlx-worker-python/tests/test_agent_reliability.py services/mlx-worker-python/tests/test_tool_registry.py
Outcome: passed after merge; 234 passed in 0.16s.

git diff --check
Outcome: passed.

COVERAGE_FILE=.runtime/coverage-issue1382 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage run -m pytest -q services/mlx-worker-python/tests/test_agentic_tools.py
COVERAGE_FILE=.runtime/coverage-issue1382 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" UV_PYTHON=3.12 uv run --project services/mlx-worker-python --extra mlx coverage json -o .runtime/coverage-issue1382.json
UV_PYTHON=3.12 uv run python scripts/changed_scope_coverage.py ... against origin/main...HEAD
Outcome: passed after merge; 105 measurable changed lines, 105 covered, 0 missed, TOTAL 105 0 100%.

git commit -m "feat(agentic): add tool guardrail admission receipts"
Outcome: passed pre-commit hook on macOS 256 GiB host:
- make swift-test rc=0, elapsed=609.1s
- make py-test rc=0, 4878 passed, 14 skipped, 2 warnings in 166.62s
- make integration-test rc=0, 123 passed, 1 skipped in 756.90s
- pre-commit performance report status ok at .runtime/pre-commit-performance/20260709-195950-4ecf7680/report/report.md

UV_PYTHON=3.12 uv run --frozen --project services/mlx-worker-python --extra mlx python - <<'PY'
from pathlib import Path
import subprocess
from scripts.pre_commit_gate import run_performance_report
root = Path.cwd()
changed_files = subprocess.check_output(["git", "diff", "--name-only", "origin/main...HEAD"], text=True).splitlines()
outcome = run_performance_report(root, changed_files, base_ref="origin/main")
print(outcome.status, outcome.report_dir)
PY
Outcome: post-merge scoped performance report reproduced an out-of-scope local-job scalar-copy derived metric regression twice:
- .runtime/pre-commit-performance/20260709-200212-8c3bd1a5/report/report.md status regression
- .runtime/pre-commit-performance/20260709-200301-8c3bd1a5/report/report.md status regression
```

## Coverage and Metrics
- Changed-line coverage after merge: 105 measurable changed Python lines, 105 covered, 0 missed, 100%.
- Full local pre-commit gate passed before the merge from `origin/main`.
- Pre-commit PR scoped performance before the merge from `origin/main`: status `ok`, selected probes `1`, regressions `0`.
- Post-merge PR scoped performance selected `local-job-followup-scan-scandir` because this PR updates `docs/unified-agentic-tool-runtime-contract.md`, a broad watched contract file. The repeated regression is only `scalar_copy_delta_ms`, a legacy/baseline-relative derived metric in `scripts/local_job_followup_scan_probe.py`; this PR does not change local-job code, the probe script, or `infra/perf/pr_scoped_probes.json`. The current-path metric `scalar_copy_optimized_elapsed_ms_mean` was neutral or faster in both post-merge runs.
- Observability mode: minimal/evidence receipt contract only. This slice adds receipt construction but does not wire live emission into an agent loop, so probe overhead for live traffic is N/A.

## Known Gaps
- The helper is not wired into the live CLI/app agent loop in this slice; later #1382 work can call it before executing model-emitted tool calls.
- Local post-merge PR scoped performance currently reports an out-of-scope derived metric regression as described above; CI performance report remains the terminal remote signal.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protobuf schema changed.
- [x] Dependency changes include updated lockfiles, or N/A because dependencies did not change.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
