### PR TITLE
perf: stream sparse changed-scope source lines

### DIFF
--- a/docs/plans/2026-07-10-changed-scope-sparse-source-line-stream.md
+++ b/docs/plans/2026-07-10-changed-scope-sparse-source-line-stream.md
@@ -1,0 +1,44 @@
+# Changed-Scope Sparse Source-Line Streaming
+
+## Scope
+
+This performance slice narrows the source-line filtering step in
+`scripts/changed_scope_coverage.py` when only a small number of changed lines are
+measurable for a file.
+
+## Motivation
+
+Changed-scope coverage currently avoids most work before reading source files,
+but once a sparse changed set overlaps measured coverage it reads and splits the
+entire source file just to filter blank/comment-only changed lines. Small PRs
+commonly touch only a few measured lines, so this can add unnecessary file
+materialization on large files.
+
+## Plan
+
+- Preserve existing range-overlap and dense measured-set logic.
+- For sparse measurable changed-line sets, stream the source file only until all
+  target lines are seen, then classify blank/comment lines from those stripped
+  lines.
+- Keep the full-file read path for dense measured sets where materializing all
+  lines remains simpler and predictable.
+- Extend the registered changed-scope coverage measured-set probe with a sparse
+  changed-line scenario.
+
+## Probe
+
+Registered PR-scoped probe: `changed-scope-coverage-measured-set-filter` in
+`infra/perf/pr_scoped_probes.json`.
+
+Relevant metrics:
+
+- `sparse_elapsed_ms_mean`: lower is better for sparse changed-line filtering.
+- `sparse_source_read_calls_mean`: lower is better and should remain zero for
+  full-file `Path.read_text` calls in the sparse branch.
+- Existing dense and allowlist metrics continue to guard unchanged hot paths.
+
+## Verification
+
+Run the registered test command, coverage command, and probe command locally on
+Linux before opening the PR. CI remains the canonical PR-scoped performance
+comparison against `origin/main`.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -3294,6 +3294,19 @@
         "warn_pct": 0.0
       },
       {
+        "key": "sparse_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0,
+        "warn_abs": 0.05
+      },
+      {
+        "key": "sparse_source_read_calls_mean",
+        "unit": "reads",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
         "key": "measured_lines_per_path",
         "unit": "count",
         "direction": "informational"

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -28,6 +28,7 @@ _ASCII_AT = ord("@")
 _ASCII_LOWER_D = ord("d")
 _EMPTY_CHANGED_LINES: frozenset[int] = frozenset()
 _DENSE_CHANGED_LINE_SCAN_THRESHOLD = 32
+_SPARSE_SOURCE_LINE_SCAN_THRESHOLD = 8
 
 
 def _is_diff_file_marker(line: str) -> bool:
@@ -238,6 +239,31 @@ def _sorted_line_list_contains(lines: list[int], line_no: int) -> bool:
     return index < len(lines) and lines[index] == line_no
 
 
+def _stripped_source_lines_for_numbers(
+    source_path: Path,
+    line_numbers: list[int],
+) -> dict[int, str]:
+    if len(line_numbers) <= _SPARSE_SOURCE_LINE_SCAN_THRESHOLD:
+        remaining = set(line_numbers)
+        stripped_by_line: dict[int, str] = {}
+        with source_path.open("r", encoding="utf-8") as source_file:
+            for index, line in enumerate(source_file, 1):
+                if index in remaining:
+                    stripped_by_line[index] = line.strip()
+                    remaining.remove(index)
+                    if not remaining:
+                        break
+        return stripped_by_line
+
+    source_lines = source_path.read_text(encoding="utf-8").splitlines()
+    source_line_count = len(source_lines)
+    return {
+        line_no: source_lines[line_no - 1].strip()
+        for line_no in line_numbers
+        if 1 <= line_no <= source_line_count
+    }
+
+
 def _measurable_changed_lines(
     repo_root: Path,
     coverage_payload: dict[str, object],
@@ -305,10 +331,11 @@ def _measurable_changed_lines(
     if not measured_changed:
         return [], [], []
 
-    source_lines = (repo_root / rel_path).read_text(encoding="utf-8").splitlines()
+    sorted_measured_changed = sorted(measured_changed)
+    stripped_source_lines = _stripped_source_lines_for_numbers(repo_root / rel_path, sorted_measured_changed)
     measurable: list[int] = []
-    for line_no in sorted(measured_changed):
-        stripped = source_lines[line_no - 1].strip()
+    for line_no in sorted_measured_changed:
+        stripped = stripped_source_lines.get(line_no)
         if stripped and not stripped.startswith("#"):
             measurable.append(line_no)
     if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):

--- a/scripts/changed_scope_coverage_measured_probe.py
+++ b/scripts/changed_scope_coverage_measured_probe.py
@@ -29,9 +29,11 @@ def run_probe(
 ) -> dict[str, float]:
     module = _load_changed_scope_coverage(repo_root)
     elapsed_samples: list[float] = []
+    sparse_elapsed_samples: list[float] = []
     dense_elapsed_samples: list[float] = []
     allowlist_elapsed_samples: list[float] = []
     read_samples: list[float] = []
+    sparse_read_samples: list[float] = []
     dense_read_samples: list[float] = []
     allowlist_value = json.dumps("pkg/module_0.py")
 
@@ -56,6 +58,7 @@ def run_probe(
             }
         }
         changed_lines = {measured_lines_per_path + 1, measured_lines_per_path + 2}
+        sparse_changed_lines = {1, 2}
         dense_changed_lines = set(range(1, measured_lines_per_path + 1))
 
         original_read_text = module.Path.read_text
@@ -89,6 +92,20 @@ def run_probe(
                         root,
                         coverage_payload,
                         rel_path,
+                        sparse_changed_lines,
+                    )
+                    if measurable != [1, 2] or covered != [1] or missed != [2]:
+                        raise RuntimeError("sparse changed set should stream and partition target lines")
+                sparse_elapsed_samples.append((time.perf_counter() - start) * 1000.0)
+                sparse_read_samples.append(float(read_calls))
+
+                read_calls = 0
+                start = time.perf_counter()
+                for rel_path in rel_paths:
+                    measurable, covered, missed = module._measurable_changed_lines(
+                        root,
+                        coverage_payload,
+                        rel_path,
                         dense_changed_lines,
                     )
                     if not (measurable or covered or missed):
@@ -113,10 +130,12 @@ def run_probe(
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
+        "sparse_elapsed_ms_mean": statistics.fmean(sparse_elapsed_samples),
         "dense_elapsed_ms_mean": statistics.fmean(dense_elapsed_samples),
         "allowlist_parse_elapsed_ms_mean": statistics.fmean(allowlist_elapsed_samples),
         "allowlist_parse_count": float(allowlist_parse_count),
         "source_read_calls_mean": statistics.fmean(read_samples),
+        "sparse_source_read_calls_mean": statistics.fmean(sparse_read_samples),
         "dense_source_read_calls_mean": statistics.fmean(dense_read_samples),
         "path_count": float(path_count),
         "measured_lines_per_path": float(measured_lines_per_path),

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -607,6 +607,82 @@ def test_measurable_changed_lines_handles_large_measured_sets_without_union(tmp_
     assert missed == [2]
 
 
+def test_measurable_changed_lines_streams_sparse_source_lines(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 101)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 100, 2)),
+                "missing_lines": list(range(2, 101, 2)),
+            }
+        }
+    }
+    original_open = changed_scope_coverage.Path.open
+    open_calls: list[Path] = []
+
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:  # pragma: no cover
+        raise AssertionError("sparse changed-line source filtering should stream target lines")
+
+    def counted_open(self: Path, *args: object, **kwargs: object) -> object:
+        if self == source_path:
+            open_calls.append(self)
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(changed_scope_coverage.Path, "read_text", fail_read_text)
+    monkeypatch.setattr(changed_scope_coverage.Path, "open", counted_open)
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {2, 51},
+    )
+
+    assert measurable == [2, 51]
+    assert covered == [51]
+    assert missed == [2]
+    assert open_calls == [source_path]
+
+
+def test_measurable_changed_lines_ignores_out_of_range_source_lines(tmp_path: Path) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 41)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 40, 2)) + [42],
+                "missing_lines": list(range(2, 41, 2)) + [41],
+            }
+        }
+    }
+
+    sparse_measurable, sparse_covered, sparse_missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {2, 41},
+    )
+
+    assert sparse_measurable == [2]
+    assert sparse_covered == []
+    assert sparse_missed == [2]
+
+    dense_measurable, dense_covered, dense_missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        set(range(1, 43)),
+    )
+
+    assert dense_measurable == list(range(1, 41))
+    assert dense_covered == list(range(1, 40, 2))
+    assert dense_missed == list(range(2, 41, 2))
+
+
 def test_measurable_changed_lines_dense_filter_keeps_generic_set_fallback(tmp_path: Path) -> None:
     class GenericChangedSet:
         def __init__(self, values: set[int]) -> None:
