### PR TITLE
perf: streamline dataset CSV TSV suffix dispatch

### DIFF
--- a/docs/plans/2026-07-10-dataset-source-csv-tsv-branch.md
+++ b/docs/plans/2026-07-10-dataset-source-csv-tsv-branch.md
@@ -1,0 +1,46 @@
+# Dataset source CSV/TSV suffix branch
+
+## Scope
+
+This Python-only performance slice is limited to dataset ingest source-kind
+classification in `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+The prior lowercase fast path handled common `.csv` and `.tsv` names by slicing the
+last four characters and checking tuple membership. The new slice keeps the same
+last-character dispatch but compares the shared four-character suffix with direct
+`==` checks so common structured-data names avoid the tuple-membership branch.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The entry
+already has focused `test_command`, `coverage_command`, and `probe_command`
+values for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+The probe reports source-tree traversal timing plus source-kind classification
+metrics (`source_kind_elapsed_ms_mean`, `source_kind_elapsed_ms_min`, and
+`source_kind_elapsed_ms_p95`).
+
+## Optimization plan
+
+1. Keep the existing lowercase suffix semantics for `.csv` and `.tsv`.
+2. Replace tuple membership with direct suffix equality checks in the hot
+   last-character branch.
+3. Preserve fallback classification for uppercase or uncommon suffix spellings.
+4. Run focused tests, changed-scope coverage, `git diff --check`, and the
+   registered probe locally on Linux before opening the PR.
+5. Use GitHub Actions PR-scoped performance as the final registered probe merge
+   gate.
+
+## Verification
+
+- Focused dataset-ingest and PR-scoped performance tests pass.
+- Changed-scope coverage for touched Python/test/probe files remains at or above
+  95%.
+- Local registered probe should improve or stay stable on
+  `source_kind_elapsed_ms_mean`; CI remains the merge-gate source of truth for
+  the registered probe report.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1300,7 +1300,8 @@ def _classify_source_kind_name(name: str) -> str | None:
         if name[-5:] == ".json":
             return "structured_data"
     elif last_char == "v":
-        if name[-4:] in (".csv", ".tsv"):
+        suffix4 = name[-4:]
+        if suffix4 == ".csv" or suffix4 == ".tsv":
             return "structured_data"
 
     dot_index = name.rfind(".")


### PR DESCRIPTION
## Summary
- Streamline the dataset ingest `.csv` / `.tsv` source-kind fast path by replacing tuple membership with direct suffix equality checks.
- Keep uppercase and uncommon suffix fallback behavior unchanged.

## Plan or Spec
- `docs/plans/2026-07-10-dataset-source-csv-tsv-branch.md`

## Commands Run
```text
# Baseline local probe before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# exit 0; source_kind_elapsed_ms_mean=23.382394878555917; elapsed_ms_mean=13.35063643960489

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# exit 0; 47 passed in 1.73s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# exit 0; 47 passed in 1.12s; changed-scope coverage TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=9 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# exit 0; source_kind_elapsed_ms_mean=18.066017668590778; elapsed_ms_mean=11.33269067051717

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-source-csv-tsv-branch-20260710 --output /tmp/dataset_source_csv_tsv_perf.json
# exit 0; registered base/head probe completed

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered local probe (`dataset-source-records-scandir`, base -> head, 11 samples):
  - `elapsed_ms_mean`: 12.29030880759555 -> 11.246978448153557 ms (-1.0433303594419918 ms, -8.49%).
  - `source_kind_elapsed_ms_mean`: 19.77843419246545 -> 17.812255283140324 ms (-1.9661789093251265 ms, -9.94%).
  - `source_kind_elapsed_ms_p95`: 22.807944973465055 -> 18.191282055340707 ms (-20.24%).
  - Guard rails: `file_count_mean=7000.0`, `source_kind_variant_count=7.0` unchanged.
- CI PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- None for the Python/Linux slice. Swift runtime effects are not involved.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
