### PR TITLE
Add stream liveness conformance coverage

### DIFF
--- a/docs/plans/2026-07-10-issue-1384-stream-liveness-conformance.md
+++ b/docs/plans/2026-07-10-issue-1384-stream-liveness-conformance.md
@@ -1,0 +1,50 @@
+# Issue 1384 Stream Liveness Conformance Slice
+
+**Issue:** #1384
+
+**Goal:** Add a narrow OpenAI-compatible conformance matrix slice proving that
+worker heartbeat events are exposed as parseable SSE heartbeat envelopes, not as
+comment-only keepalives or unstructured transport noise.
+
+## Scope
+
+This slice covers only the deterministic Swift control-plane boundary:
+
+- `/v1/chat/completions` streaming responses backed by the in-process
+  `RecordingConformanceWorker` fixture.
+- Worker `heartbeat` events encoded by `SSEStreamWriter`.
+- Machine-readable `OpenAIConformanceReport` rows for the heartbeat contract.
+
+It does not change live socket behavior, add idle timers, implement stall
+receipts, or add cancellation cleanup receipts. Those remain follow-up #1384
+stream-liveness slices.
+
+## Expected Contract
+
+- A worker heartbeat event becomes an SSE record with `event: heartbeat`.
+- The heartbeat record `data` is valid JSON containing the stable request id and
+  heartbeat timestamp fields.
+- Heartbeat data does not appear as an unnamed OpenAI data chunk.
+- Token, heartbeat, terminal completion, optional usage, and `[DONE]` ordering
+  remains deterministic for the fixture.
+
+## Verification
+
+Focused:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
+git diff --check
+```
+
+Coverage:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter OpenAIConformanceMatrixTests
+```
+
+Metrics:
+
+This is a conformance-test/documentation slice. If the repository scoped
+performance selector does not select a direct probe, report metrics as
+`N/A: conformance coverage only`.

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
@@ -952,6 +952,68 @@ struct OpenAIConformanceMatrixTests {
         ]))
     }
 
+    @Test("streaming chat heartbeat emits parseable liveness envelope")
+    func streamingChatHeartbeatEmitsParseableLivenessEnvelope() async throws {
+        let worker = RecordingConformanceWorker(
+            requestID: "req-stream-heartbeat",
+            events: [
+                makeTokenEvent(requestID: "req-stream-heartbeat", seq: 1, text: "working"),
+                makeHeartbeatEvent(requestID: "req-stream-heartbeat", seq: 2, unixMs: 12_345),
+                makeUsageEvent(requestID: "req-stream-heartbeat", seq: 3, promptTokens: 4, completionTokens: 1),
+                makeCompletedEvent(
+                    requestID: "req-stream-heartbeat",
+                    seq: 4,
+                    finishReason: "stop",
+                    assistantText: "working"
+                ),
+            ]
+        )
+        let response = try await Self.handler(worker: worker).handle(
+            HTTPRequest(
+                method: .post,
+                path: "/v1/chat/completions",
+                headers: ["content-type": "application/json"],
+                body: Data(
+                    Self.body(extra: #""stream": true, "stream_options": { "include_usage": true }"#).utf8
+                )
+            )
+        )
+        let payload = try await collectConformanceBody(response.body)
+        let records = parseSSERecords(payload)
+        let eventOrder = records.map { $0.event ?? "data" }.joined(separator: ",")
+        let heartbeatRecord = try #require(records.first { $0.event == "heartbeat" })
+        let heartbeatPayload = try #require(
+            try JSONSerialization.jsonObject(with: Data(heartbeatRecord.data.utf8)) as? [String: Any]
+        )
+
+        #expect(response.statusCode == 200)
+        #expect(heartbeatPayload["request_id"] as? String == "req-stream-heartbeat")
+        #expect(heartbeatPayload["unix_ms"] as? Int == 12_345)
+        #expect(records.filter { $0.event == "heartbeat" }.count == 1)
+        #expect(records.filter { $0.event == nil && $0.data.contains(#""unix_ms""#) }.isEmpty)
+        #expect(eventOrder == "data,heartbeat,data,data,data")
+        #expect(orderedConformanceRanges(in: payload, needles: [
+            "\"content\":\"working\"",
+            "event: heartbeat",
+            "\"finish_reason\":\"stop\"",
+            "\"usage\"",
+            "data: [DONE]",
+        ]))
+
+        let report = OpenAIConformanceReport(rows: [
+            OpenAIConformanceRow(
+                field: "worker heartbeat event",
+                route: "/v1/chat/completions -> SSE liveness",
+                expectedBehavior: "worker heartbeat events emit a named, JSON-parseable SSE heartbeat envelope before terminal chunks.",
+                observedStatus: eventOrder == "data,heartbeat,data,data,data" ? .pass : .fail,
+                observedReason: "chunk_order=\(eventOrder)"
+            ),
+        ])
+        #expect(report.summary.passed == 1)
+        #expect(report.summary.failed == 0)
+        #expect(try report.jsonString().contains("\"worker heartbeat event\""))
+    }
+
     @Test("streaming prefill progress stays invisible unless opted in")
     func streamingPrefillProgressStaysInvisibleUnlessOptedIn() async throws {
         func prefillEvents(requestID: String) -> [Melix_Worker_V1_ExecuteEvent] {


### PR DESCRIPTION
## Summary
- Add a narrow #1384 conformance slice for `/v1/chat/completions` streaming heartbeats.
- Verify worker heartbeat events are emitted as named `event: heartbeat` SSE records with parseable JSON data, without leaking heartbeat payloads into unnamed OpenAI data chunks.
- Add the governing plan for this stream-liveness conformance slice.

## Plan or Spec
- `docs/plans/2026-07-10-issue-1384-stream-liveness-conformance.md`
- `docs/adr/0002-openai-conformance-at-control-plane-boundary.md`

## Commands Run
```text
make bootstrap
- Passed; configured hooks and checked Python env.

make proto
- Passed; generated artifacts already current; git status remained clean.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests/streamingChatHeartbeatEmitsParseableLivenessEnvelope
- Passed; 1 test passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests
- Passed; 22 tests passed.

git diff --check
- Passed.

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter OpenAIConformanceMatrixTests
- Passed; 22 tests passed with coverage instrumentation.

UV_PYTHON=3.12 uv run python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata --diff-from origin/main services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
- Passed; changed-line coverage 100.00% (60/60).

git commit -m "Add stream liveness conformance coverage"
- Passed via pre-commit hook:
  - make swift-test: rc=0, elapsed=619.0s
  - make py-test: rc=0, 4895 passed, 14 skipped, 2 warnings in 181.37s
  - make integration-test: rc=0, 123 passed, 1 skipped in 753.36s
  - PR scoped performance report: Status ok, Changed files 2, Selected probes 0, Direct/gated probes 0, Regressions 0, Verification failures 0
```

## Coverage and Metrics
- Changed-line coverage: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift` 100.00% (60/60).
- Metrics report: `.runtime/pre-commit-performance/20260710-115044-746662da/report/report.md` reported `Status: ok`, `Regressions: 0`, `Verification failures: 0`.
- Performance probes: `N/A: conformance-test/documentation slice; scoped selector selected 0 direct probes`.
- Observability mode: `N/A: no production observability or runtime debug mode added`; probe overhead `N/A` for the same reason.

## Known Gaps
- Follow-up #1384 slices still need live socket idle/stall receipts, cancellation cleanup receipts, and broader proxy parity coverage.
- This PR intentionally does not change production SSE runtime behavior; it locks the existing heartbeat envelope at the OpenAI boundary.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
