### PR TITLE
perf: reuse dataset registry scandir stat

### DIFF
--- a/docs/plans/2026-07-10-dataset-registry-direntry-stat.md
+++ b/docs/plans/2026-07-10-dataset-registry-direntry-stat.md
@@ -1,0 +1,31 @@
+# Dataset registry DirEntry stat reuse
+
+## Scope
+
+This Python-only performance slice is limited to dataset registry snapshot file
+materialization in `services/mlx-worker-python/worker/dataset_registry/catalog.py`.
+
+`_dataset_files()` now uses a snapshot-scan helper that keeps the existing
+sorted `os.scandir()` traversal and reads file sizes from the scan-time
+`DirEntry.stat()` result. This avoids constructing a `Path` only to call
+`Path.stat()` for every supported dataset file while preserving relative path,
+file-format, split, config, and metadata behavior.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-registry-snapshot-inference-single-pass` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_snapshot_probe.py`
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, `git diff
+--check`, and the registered `dataset-registry-snapshot-inference-single-pass`
+probe locally on Linux before opening the PR. GitHub Actions PR-scoped
+performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -1614,19 +1614,68 @@ def test_dataset_catalog_filesystem_error_helpers(
     snapshot_dir.mkdir()
     data_file = snapshot_dir / "train.jsonl"
     data_file.write_text('{"prompt":"ok"}\n', encoding="utf-8")
-    original_stat = Path.stat
+    def fail_path_stat(self: Path, *args: object, **kwargs: object):
+        raise AssertionError(  # pragma: no cover - regression sentinel
+            f"dataset files should reuse scandir stat results, got Path.stat({self!s})"
+        )
 
-    def guarded_stat(self: Path, *args: object, **kwargs: object):
-        if self == data_file:
-            raise OSError("stat failed")
-        return original_stat(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "stat", guarded_stat)
-    assert list(catalog._dataset_files(snapshot_dir)) == []
+    monkeypatch.setattr(Path, "stat", fail_path_stat)
+    assert list(catalog._dataset_files(snapshot_dir)) == [
+        catalog.DatasetFile(
+            relative_path="train.jsonl",
+            size_bytes=len(data_file.read_bytes()),
+            file_format="jsonl",
+        )
+    ]
 
     def raising_scandir(_path):
         raise OSError("scan failed")
 
     monkeypatch.setattr(catalog.os, "scandir", raising_scandir)
+    assert list(catalog._dataset_files(snapshot_dir)) == []
     assert list(catalog._iter_supported_dataset_files(snapshot_dir)) == []
     assert catalog._sorted_child_directories(snapshot_dir) == ()
+
+
+def test_dataset_catalog_dataset_file_stat_records_skip_nonfiles_and_stat_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class FakeEntry:
+        def __init__(self, name: str, *, is_file: bool = True, stat_error: bool = False) -> None:
+            self.name = name
+            self.path = str(tmp_path / name)
+            self._is_file = is_file
+            self._stat_error = stat_error
+
+        def is_dir(self) -> bool:
+            return False
+
+        def is_file(self) -> bool:
+            return self._is_file
+
+        def stat(self):
+            if self._stat_error:
+                raise OSError("stat failed")
+            return type("Stat", (), {"st_size": 7})()
+
+    class FakeScandir:
+        def __init__(self, entries: tuple[FakeEntry, ...]) -> None:
+            self._entries = entries
+
+        def __enter__(self) -> tuple[FakeEntry, ...]:
+            return self._entries
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    entries = (
+        FakeEntry("directory.jsonl", is_file=False),
+        FakeEntry("broken.jsonl", stat_error=True),
+        FakeEntry("train.jsonl"),
+    )
+    monkeypatch.setattr(catalog.os, "scandir", lambda _path: FakeScandir(entries))
+
+    assert list(catalog._iter_supported_dataset_file_stat_records(tmp_path)) == [
+        ("train.jsonl", "jsonl", 7)
+    ]

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -978,16 +978,39 @@ def _build_dataset_snapshot(
 
 
 def _dataset_files(snapshot_dir: Path) -> Iterator[DatasetFile]:
-    for path, relative_path, file_format in _iter_supported_dataset_file_records(snapshot_dir):
-        try:
-            stat_result = path.stat()
-        except OSError:
-            continue
+    for relative_path, file_format, size_bytes in _iter_supported_dataset_file_stat_records(snapshot_dir):
         yield DatasetFile(
             relative_path=relative_path,
-            size_bytes=stat_result.st_size,
+            size_bytes=size_bytes,
             file_format=file_format,
         )
+
+
+def _iter_supported_dataset_file_stat_records(
+    snapshot_dir: Path, relative_prefix: str = ""
+) -> Iterator[tuple[str, str, int]]:
+    try:
+        with os.scandir(os.fspath(snapshot_dir)) as entries:
+            child_entries = sorted(entries, key=lambda entry: entry.name)
+    except OSError:
+        return
+    for entry in child_entries:
+        name = entry.name
+        relative_path = f"{relative_prefix}{name}"
+        try:
+            if entry.is_dir():
+                yield from _iter_supported_dataset_file_stat_records(
+                    Path(entry.path), f"{relative_path}/"
+                )
+                continue
+            if not entry.is_file():
+                continue
+            stat_result = entry.stat()
+        except OSError:
+            continue
+        file_format = _dataset_file_format_name(name)
+        if file_format:
+            yield relative_path, file_format, stat_result.st_size
 
 
 def _iter_supported_dataset_files(snapshot_dir: Path) -> Iterator[Path]:


### PR DESCRIPTION
## Summary
- Reuses `DirEntry.stat()` while materializing dataset registry `DatasetFile` records instead of constructing a `Path` only to call `Path.stat()` for every supported file.
- Keeps the sorted scandir traversal, relative paths, file format reuse, split/config inference behavior, and filesystem error handling unchanged.
- Adds regression coverage proving `_dataset_files()` no longer depends on `Path.stat()` and still skips scandir/stat failures.

## Plan or Spec
- `docs/plans/2026-07-10-dataset-registry-direntry-stat.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_dataset_files_reuse_scanned_file_format services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_filesystem_error_helpers
# 2 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics
# 65 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_snapshot_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_snapshot_probe.py
# 65 passed in 0.43s; TOTAL 51 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_snapshot_probe.py
# {"elapsed_ms_mean": 130.11621941113845, "file_count_mean": 2401.0, "legacy_inference_helper_calls_mean": 0.0, "peak_bytes_mean": 780817.4, "sample_count": 5.0, "sidecar_count_mean": 2400.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 51 0 100%`.
- Registered local probe: `dataset-registry-snapshot-inference-single-pass`.
- Baseline from `origin/main` before the slice: `elapsed_ms_mean=145.26168641168624`, `peak_bytes_mean=778415.8`, `file_count_mean=2401.0`.
- This branch: `elapsed_ms_mean=130.11621941113845`, `peak_bytes_mean=780817.4`, `file_count_mean=2401.0`.
- Delta: `-15.145467000547796 ms` mean elapsed, `10.426332899388225%` lower elapsed mean (`11.639953165785943%` speedup ratio).
- CI PR-scoped performance report is required as the merge gate for the registered probe.

## Known Gaps
- Local verification was Linux/Python-only; no Swift runtime validation is involved in this slice.
- CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