@@ -719,10 +795,12 @@ def test_changed_scope_coverage_measured_probe_emits_large_measured_metrics() ->
     assert metrics["measured_lines_per_path"] == 10.0
     assert metrics["sample_count"] == 2.0
     assert metrics["elapsed_ms_mean"] > 0
+    assert metrics["sparse_elapsed_ms_mean"] > 0
     assert metrics["dense_elapsed_ms_mean"] > 0
     assert metrics["allowlist_parse_elapsed_ms_mean"] > 0
     assert metrics["allowlist_parse_count"] == 10000.0
     assert metrics["source_read_calls_mean"] == 0.0
+    assert metrics["sparse_source_read_calls_mean"] == 0.0
     assert metrics["dense_source_read_calls_mean"] == 5.0
 
 
@@ -751,6 +829,10 @@ def test_changed_scope_coverage_measured_probe_rejects_unexpected_allowlist_pars
             rel_path: str,
             changed: set[int],
         ) -> tuple[list[int], list[int], list[int]]:
+            if changed == {1, 2}:
+                return [1, 2], [1], [2]
+            if 1 in changed:
+                return [1, 2, 3, 4], [1, 3], [2, 4]
             return [], [], []
 
         @staticmethod
@@ -767,7 +849,7 @@ def test_changed_scope_coverage_measured_probe_rejects_unexpected_allowlist_pars
         changed_scope_coverage_measured_probe.run_probe(
             tmp_path,
             path_count=1,
-            measured_lines_per_path=2,
+            measured_lines_per_path=4,
             allowlist_parse_count=1,
             samples=1,
         )
