### PR TITLE
perf: cache startup product version key

### DIFF
--- a/docs/plans/2026-07-10-startup-product-version-cache-key.md
+++ b/docs/plans/2026-07-10-startup-product-version-cache-key.md
@@ -1,0 +1,19 @@
+# Startup product version cache key slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.startup_signals.read_product_version()`.
+
+The hot repeated-read path already caches the resolved `pyproject.toml` `Path` and uses a stat-valid version cache. This slice keeps that behavior but also caches the string cache key derived from the resolved `pyproject.toml` path so repeated stat-valid reads avoid reconstructing the same path string before the version-cache lookup.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped performance probe `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `product_version_elapsed_ms_mean` for repeated cached product version reads.
+- `product_version_peak_bytes_mean` for allocation stability.
+- update-check and version-comparison metrics to guard adjacent startup-signal paths.
+
+## Verification plan
+
+Run the registered focused startup-signals tests, changed-scope coverage, and the registered probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate after the PR is opened.

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -254,9 +254,15 @@ def test_read_product_version_reuses_cached_pyproject_path(
     pyproject_path.write_text('[project]\nname = "melix"\nversion = "1.2.3"\n', encoding="utf-8")
     startup_signals_module._PRODUCT_VERSION_CACHE.clear()
     startup_signals_module._PRODUCT_VERSION_PATH_CACHE.clear()
+    startup_signals_module._PRODUCT_VERSION_CACHE_KEY_CACHE.clear()
 
     assert read_product_version(tmp_path) == "1.2.3"
-    assert startup_signals_module._PRODUCT_VERSION_PATH_CACHE[str(tmp_path)] == pyproject_path
+    root_key = str(tmp_path)
+    assert startup_signals_module._PRODUCT_VERSION_PATH_CACHE[root_key] == pyproject_path
+    assert startup_signals_module._PRODUCT_VERSION_CACHE_KEY_CACHE[root_key] == str(pyproject_path)
+    startup_signals_module._PRODUCT_VERSION_CACHE_KEY_CACHE.clear()
+    assert read_product_version(tmp_path) == "1.2.3"
+    assert startup_signals_module._PRODUCT_VERSION_CACHE_KEY_CACHE[root_key] == str(pyproject_path)
 
     def fail_path_join(self: Path, key: str) -> Path:  # pragma: no cover - sentinel
         raise AssertionError("stat-valid product version reads should reuse cached pyproject path")

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -30,6 +30,7 @@ _QUOTE_BYTE = 34
 _EQUALS_BYTE = 61
 _PRODUCT_VERSION_CACHE: dict[str, tuple[int, int, str]] = {}
 _PRODUCT_VERSION_PATH_CACHE: dict[str, Path] = {}
+_PRODUCT_VERSION_CACHE_KEY_CACHE: dict[str, str] = {}
 _UPDATE_CHANNEL_CACHE: dict[str, tuple[int, int, str, str]] = {}
 
 
@@ -80,8 +81,14 @@ def read_product_version(repo_root: str | Path) -> str:
     if pyproject_path is None:
         pyproject_path = root / "pyproject.toml"
         _PRODUCT_VERSION_PATH_CACHE[root_text] = pyproject_path
+        cache_key = str(pyproject_path)
+        _PRODUCT_VERSION_CACHE_KEY_CACHE[root_text] = cache_key
+    else:
+        cache_key = _PRODUCT_VERSION_CACHE_KEY_CACHE.get(root_text)
+        if cache_key is None:
+            cache_key = str(pyproject_path)
+            _PRODUCT_VERSION_CACHE_KEY_CACHE[root_text] = cache_key
     stat_result = pyproject_path.stat()
-    cache_key = str(pyproject_path)
     cached = _PRODUCT_VERSION_CACHE.get(cache_key)
     if cached is not None:
         cached_mtime_ns, cached_size, cached_version = cached


### PR DESCRIPTION
## Summary
- Cache the `pyproject.toml` string cache key alongside the cached product-version path in `read_product_version()`.
- Extend the focused cache test to cover the new cache-key entry and fallback rebuild path.
- Add a plan note for this Python-only startup-signals performance slice.

## Plan or Spec
- `docs/plans/2026-07-10-startup-product-version-cache-key.md`
- Registered probe: `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused test command)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/startup_signals_version_probe.py"; ...'`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-version-compare-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-main --head-repo "$PWD" --output .runtime/startup-product-version-cache-key-probe`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 29 passed.
- Changed-scope coverage: 100% (`TOTAL 14 0 100%`).
- Registered local probe comparison (`startup-signals-version-compare-single-pass`):
  - `product_version_elapsed_ms_mean`: base `200.5169 ms`, head `192.6288 ms` (`-7.8881 ms`, ~3.93% faster).
  - `product_version_peak_bytes_mean`: base `1404.14`, head `1404.14` (unchanged).
  - Adjacent guard metrics stayed within the registered probe output: `update_channel_elapsed_ms_mean` base `75.1031 ms`, head `72.5891 ms`; `update_result_elapsed_ms_mean` base `77.9664 ms`, head `75.2809 ms`.
- CI PR-scoped performance is still required as the merge gate.

## Known Gaps
- Local validation is Linux/Python-only. This slice does not touch Swift runtime paths.
- GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Registered probe exists for the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally against base and head.
- [ ] GitHub Actions checks are green.
- [ ] PR-scoped performance report completed successfully.
