### PR TITLE
perf: streamline dataset source path materialization

### DIFF
--- a/docs/plans/2026-05-25-dataset-source-kind-suffix-fastpath.md
+++ b/docs/plans/2026-05-25-dataset-source-kind-suffix-fastpath.md
@@ -27,3 +27,16 @@ The registry entry includes focused `test_command`, `coverage_command`, and `pro
 ## Verification Notes
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime effect is claimed.
+
+## 2026-07-10 follow-up: path materialization comprehension
+
+The `dataset-source-records-scandir` registered probe also covers the source-file
+path discovery helper `_iter_source_file_paths()`. After the scandir traversal
+collects and sorts file path strings, the helper materializes `Path` objects for
+callers. This follow-up keeps traversal, sorting, symlink, and error-tolerance
+semantics unchanged while using an explicit list comprehension instead of
+`list(map(Path, ...))` for the final materialization step.
+
+Validation remains the registered focused test command, changed-scope coverage
+command, and local Linux `dataset-source-records-scandir` probe, with GitHub
+Actions PR-scoped performance as the merge gate.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1271,7 +1271,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return list(map(path_cls, file_paths))
+    return [path_cls(path) for path in file_paths]
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Streamlines dataset source-file path materialization after the existing `os.scandir` traversal by using an explicit `Path` list comprehension instead of `list(map(...))`.
- Keeps traversal order, sorted output, symlink handling, and scandir error tolerance unchanged.

## Plan or Spec
- `docs/plans/2026-05-25-dataset-source-kind-suffix-fastpath.md` documents the `2026-07-10 follow-up: path materialization comprehension` slice.
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`, with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# baseline before accepted edit: exit 0; elapsed_ms_mean=12.258705383698855, elapsed_ms_p95=15.209748991765082, file_count_mean=7000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=21 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# after accepted edit: exit 0; elapsed_ms_mean=11.361664186032224, elapsed_ms_p95=12.058106018230319, file_count_mean=7000.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# exit 0; 47 passed in 1.82s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# exit 0; 47 passed in 1.15s; TOTAL 1 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `dataset_preparation.py`, focused ingest tests, PR-scoped performance tests, and `scripts/dataset_source_records_probe.py`.
- Local registered probe on Linux: old_mean=12.258705383698855 ms, new_mean=11.361664186032224 ms, delta=-0.897041197666631 ms, speedup=1.07895x, file_count_mean=7000.0.
- CI PR-scoped performance report is required as the final registered-probe validation before merge.

## Known Gaps
- No Swift runtime effect is claimed; this is a Python-only slice verified locally on Linux.
- Longer local 51-sample exploratory reruns were noisy around the path-discovery metric, so GitHub Actions PR-scoped performance remains the merge gate for the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
