### PR TITLE
perf: decode dataset preview jsonl raw lines

### DIFF
--- a/docs/plans/2026-07-10-dataset-preview-jsonl-raw-line-decode.md
+++ b/docs/plans/2026-07-10-dataset-preview-jsonl-raw-line-decode.md
@@ -1,0 +1,36 @@
+# Dataset preview JSONL raw-line decode
+
+## Scope
+
+This Python-only performance slice is limited to the JSONL row reader used by
+`services/mlx-worker-python/worker/dataset_registry/catalog.py` during dataset
+preview reads.
+
+Registered PR-scoped probe: `dataset-registry-preview-limit-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for this path.
+
+## Root cause
+
+The JSONL preview path already receives newline-delimited JSON records, but it
+called `raw_line.strip()` for every non-empty candidate before decoding. That
+allocates a second string on the hot path even though `json.loads()` accepts
+leading and trailing whitespace, including the line terminator. Blank or
+whitespace-only records still need to be skipped before decoding.
+
+## Slice
+
+Replace the per-row strip/empty check with `raw_line.isspace()` for blank-line
+skipping and pass the original line directly to `json.loads()`. This preserves
+behavior for blank lines, whitespace-padded JSON objects, non-dict entries, and
+multi-row limits while avoiding a redundant string allocation for each decoded
+JSONL row.
+
+## Verification plan
+
+- Run the focused dataset-registry JSONL regression test and the registered
+  dataset preview test command locally on Linux.
+- Run the registered changed-scope coverage command locally on Linux.
+- Run the registered `dataset-registry-preview-limit-short-circuit` probe locally
+  on Linux against `origin/main` and this branch, then use the GitHub PR-scoped
+  performance workflow as the merge gate.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -487,6 +487,28 @@ def test_dataset_catalog_jsonl_limit_one_returns_first_dict_directly(
     assert catalog._read_rows_from_file(no_dict_path, limit=1) == []
 
 
+def test_dataset_catalog_jsonl_preview_preserves_raw_lines_for_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    jsonl_path = tmp_path / "data.jsonl"
+    jsonl_path.write_text(
+        "\n   \n  {\"prompt\": \"first\"}\n{\"prompt\": \"second\"}\n",
+        encoding="utf-8",
+    )
+    seen_payloads: list[str] = []
+    original_loads = catalog.json.loads
+
+    def tracking_loads(payload: str) -> object:
+        seen_payloads.append(payload)
+        return original_loads(payload)
+
+    monkeypatch.setattr(catalog.json, "loads", tracking_loads)
+
+    assert catalog._read_rows_from_file(jsonl_path, limit=1) == [{"prompt": "first"}]
+    assert seen_payloads == ['  {"prompt": "first"}\n']
+
+
 def test_dataset_catalog_first_preview_scan_skips_readme_without_rescan(tmp_path: Path) -> None:
     snapshot_dir = tmp_path / "snapshot"
     data_dir = snapshot_dir / "data"

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -649,10 +649,9 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
         if limit == 1:
             with path.open("r", encoding="utf-8") as handle:
                 for raw_line in handle:
-                    line = raw_line.strip()
-                    if not line:
+                    if raw_line.isspace():
                         continue
-                    payload = loads(line)
+                    payload = loads(raw_line)
                     if isinstance(payload, dict):
                         return [payload]
             return []
@@ -660,10 +659,9 @@ def _read_rows_from_file(path: Path, *, limit: int | None = None) -> list[dict[s
         append_row = rows.append
         with path.open("r", encoding="utf-8") as handle:
             for raw_line in handle:
-                line = raw_line.strip()
-                if not line:
+                if raw_line.isspace():
                     continue
-                payload = loads(line)
+                payload = loads(raw_line)
                 if isinstance(payload, dict):
                     append_row(payload)
                     if limit is not None and len(rows) >= limit:


### PR DESCRIPTION
## Summary
- Decode dataset preview JSONL rows from the original raw line instead of allocating a stripped copy for each decoded record.
- Keep whitespace-only JSONL records skipped before decoding and add a focused regression test for whitespace-padded records.

## Plan or Spec
- `docs/plans/2026-07-10-dataset-preview-jsonl-raw-line-decode.md`
- Registered PR-scoped probe: `dataset-registry-preview-limit-short-circuit`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_jsonl_preview_preserves_raw_lines_for_decoder
.                                                                        [100%]
1 passed in 0.24s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered dataset-registry-preview-limit-short-circuit test_command>
.............................                                            [100%]
29 passed in 1.21s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered tests plus new JSONL regression> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py
30 passed in 0.39s
TOTAL 15 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
{"elapsed_ms_mean": 98.45202, "elapsed_ms_min": 96.547034, "file_count": 50000.0, "multi_limit": 5.0, "multi_limit_dataset_files_yielded_mean": 5.0, "multi_limit_elapsed_ms_mean": 140.770208, "multi_limit_peak_bytes_mean": 20635.714, "peak_bytes_mean": 14677.143, "rows_returned": 1.0, "sample_count": 7.0, "sidecar_count": 1000.0, "zero_limit_elapsed_ms_mean": 0.001563, "zero_limit_peak_bytes_mean": 0.0, "zero_limit_rows_returned": 0.0}
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 15 0 100%`.
- Local Linux registered probe comparison against `origin/main` (same default probe settings):
  - `elapsed_ms_mean`: `99.573414` -> `98.452020` ms (`delta=-1.121394` ms, ~`1.13%` lower).
  - `multi_limit_elapsed_ms_mean`: `142.433947` -> `140.770208` ms (`delta=-1.663739` ms, ~`1.17%` lower).
  - `peak_bytes_mean`: unchanged at `14677.143` bytes.
- CI PR-scoped performance report is required as the merge gate for the registered probe.

## Known Gaps
- None for the Python slice. Swift runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug changes.
- [x] Deferred work and known gaps are stated explicitly.
