### PR TITLE
perf: fast path report evidence metric strings

### DIFF
--- a/docs/plans/2026-07-10-report-evidence-metric-prefix-string-fastpath.md
+++ b/docs/plans/2026-07-10-report-evidence-metric-prefix-string-fastpath.md
@@ -1,0 +1,23 @@
+# Report evidence metric-prefix string fast path slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.report_evidence_gate._rule_matches_report()` metric-prefix matching.
+Metric rows normally provide `metric` as an exact string, but the previous loop still called `str()` for every metric before checking the prefix initials and tuple.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports `metric_prefix_elapsed_ms_mean` alongside aggregate report-evidence metrics.
+
+## Optimization plan
+
+1. Add an exact-string fast path in the metric-prefix loop so common string metrics reuse the existing value directly.
+2. Preserve non-string metric semantics by falling back to `str(value)` before prefix checks.
+3. Run the registered focused tests, changed-scope coverage, and the registered probe locally on Linux before opening the PR.
+4. Use GitHub Actions PR-scoped performance as the registered probe merge gate.
+
+## Verification
+
+- Focused report-evidence gate tests pass.
+- Changed-scope coverage for the touched Python file, test file, probe script, and this plan is at least 95%.
+- Local registered probe reports stable or improved `metric_prefix_elapsed_ms_mean`; CI remains the source of truth for PR-scoped performance validation.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -442,7 +442,8 @@ def _rule_matches_report(
         if metric_prefix_matches_empty:
             return bool(metrics)
         for metric in metrics:
-            metric_value = to_string(metric.get(metric_key, ""))
+            metric_raw = metric.get(metric_key, "")
+            metric_value = metric_raw if type(metric_raw) is str else to_string(metric_raw)
             if (
                 metric_value
                 and metric_value[0] in metric_prefix_initials


### PR DESCRIPTION
## Summary
- Add an exact-string fast path to report-evidence metric-prefix matching.
- Preserve non-string metric matching by falling back to `str(value)` before prefix checks.

## Plan or Spec
- `docs/plans/2026-07-10-report-evidence-metric-prefix-string-fastpath.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=20000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py` (baseline and candidate quick probe)
- `bash /tmp/report_evidence_test_command.sh`
- `bash /tmp/report_evidence_coverage_command.sh`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 29 passed.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Local registered probe candidate: `metric_prefix_elapsed_ms_mean=357.0419887895696`, `elapsed_ms_mean=985.9756788238883`.
- Local baseline probe from `origin/main`: `metric_prefix_elapsed_ms_mean=371.40224219765514`, `elapsed_ms_mean=975.8617396000773`.
- Metric-prefix delta: `-14.360253408085536 ms` (`~3.87%` faster). Aggregate elapsed was noise-mixed and slightly slower locally; the slice is accepted on the focused metric-prefix improvement and CI registered probe remains the merge gate.

## Known Gaps
- Linux local probe validates the Python path only. GitHub Actions PR-scoped performance is required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe was run against baseline and candidate.
- [ ] PR-scoped performance workflow completed successfully in CI.
