### PR TITLE
perf: bind dataset record sha256 constructor

### DIFF
--- a/docs/plans/2026-07-10-dataset-record-sha256-local-binding.md
+++ b/docs/plans/2026-07-10-dataset-record-sha256-local-binding.md
@@ -1,0 +1,28 @@
+# Dataset record SHA-256 local binding performance slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.dataset_preparation._record()`.
+Dataset ingest builds one source record per candidate file, and `_record()` currently resolves `hashlib.sha256` inside every record construction before hashing the source path. This slice keeps record semantics unchanged while reusing a module-level SHA-256 constructor binding for both source-id hashing and normalized text digesting.
+
+## Registered performance probe
+
+The affected path is covered by the registered PR-scoped performance probe `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+The probe reports `record_elapsed_ms_*` for `_record()` construction plus source path iteration and source-kind classification metrics.
+
+## Implementation plan
+
+1. Add regression coverage asserting `_record()` source ids remain the first 16 hex characters of the SHA-256 digest of the UTF-8 path string.
+2. Add a module-level SHA-256 constructor binding and use it in `_record()` and `_record_content_digest_and_size()`.
+3. Run the registered focused test command, changed-scope coverage command, and the registered probe locally on Linux.
+4. Use GitHub Actions PR-scoped performance as the merge gate after opening the PR.
+
+## Validation notes
+
+This slice is locally verifiable on Linux. No Swift runtime effect is claimed.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -237,6 +238,8 @@ def test_dataset_ingest_record_reuses_normalized_text_digest_cache() -> None:
     assert cache_info.misses == 1
     assert first_record["content_sha256"] == second_record["content_sha256"]
     assert first_record["byte_size"] == second_record["byte_size"] == len(b"hello\n")
+    assert first_record["source_id"] == hashlib.sha256(b"first.txt").hexdigest()[:16]
+    assert second_record["source_id"] == hashlib.sha256(b"second.txt").hexdigest()[:16]
     assert first_record["source_id"] != second_record["source_id"]
 
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -51,6 +51,7 @@ _CODE_SOURCE_LANGUAGE_BY_SUFFIX = {
 }
 _SOURCE_KIND_NAME_CACHE_MAX = 4096
 _SOURCE_KIND_BY_NAME: dict[str, str | None] = {}
+_SHA256 = hashlib.sha256
 _MISSING = object()
 
 
@@ -1516,7 +1517,7 @@ def _record(
     normalized_text = text if normalized else _normalize_line_endings(text)
     content_sha256, byte_size = _record_content_digest_and_size(normalized_text)
     record_metadata = dict(metadata) if metadata else {}
-    sha256 = hashlib.sha256
+    sha256 = _SHA256
     path_name = path.name
     path_key = str(path).encode("utf-8")
     return {
@@ -1534,7 +1535,7 @@ def _record(
 @lru_cache(maxsize=4096)
 def _record_content_digest_and_size(normalized_text: str) -> tuple[str, int]:
     normalized_bytes = normalized_text.encode("utf-8")
-    return hashlib.sha256(normalized_bytes).hexdigest(), len(normalized_bytes)
+    return _SHA256(normalized_bytes).hexdigest(), len(normalized_bytes)
 
 
 def _failure_id(reason: str, name: str) -> str:


### PR DESCRIPTION
## Summary
- Reuses a module-level SHA-256 constructor binding in dataset ingest record construction.
- Adds focused regression coverage that source ids remain the first 16 hex chars of the UTF-8 path SHA-256 digest.
- Documents the slice and its registered probe gate.

## Plan or Spec
- `docs/plans/2026-07-10-dataset-record-sha256-local-binding.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting` → 47 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py` → TOTAL 6 0 100%.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py` → completed successfully.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-main --head-repo "$PWD" --output /tmp/dataset-record-sha256-local-binding-probe.json` → completed successfully.
- `git diff --check` → passed.

## Coverage and Metrics
- Changed-scope coverage: 100% (6/6 changed measurable lines).
- Local registered probe comparison (`dataset-source-records-scandir`):
  - `record_elapsed_ms_mean`: base 17.826992 ms → head 17.423628 ms (delta -0.403364 ms, ~2.26% lower).
  - `record_elapsed_ms_p95`: base 19.333411 ms → head 18.844325 ms (delta -0.489086 ms).
  - `elapsed_ms_mean`: base 11.929353 ms → head 11.501382 ms (delta -0.427971 ms).
  - `source_kind_elapsed_ms_mean`: base 18.411600 ms → head 18.108474 ms (informational neighboring metric, delta -0.303125 ms).
- CI PR-scoped performance is required as the final registered probe validation and merge gate.

## Known Gaps
- Local validation is Linux-only; this slice changes Python code only and claims no Swift runtime effect.
- The measured improvement is intentionally small because the slice removes one hot per-record module attribute lookup without changing ingest behavior.

## Evidence Checklist
- [x] Registered probe covers the affected path with focused test, coverage, and probe commands.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Local registered probe shows no regression and a lower record construction mean.
- [ ] GitHub Actions PR-scoped performance completed successfully.
- [ ] Required PR checks are green.
