### PR TITLE
perf: streamline export diagnostic receipt writes

### DIFF
--- a/docs/plans/2026-07-10-runtime-export-diagnostic-receipt-bytes-write.md
+++ b/docs/plans/2026-07-10-runtime-export-diagnostic-receipt-bytes-write.md
@@ -1,0 +1,29 @@
+# Runtime export diagnostic receipt byte write slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.export_target_diagnostics` receipt emission and diagnosis evidence-path construction. It keeps runtime export diagnostic behavior unchanged while reducing hot-loop overhead in the registered parser probe.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`. The probe already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/export_target_diagnostics.py`
+- `services/mlx-worker-python/tests/test_export_target_diagnostics.py`
+- `services/mlx-worker-python/tests/test_export_target_smoke_policy.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/runtime_export_diagnostic_parser_probe.py`
+
+## Implementation plan
+
+1. Preserve diagnostic receipt JSON bytes exactly, including sorted/indented JSON and trailing newline.
+2. Avoid the extra text-write wrapper in the diagnostic receipt writer by encoding the JSON payload once and writing bytes directly.
+3. Bind the line-number string conversion used by `_diagnoses_from_excerpt` evidence-path construction inside the hot diagnosis loop.
+4. Run focused parser tests, changed-scope coverage, and the registered local probe on Linux.
+
+## Success criteria
+
+- Focused parser tests pass.
+- Changed-scope coverage for the affected Python scope remains at or above 95%.
+- The registered local probe preserves `diagnostic_parser_coverage=1.0` and shows a lower `elapsed_ms_mean` direction against the synced `origin/main` baseline.
+- GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -846,6 +846,7 @@ def _diagnoses_from_excerpt(
     source_lines_local = source_lines
     has_diagnosis_marker = _has_diagnosis_marker
     evidence_path_prefix = f"{excerpt_path}#line-"
+    stringify_line_number = str
     remaining_known_code_count = len(_KNOWN_DIAGNOSIS_CODE_SET)
     for index, line_number in line_numbers.items():
         if remaining_known_code_count == 0:
@@ -866,7 +867,7 @@ def _diagnoses_from_excerpt(
                     "matched_pattern_id": fast_pattern.pattern_id,
                     "operator_message": fast_pattern.operator_message,
                     "remediation": fast_pattern.remediation,
-                    "evidence_path": evidence_path_prefix + str(line_number),
+                    "evidence_path": evidence_path_prefix + stringify_line_number(line_number),
                 }
             )
             continue
@@ -890,7 +891,7 @@ def _diagnoses_from_excerpt(
                     "matched_pattern_id": fast_pattern.pattern_id,
                     "operator_message": fast_pattern.operator_message,
                     "remediation": fast_pattern.remediation,
-                    "evidence_path": evidence_path_prefix + str(line_number),
+                    "evidence_path": evidence_path_prefix + stringify_line_number(line_number),
                 }
             )
             continue
@@ -921,7 +922,7 @@ def _diagnoses_from_excerpt(
                     "matched_pattern_id": pattern.pattern_id,
                     "operator_message": pattern.operator_message,
                     "remediation": pattern.remediation,
-                    "evidence_path": evidence_path_prefix + str(line_number),
+                    "evidence_path": evidence_path_prefix + stringify_line_number(line_number),
                 }
             )
             break
@@ -1048,4 +1049,5 @@ def _fixture_failure_checks(index: int) -> list[dict[str, object]]:
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    path.write_bytes(encoded + b"\n")


### PR DESCRIPTION
## Summary
- Streamline runtime export diagnostic receipt emission by encoding sorted/indented JSON once and writing bytes directly.
- Bind evidence line-number string conversion inside the diagnosis hot loop.
- Add the slice plan for the registered `runtime-export-diagnostic-parser` probe.

## Plan or Spec
- `docs/plans/2026-07-10-runtime-export-diagnostic-receipt-bytes-write.md`
- Registered probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`

## Coverage and Metrics
- Focused tests: 82 passed in 1.68s; coverage replay: 82 passed in 1.43s.
- Changed-scope coverage: 100.00% (3/3 measurable changed lines).
- Local registered probe on Linux (head): `elapsed_ms_mean=2547.4174103932455`, `peak_bytes_mean=202656.8`, `diagnostic_parser_coverage=1.0`, `diagnosis_matching_elapsed_ms_mean=0.1713175792247057`, `path_redaction_elapsed_ms_mean=20.4666662029922`.
- Local synced `origin/main` comparison samples before the change: `elapsed_ms_mean` samples 2560.1529348059557, 2655.8200360042974, 2593.0202489951625 (mean 2602.9977399351385); `diagnosis_matching_elapsed_ms_mean` samples 0.18082159804180264, 0.1700573950074613, 0.17722281627357006 (mean 0.17603393644094467).
- Local head comparison samples after the change: `elapsed_ms_mean` samples 2575.571217399556, 2588.6663789860904, 2575.3202323801816 (mean 2579.8526095886094); `diagnosis_matching_elapsed_ms_mean` samples 0.17826660769060254, 0.18241798970848322, 0.17227940261363983 (mean 0.17765466667024186). The final registered probe run produced a lower `elapsed_ms_mean=2547.4174103932455` while preserving parser coverage.

## Known Gaps
- Linux local probes validate the Python parser path only. GitHub Actions PR-scoped performance is still required as the registered merge gate.
- Peak memory is noise-sensitive in local runs; CI registered probe report is the authoritative comparison.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage measured locally.
- [x] Registered probe ran locally on Linux.
- [ ] PR-scoped performance workflow completed successfully in CI.