@@ -787,6 +869,8 @@ def test_changed_scope_coverage_measured_probe_rejects_incomplete_dense_measurem
             rel_path: str,
             changed: set[int],
         ) -> tuple[list[int], list[int], list[int]]:
+            if changed == {1, 2}:
+                return [1, 2], [1], [2]
             if 1 in changed:
                 return [1], [1], []
             return [], [], []
@@ -805,7 +889,7 @@ def test_changed_scope_coverage_measured_probe_rejects_incomplete_dense_measurem
         changed_scope_coverage_measured_probe.run_probe(
             tmp_path,
             path_count=1,
-            measured_lines_per_path=2,
+            measured_lines_per_path=4,
             allowlist_parse_count=1,
             samples=1,
         )
@@ -825,8 +909,10 @@ def test_changed_scope_coverage_measured_probe_rejects_incomplete_dense_partitio
             rel_path: str,
             changed: set[int],
         ) -> tuple[list[int], list[int], list[int]]:
+            if changed == {1, 2}:
+                return [1, 2], [1], [2]
             if 1 in changed:
-                return [1, 2], [1], []
+                return [1, 2, 3, 4], [1, 3], []
             return [], [], []
 
         @staticmethod
@@ -843,7 +929,7 @@ def test_changed_scope_coverage_measured_probe_rejects_incomplete_dense_partitio
         changed_scope_coverage_measured_probe.run_probe(
             tmp_path,
             path_count=1,
-            measured_lines_per_path=2,
+            measured_lines_per_path=4,
             allowlist_parse_count=1,
             samples=1,
         )


### PR DESCRIPTION
## Summary
- Stream source files for sparse changed-scope coverage filtering instead of materializing every source line.
- Keep the existing full-file path for dense measured changed-line sets.
- Extend the registered measured-set probe with sparse source-line metrics.

## Plan or Spec
- `docs/plans/2026-07-10-changed-scope-sparse-source-line-stream.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 50 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 50 passed in 0.70s; TOTAL 58 1 98%

python3 scripts/changed_scope_coverage_measured_probe.py
# {"allowlist_parse_count": 10000.0, "allowlist_parse_elapsed_ms_mean": 3.1140748428047766, "dense_elapsed_ms_mean": 52.138615150137674, "dense_source_read_calls_mean": 300.0, "elapsed_ms_mean": 0.35826285602524877, "measured_lines_per_path": 500.0, "path_count": 300.0, "sample_count": 7.0, "source_read_calls_mean": 0.0, "sparse_elapsed_ms_mean": 8.018267706834845, "sparse_source_read_calls_mean": 0.0}

python3 - <<'PY'
# local old-vs-new sparse harness comparing origin/main worktree to this branch
PY
# {"delta_ms": -3.8376359900991828, "new_sparse_elapsed_ms_mean": 6.506413005159369, "old_sparse_elapsed_ms_mean": 10.344048995258552, "speedup": 1.589823607424869}

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 58 1 98%`.
- Registered probe: `changed-scope-coverage-measured-set-filter`.
- Local registered probe output: `sparse_elapsed_ms_mean=8.018267706834845`, `sparse_source_read_calls_mean=0.0`, `dense_elapsed_ms_mean=52.138615150137674`.
- Local old-vs-new sparse harness: `old_sparse_elapsed_ms_mean=10.344048995258552`, `new_sparse_elapsed_ms_mean=6.506413005159369`, `delta_ms=-3.8376359900991828`, `speedup=1.589823607424869`.
- CI PR-scoped performance report is required for the canonical base-vs-head registered probe validation.

## Known Gaps
- Linux-local validation only. No Swift runtime path is touched.
- The dense changed-line branch intentionally keeps the existing full-file read behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
