### PR TITLE
perf: precompute MLX-LM result prefixes

### DIFF
--- a/docs/plans/2026-07-10-mlx-lm-result-prefix-constants.md
+++ b/docs/plans/2026-07-10-mlx-lm-result-prefix-constants.md
@@ -1,0 +1,42 @@
+# MLX-LM Structured Result Prefix Constants
+
+## Scope
+
+This Python-only performance slice is limited to the MLX-LM subprocess structured
+result extractor in `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`.
+The extractor already scans from the tail of stdout with `str.rfind()` instead
+of materializing `splitlines()`. This slice removes per-call construction of the
+newline and carriage-return result marker strings by precomputing them at module
+load time.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`mlx-lm-structured-result-tail-parse` in `infra/perf/pr_scoped_probes.json`. The
+registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py`
+- `services/mlx-worker-python/tests/test_lora_model_ops_unit.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/mlx_lm_result_tail_probe.py`
+
+The probe reports `elapsed_ms_mean` and `peak_bytes_mean` for repeated extraction
+from a large noisy stdout payload.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command,
+`git diff --check`, and the registered `mlx-lm-structured-result-tail-parse`
+probe locally on Linux before opening the PR. GitHub Actions PR-scoped
+performance remains the merge gate for the registered probe report.
+
+## Success Metrics
+
+- Preserve structured-result extraction for terminal newline and carriage-return
+  prefixes, embedded prefix noise, and missing-result behavior.
+- Keep changed-scope coverage at or above 95 percent for the touched Python
+  scope.
+- The registered probe should show a non-regressing `elapsed_ms_mean` and
+  `peak_bytes_mean` versus `origin/main`; expected benefit is small because the
+  existing tail scan is already the dominant optimization.

--- a/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
+++ b/services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py
@@ -33,6 +33,8 @@ from worker.model_ops.training_log_events import parse_training_log_events
 
 _RESULT_PREFIX = "__MELIX_MLX_RESULT__="
 _RESULT_PREFIX_LENGTH = len(_RESULT_PREFIX)
+_RESULT_LINE_PREFIX = "\n" + _RESULT_PREFIX
+_RESULT_CARRIAGE_PREFIX = "\r" + _RESULT_PREFIX
 _RESULT_PAYLOAD_DECODER = json.JSONDecoder()
 # Sentinel tied to mlx-lm's internal error wording. Keep the mlx-lm pin in
 # pyproject.toml tight: any upstream wording change would silently disable the
@@ -599,9 +601,9 @@ class MLXLMRunner:
 
 
 def _extract_structured_result_payload(stdout: str) -> dict[str, object] | None:
-    prefix_index = stdout.rfind("\n" + _RESULT_PREFIX)
+    prefix_index = stdout.rfind(_RESULT_LINE_PREFIX)
     carriage_prefix_index = stdout.rfind(
-        "\r" + _RESULT_PREFIX,
+        _RESULT_CARRIAGE_PREFIX,
         prefix_index + 1 if prefix_index >= 0 else 0,
     )
     if carriage_prefix_index > prefix_index:


### PR DESCRIPTION
## Summary
- Precompute the MLX-LM structured-result newline and carriage-return marker strings at module load time.
- Keep the existing tail `rfind()` extraction semantics unchanged for noisy stdout payloads.

## Plan or Spec
- `docs/plans/2026-07-10-mlx-lm-result-prefix-constants.md`
- Registered probe: `mlx-lm-structured-result-tail-parse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_extracts_terminal_structured_result_without_splitlines services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_float_ext_rejects_non_numeric_and_out_of_range_values services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_mlx_lm_runner_evaluate_heldout_native_uses_adapter_and_test_split services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_run_subprocess_rejects_missing_structured_result services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_accepts_carriage_return_line_end services/mlx-worker-python/tests/test_lora_model_ops_unit.py::test_extract_structured_result_payload_skips_embedded_prefix_and_finds_prior_line services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_mlx_lm_runner_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_covers_heldout_evaluation_import_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_mlx_lm_result_tail_probe_script_main_covers_checked_in_file
# 11 passed in 2.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered focused pytest selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/mlx_lm_runner.py services/mlx-worker-python/tests/test_lora_model_ops_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/mlx_lm_result_tail_probe.py
# 11 passed in 1.55s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/mlx_lm_result_tail_probe.py
# {"elapsed_ms_mean": 0.073544, "iteration_count": 12.0, "line_count": 50002.0, "payload_value": 42.0, "peak_bytes_mean": 481.2, "sample_count": 5.0}

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id mlx-lm-structured-result-tail-parse --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-main --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-mlx-lm-result-prefix-constants-20260710 --output /tmp/mlx_lm_result_prefix_perf.json
# base elapsed_ms_mean=0.07957, peak_bytes_mean=481.2; head elapsed_ms_mean=0.074035, peak_bytes_mean=481.2

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `mlx_lm_runner.py` changed lines.
- Registered local probe comparison (`mlx-lm-structured-result-tail-parse`): `old_mean=0.07957ms`, `new_mean=0.074035ms`, `delta_ms=-0.005535`, `speedup=1.0748x`; `peak_bytes_mean` stayed `481.2` bytes.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode change.
- [x] Deferred work and known gaps are stated explicitly.
