### PR TITLE
Add text model policy catalog receipts

### DIFF
--- a/docs/plans/2026-07-11-issue-1385-model-policy-catalog.md
+++ b/docs/plans/2026-07-11-issue-1385-model-policy-catalog.md
@@ -15,6 +15,9 @@ lookup visible in the existing effective-policy receipt.
   `TextRequestShaper`.
 - Add effective-policy receipt fields for policy lookup status, canonical model
   identity, matched alias, source URL, and request override state.
+- Treat `policy_lookup_status` as catalog lookup provenance: imported
+  `generation_config` defaults may still provide model sampling values, but they
+  remain `unknown` unless a catalog entry matches.
 - Wire HTTP gateway, XPC chat execution, and serving-default summaries through
   the catalog-aware initializer.
 - Keep the repository default catalog empty for this slice so existing gateway

--- a/docs/plans/2026-07-11-issue-1385-model-policy-catalog.md
+++ b/docs/plans/2026-07-11-issue-1385-model-policy-catalog.md
@@ -1,0 +1,92 @@
+# Issue 1385 Model Policy Catalog Slice
+
+## Goal
+
+Add the first shared text model policy catalog path so model identity aliases can
+resolve recommended sampling defaults before request dispatch, and make that
+lookup visible in the existing effective-policy receipt.
+
+## Scope
+
+- Add a pure catalog lookup type for text model sampling policies.
+- Let `ModelSamplingPolicy` merge imported `generation_config` fields with
+  catalog recommendations field by field.
+- Preserve request, preset, OCR, and gateway precedence already implemented by
+  `TextRequestShaper`.
+- Add effective-policy receipt fields for policy lookup status, canonical model
+  identity, matched alias, source URL, and request override state.
+- Wire HTTP gateway, XPC chat execution, and serving-default summaries through
+  the catalog-aware initializer.
+- Keep the repository default catalog empty for this slice so existing gateway
+  defaults do not drift until source-verified production entries are added in a
+  later slice.
+
+## Out Of Scope
+
+- Strict unknown-model rejection.
+- New public request fields for recommended-sampling opt-in.
+- Benchmark/evaluation export schema changes.
+- Desktop or CLI inspection UI.
+
+## Files
+
+- Create `services/control-plane-swift/Sources/Requests/TextModelPolicyCatalog.swift`
+  for catalog entries, alias normalization, and lookup results.
+- Modify `services/control-plane-swift/Sources/Requests/TextRequestShaper.swift`
+  to extend `ModelSamplingPolicy` metadata and pass receipt metadata through
+  `ShapedTextRequest`.
+- Modify `services/control-plane-swift/Sources/Requests/TextEffectivePolicyReceipt.swift`
+  to serialize policy lookup metadata deterministically.
+- Modify `services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift`
+  only if shaped request construction or dispatch metadata needs the new fields.
+- Modify `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift`,
+  `services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift`,
+  and `services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift`
+  to use catalog-aware `ModelSamplingPolicy` construction.
+- Modify `services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift`
+  with red tests for alias lookup, request override reporting, and unknown
+  fallback receipt metadata.
+
+## TDD Steps
+
+1. Add a failing `TextEndpointContractTests` case for a custom catalog entry
+   matched by an imported filename alias. Assert effective temperature, `top_p`,
+   max tokens, `policy_lookup_status == "known"`, canonical ID, matched alias,
+   source URL, and `request_override_applied == false`.
+2. Run:
+
+   ```bash
+   xcrun swift test --package-path services/control-plane-swift --filter 'TextEndpointContractTests/chatTranslationUsesCatalogSamplingPolicyForAliasedModelIdentity'
+   ```
+
+   Expected before implementation: compile failure or test failure because the
+   catalog API and receipt fields do not exist.
+
+3. Implement `TextModelPolicyCatalog` and catalog-aware `ModelSamplingPolicy`
+   with generation-config precedence over catalog values and catalog fallback
+   for missing fields.
+4. Add the receipt fields to `ShapedTextRequest` and
+   `TextEffectivePolicyReceipt`.
+5. Run the same focused test and keep iterating until it passes.
+6. Add a failing override test proving request temperature records
+   `policy_lookup_status == "operator_override"` while catalog `top_p` and max
+   tokens remain effective.
+7. Implement the minimal override-status derivation.
+8. Add a failing unknown fallback test proving gateway defaults still dispatch
+   with `policy_lookup_status == "unknown"`.
+9. Implement the minimal unknown metadata defaults.
+10. Wire production call sites to use the catalog-aware initializer.
+11. Run focused and changed-scope verification:
+
+    ```bash
+    xcrun swift test --package-path services/control-plane-swift --filter ControlPlaneTests.TextEndpointContractTests
+    ```
+
+12. Build changed-line coverage and scoped metrics before commit/PR.
+
+## Metrics And Verification
+
+- Required changed-line coverage for touched Swift scope: at least 95 percent.
+- Focused Swift test suite: `ControlPlaneTests.TextEndpointContractTests`.
+- Metrics report: scoped performance report or `N/A` only if no scoped probe
+  applies to this request-shaping metadata change.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift
@@ -712,7 +712,12 @@ public actor GatewayServingDefaultsStore {
             let requestedMultimodalRoutePolicy = record?.multimodalRoutePolicy ?? defaults.multimodalRoutePolicy
             let requestedSpeculativeRoutePolicy = record?.speculativeRoutePolicy ?? defaults.speculativeRoutePolicy
             let defaultModelID = Self.trimmed(defaultModelIDs[serverSessionID] ?? "")
-            let modelSamplingPolicy = modelSettingsByModelID[defaultModelID].flatMap(ModelSamplingPolicy.init)
+            let modelSamplingPolicy = modelSettingsByModelID[defaultModelID].flatMap {
+                ModelSamplingPolicy(
+                    modelID: defaultModelID,
+                    modelSettings: $0
+                )
+            }
             let modelSettings = modelSettingsByModelID[defaultModelID]
             let effectiveBatchingDefaults = Self.effectiveBatchingDefaults(
                 concurrentProcessingEnabled: requestedConcurrentProcessingEnabled,

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift
@@ -2947,7 +2947,10 @@ button.primary:active {
             throw HTTPRequestHandlingError.gatewayResponse(validationFailure)
         }
         let modelSamplingPolicy: ModelSamplingPolicy? = if let resolvedModel {
-            ModelSamplingPolicy(modelSettings: resolvedModel.settings)
+            ModelSamplingPolicy(
+                modelID: resolvedModel.modelID,
+                modelSettings: resolvedModel.settings
+            )
         } else {
             nil
         }

--- a/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
+++ b/services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift
@@ -339,6 +339,11 @@ public struct ShapedTextRequest: Sendable, Equatable {
     public let topPSource: String
     public let maxTokens: UInt32
     public let maxTokensSource: String
+    public let samplingPolicyLookupStatus: String
+    public let samplingPolicyCanonicalModel: String
+    public let samplingPolicyMatchedAlias: String
+    public let samplingPolicySourceURL: String
+    public let samplingRequestOverrideApplied: Bool
     public let requestedMaxTokens: UInt32?
     public let requestedMaxCompletionTokens: UInt32?
     public let outputCapSource: String

--- a/services/control-plane-swift/Sources/Requests/TextEffectivePolicyReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/TextEffectivePolicyReceipt.swift
@@ -11,6 +11,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
     public let topPSource: String
     public let maxTokens: UInt32
     public let maxTokensSource: String
+    public let samplingPolicyLookupStatus: String
+    public let samplingPolicyCanonicalModel: String
+    public let samplingPolicyMatchedAlias: String
+    public let samplingPolicySourceURL: String
+    public let samplingRequestOverrideApplied: Bool
     public let seed: UInt32?
     public let seedSource: String
     public let stopSource: String
@@ -36,6 +41,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
             topPSource: shapedRequest.topPSource,
             maxTokens: shapedRequest.maxTokens,
             maxTokensSource: shapedRequest.maxTokensSource,
+            samplingPolicyLookupStatus: shapedRequest.samplingPolicyLookupStatus,
+            samplingPolicyCanonicalModel: shapedRequest.samplingPolicyCanonicalModel,
+            samplingPolicyMatchedAlias: shapedRequest.samplingPolicyMatchedAlias,
+            samplingPolicySourceURL: shapedRequest.samplingPolicySourceURL,
+            samplingRequestOverrideApplied: shapedRequest.samplingRequestOverrideApplied,
             seed: shapedRequest.seed,
             seedSource: seedSource,
             stopSource: shapedRequest.stopSource,
@@ -58,6 +68,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
         self.topPSource = shapedRequest.topPSource
         self.maxTokens = shapedRequest.maxTokens
         self.maxTokensSource = shapedRequest.maxTokensSource
+        self.samplingPolicyLookupStatus = shapedRequest.samplingPolicyLookupStatus
+        self.samplingPolicyCanonicalModel = shapedRequest.samplingPolicyCanonicalModel
+        self.samplingPolicyMatchedAlias = shapedRequest.samplingPolicyMatchedAlias
+        self.samplingPolicySourceURL = shapedRequest.samplingPolicySourceURL
+        self.samplingRequestOverrideApplied = shapedRequest.samplingRequestOverrideApplied
         self.seed = shapedRequest.seed
         self.seedSource = seedSource
         self.stopSource = shapedRequest.stopSource
@@ -83,6 +98,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
             "melix.effective_policy.sampling.temperature_source": temperatureSource,
             "melix.effective_policy.sampling.top_p_source": topPSource,
             "melix.effective_policy.sampling.max_tokens_source": maxTokensSource,
+            "melix.effective_policy.sampling.policy_lookup_status": samplingPolicyLookupStatus,
+            "melix.effective_policy.sampling.policy_canonical_model": samplingPolicyCanonicalModel,
+            "melix.effective_policy.sampling.policy_matched_alias": samplingPolicyMatchedAlias,
+            "melix.effective_policy.sampling.policy_source_url": samplingPolicySourceURL,
+            "melix.effective_policy.sampling.request_override_applied": samplingRequestOverrideApplied ? "true" : "false",
             "melix.effective_policy.sampling.seed_source": seedSource,
             "melix.effective_policy.chat_template.source": chatTemplateSource,
             "melix.effective_policy.chat_template.request_override_applied": chatTemplateRequestOverrideApplied ? "true" : "false",
@@ -102,6 +122,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
         let topPSource: String
         let maxTokens: UInt32
         let maxTokensSource: String
+        let samplingPolicyLookupStatus: String
+        let samplingPolicyCanonicalModel: String
+        let samplingPolicyMatchedAlias: String
+        let samplingPolicySourceURL: String
+        let samplingRequestOverrideApplied: Bool
         let seed: UInt32?
         let seedSource: String
         let stopSource: String
@@ -125,6 +150,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
                 topPSource: topPSource,
                 maxTokens: maxTokens,
                 maxTokensSource: maxTokensSource,
+                samplingPolicyLookupStatus: samplingPolicyLookupStatus,
+                samplingPolicyCanonicalModel: samplingPolicyCanonicalModel,
+                samplingPolicyMatchedAlias: samplingPolicyMatchedAlias,
+                samplingPolicySourceURL: samplingPolicySourceURL,
+                samplingRequestOverrideApplied: samplingRequestOverrideApplied,
                 seed: seed,
                 seedSource: seedSource,
                 stopSource: stopSource,
@@ -157,6 +187,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
         case topPSource = "top_p_source"
         case maxTokens = "max_tokens"
         case maxTokensSource = "max_tokens_source"
+        case policyLookupStatus = "policy_lookup_status"
+        case policyCanonicalModel = "policy_canonical_model"
+        case policyMatchedAlias = "policy_matched_alias"
+        case policySourceURL = "policy_source_url"
+        case requestOverrideApplied = "request_override_applied"
         case seed
         case seedSource = "seed_source"
         case stopSource = "stop_source"
@@ -187,6 +222,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
             topPSource: topPSource,
             maxTokens: maxTokens,
             maxTokensSource: maxTokensSource,
+            samplingPolicyLookupStatus: samplingPolicyLookupStatus,
+            samplingPolicyCanonicalModel: samplingPolicyCanonicalModel,
+            samplingPolicyMatchedAlias: samplingPolicyMatchedAlias,
+            samplingPolicySourceURL: samplingPolicySourceURL,
+            samplingRequestOverrideApplied: samplingRequestOverrideApplied,
             seed: seed,
             seedSource: seedSource,
             stopSource: stopSource,
@@ -213,6 +253,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
         topPSource: String,
         maxTokens: UInt32,
         maxTokensSource: String,
+        samplingPolicyLookupStatus: String,
+        samplingPolicyCanonicalModel: String,
+        samplingPolicyMatchedAlias: String,
+        samplingPolicySourceURL: String,
+        samplingRequestOverrideApplied: Bool,
         seed: UInt32?,
         seedSource: String,
         stopSource: String,
@@ -237,6 +282,11 @@ public struct TextEffectivePolicyReceipt: Sendable, Equatable, Encodable {
         try samplingContainer.encode(topPSource, forKey: .topPSource)
         try samplingContainer.encode(Int(maxTokens), forKey: .maxTokens)
         try samplingContainer.encode(maxTokensSource, forKey: .maxTokensSource)
+        try samplingContainer.encode(samplingPolicyLookupStatus, forKey: .policyLookupStatus)
+        try samplingContainer.encode(samplingPolicyCanonicalModel, forKey: .policyCanonicalModel)
+        try samplingContainer.encode(samplingPolicyMatchedAlias, forKey: .policyMatchedAlias)
+        try samplingContainer.encode(samplingPolicySourceURL, forKey: .policySourceURL)
+        try samplingContainer.encode(samplingRequestOverrideApplied, forKey: .requestOverrideApplied)
         try samplingContainer.encode(seed.map { Int($0) }, forKey: .seed)
         try samplingContainer.encode(seedSource, forKey: .seedSource)
         try samplingContainer.encode(stopSource, forKey: .stopSource)

--- a/services/control-plane-swift/Sources/Requests/TextModelPolicyCatalog.swift
+++ b/services/control-plane-swift/Sources/Requests/TextModelPolicyCatalog.swift
@@ -57,16 +57,29 @@ public struct TextModelPolicyCatalog: Sendable, Equatable {
 
     public init(entries: [Entry]) {
         var indexed: [String: LookupResult] = [:]
-        for entry in entries where !entry.canonicalModelID.isEmpty && !entry.sampling.isEmpty {
-            let identities = [entry.canonicalModelID] + entry.aliases
-            for identity in identities {
+        let validEntries = entries.filter { !$0.canonicalModelID.isEmpty && !$0.sampling.isEmpty }
+
+        for entry in validEntries {
+            let result = LookupResult(
+                canonicalModelID: entry.canonicalModelID,
+                matchedAlias: entry.canonicalModelID,
+                sampling: entry.sampling,
+                sourceURL: entry.sourceURL
+            )
+            for key in Self.identityKeys(for: entry.canonicalModelID) where indexed[key] == nil {
+                indexed[key] = result
+            }
+        }
+
+        for entry in validEntries {
+            for alias in entry.aliases {
                 let result = LookupResult(
                     canonicalModelID: entry.canonicalModelID,
-                    matchedAlias: identity,
+                    matchedAlias: alias,
                     sampling: entry.sampling,
                     sourceURL: entry.sourceURL
                 )
-                for key in Self.identityKeys(for: identity) where indexed[key] == nil {
+                for key in Self.identityKeys(for: alias) where indexed[key] == nil {
                     indexed[key] = result
                 }
             }

--- a/services/control-plane-swift/Sources/Requests/TextModelPolicyCatalog.swift
+++ b/services/control-plane-swift/Sources/Requests/TextModelPolicyCatalog.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public struct TextModelSamplingRecommendation: Sendable, Equatable {
+    public let temperature: Double?
+    public let topP: Double?
+    public let maxTokens: UInt32?
+
+    public init(
+        temperature: Double? = nil,
+        topP: Double? = nil,
+        maxTokens: UInt32? = nil
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+    }
+
+    public var isEmpty: Bool {
+        temperature == nil && topP == nil && maxTokens == nil
+    }
+}
+
+public struct TextModelPolicyCatalog: Sendable, Equatable {
+    public struct Entry: Sendable, Equatable {
+        public let canonicalModelID: String
+        public let aliases: [String]
+        public let sampling: TextModelSamplingRecommendation
+        public let sourceURL: String
+
+        public init(
+            canonicalModelID: String,
+            aliases: [String] = [],
+            sampling: TextModelSamplingRecommendation,
+            sourceURL: String
+        ) {
+            self.canonicalModelID = canonicalModelID.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.aliases = aliases.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            self.sampling = sampling
+            self.sourceURL = sourceURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    public struct LookupResult: Sendable, Equatable {
+        public let canonicalModelID: String
+        public let matchedAlias: String
+        public let sampling: TextModelSamplingRecommendation
+        public let sourceURL: String
+    }
+
+    public static let empty = TextModelPolicyCatalog(entries: [])
+
+    // Start empty until production entries have source-verified recommendations.
+    public static let `default` = TextModelPolicyCatalog(entries: [])
+
+    private let entriesByIdentity: [String: LookupResult]
+
+    public init(entries: [Entry]) {
+        var indexed: [String: LookupResult] = [:]
+        for entry in entries where !entry.canonicalModelID.isEmpty && !entry.sampling.isEmpty {
+            let identities = [entry.canonicalModelID] + entry.aliases
+            for identity in identities {
+                let result = LookupResult(
+                    canonicalModelID: entry.canonicalModelID,
+                    matchedAlias: identity,
+                    sampling: entry.sampling,
+                    sourceURL: entry.sourceURL
+                )
+                for key in Self.identityKeys(for: identity) where indexed[key] == nil {
+                    indexed[key] = result
+                }
+            }
+        }
+        self.entriesByIdentity = indexed
+    }
+
+    public func lookup(identities: [String]) -> LookupResult? {
+        for identity in identities {
+            for key in Self.identityKeys(for: identity) {
+                if let result = entriesByIdentity[key] {
+                    return result
+                }
+            }
+        }
+        return nil
+    }
+
+    public static func identityKeys(for rawValue: String) -> [String] {
+        let normalized = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\", with: "/")
+            .lowercased()
+        guard !normalized.isEmpty else {
+            return []
+        }
+
+        var keys: [String] = []
+        func appendUnique(_ key: String) {
+            guard !key.isEmpty, !keys.contains(key) else {
+                return
+            }
+            keys.append(key)
+        }
+
+        appendUnique(normalized)
+
+        if let lastComponent = normalized.split(separator: "/").last {
+            appendUnique(String(lastComponent))
+        }
+        if let handlePrefix = normalized.split(separator: "::").first {
+            appendUnique(String(handlePrefix))
+        }
+
+        return keys
+    }
+}

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -79,21 +79,64 @@ public struct ModelSamplingPolicy: Sendable, Equatable {
     public let temperature: Double?
     public let topP: Double?
     public let maxTokens: UInt32?
+    public let lookupStatus: String
+    public let canonicalModelID: String
+    public let matchedAlias: String
+    public let sourceURL: String
 
     public init?(
         modelSettings: Melix_Controlplane_V1_ModelSettings
     ) {
+        self.init(
+            modelID: "",
+            modelSettings: modelSettings,
+            catalog: .empty
+        )
+    }
+
+    public init?(
+        modelID: String,
+        modelSettings: Melix_Controlplane_V1_ModelSettings,
+        catalog: TextModelPolicyCatalog = .default
+    ) {
         let temperature = Self.parseDouble(modelSettings.ext["melix.generation_config.temperature"])
         let topP = Self.parseDouble(modelSettings.ext["melix.generation_config.top_p"])
         let maxTokens = Self.parseUInt32(modelSettings.ext["melix.generation_config.max_tokens"])
+        let catalogLookup = catalog.lookup(
+            identities: Self.identityCandidates(
+                modelID: modelID,
+                modelSettings: modelSettings
+            )
+        )
+        let resolvedTemperature = temperature ?? catalogLookup?.sampling.temperature
+        let resolvedTopP = topP ?? catalogLookup?.sampling.topP
+        let resolvedMaxTokens = maxTokens ?? catalogLookup?.sampling.maxTokens
 
-        guard temperature != nil || topP != nil || maxTokens != nil else {
+        guard resolvedTemperature != nil || resolvedTopP != nil || resolvedMaxTokens != nil else {
             return nil
         }
 
-        self.temperature = temperature
-        self.topP = topP
-        self.maxTokens = maxTokens
+        self.temperature = resolvedTemperature
+        self.topP = resolvedTopP
+        self.maxTokens = resolvedMaxTokens
+        self.lookupStatus = "known"
+        self.canonicalModelID = catalogLookup?.canonicalModelID
+            ?? Self.firstNonEmpty([
+                modelID,
+                modelSettings.ext["melix.hf_repo_id"],
+                modelSettings.ext["melix.source_repo"],
+                modelSettings.alias,
+            ])
+        self.matchedAlias = catalogLookup?.matchedAlias
+            ?? Self.firstNonEmpty([
+                modelID,
+                modelSettings.alias,
+                modelSettings.ext["melix.model_path"],
+                modelSettings.ext["melix.hf_repo_id"],
+                modelSettings.ext["melix.source_repo"],
+            ])
+        self.sourceURL = catalogLookup?.sourceURL
+            ?? Self.modelSettingsSourceURL(modelSettings)
     }
 
     private static func parseDouble(_ rawValue: String?) -> Double? {
@@ -108,6 +151,38 @@ public struct ModelSamplingPolicy: Sendable, Equatable {
             return nil
         }
         return UInt32(rawValue)
+    }
+
+    private static func identityCandidates(
+        modelID: String,
+        modelSettings: Melix_Controlplane_V1_ModelSettings
+    ) -> [String] {
+        [
+            modelID,
+            modelSettings.alias,
+            modelSettings.ext["melix.model_path"],
+            modelSettings.ext["melix.hf_repo_id"],
+            modelSettings.ext["melix.source_repo"],
+            modelSettings.ext["melix.source_model_id"],
+        ].compactMap { $0?.nilIfEmpty }
+    }
+
+    private static func firstNonEmpty(_ values: [String?]) -> String {
+        values.compactMap { $0?.nilIfEmpty }.first ?? ""
+    }
+
+    private static func modelSettingsSourceURL(
+        _ modelSettings: Melix_Controlplane_V1_ModelSettings
+    ) -> String {
+        if let source = modelSettings.ext["melix.generation_config.source"]?.nilIfEmpty {
+            return source
+        }
+        if let repoID = modelSettings.ext["melix.hf_repo_id"]?.nilIfEmpty
+            ?? modelSettings.ext["melix.source_repo"]?.nilIfEmpty,
+           repoID.contains("/") {
+            return "https://huggingface.co/\(repoID)"
+        }
+        return ""
     }
 }
 
@@ -293,6 +368,13 @@ public struct TextRequestShaper: Sendable {
             presetMaxTokens: preset?.maxTokens,
             fallbackMaxTokens: fallbackMaxTokens
         )
+        let samplingRequestOverrideApplied = request.temperature != nil
+            || request.topP != nil
+            || request.maxTokens != nil
+            || request.maxCompletionTokens != nil
+        let samplingPolicyLookupStatus = samplingRequestOverrideApplied
+            ? "operator_override"
+            : (modelSamplingPolicy?.lookupStatus ?? "unknown")
         let maxTokens = outputCap.value
         let streamIntervalTokens = gatewayServingDefaults?.streamIntervalTokens ?? 1
         let maxConcurrentRequests = gatewayServingDefaults?.maxConcurrentRequests ?? 4
@@ -361,6 +443,11 @@ public struct TextRequestShaper: Sendable {
             topPSource: topP.source,
             maxTokens: maxTokens,
             maxTokensSource: outputCap.policySource,
+            samplingPolicyLookupStatus: samplingPolicyLookupStatus,
+            samplingPolicyCanonicalModel: modelSamplingPolicy?.canonicalModelID ?? "",
+            samplingPolicyMatchedAlias: modelSamplingPolicy?.matchedAlias ?? "",
+            samplingPolicySourceURL: modelSamplingPolicy?.sourceURL ?? "",
+            samplingRequestOverrideApplied: samplingRequestOverrideApplied,
             requestedMaxTokens: request.maxTokens,
             requestedMaxCompletionTokens: request.maxCompletionTokens,
             outputCapSource: outputCap.source,

--- a/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
+++ b/services/control-plane-swift/Sources/Requests/TextRequestShaper.swift
@@ -119,7 +119,7 @@ public struct ModelSamplingPolicy: Sendable, Equatable {
         self.temperature = resolvedTemperature
         self.topP = resolvedTopP
         self.maxTokens = resolvedMaxTokens
-        self.lookupStatus = "known"
+        self.lookupStatus = catalogLookup == nil ? "unknown" : "known"
         self.canonicalModelID = catalogLookup?.canonicalModelID
             ?? Self.firstNonEmpty([
                 modelID,

--- a/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
+++ b/services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift
@@ -412,7 +412,10 @@ public actor ControlPlaneService {
             nil
         }
         let modelSamplingPolicy: ModelSamplingPolicy? = if let resolvedModel {
-            ModelSamplingPolicy(modelSettings: resolvedModel.settings)
+            ModelSamplingPolicy(
+                modelID: resolvedModel.modelID,
+                modelSettings: resolvedModel.settings
+            )
         } else {
             nil
         }

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -298,6 +298,22 @@ struct TextEndpointContractTests {
         return try #require(receipts.first)
     }
 
+    private static func effectivePolicyReceipt(
+        from request: Melix_Worker_V1_GenerateRequest
+    ) throws -> [String: Any] {
+        let receiptJSON = try #require(request.execution.ext["melix.effective_policy.receipt_json"])
+        return try #require(
+            try JSONSerialization.jsonObject(with: Data(receiptJSON.utf8)) as? [String: Any]
+        )
+    }
+
+    private static func effectivePolicySampling(
+        from request: Melix_Worker_V1_GenerateRequest
+    ) throws -> [String: Any] {
+        let receipt = try effectivePolicyReceipt(from: request)
+        return try #require(receipt["sampling"] as? [String: Any])
+    }
+
     @Test("stream options encode include_usage across public contracts")
     func streamOptionsEncodeIncludeUsageAcrossPublicContracts() throws {
         let encoder = JSONEncoder()
@@ -2945,6 +2961,102 @@ struct TextEndpointContractTests {
         #expect(reasoning["effort"] as? String == "medium")
     }
 
+    @Test("chat translation uses catalog sampling policy for aliased model identity")
+    func chatTranslationUsesCatalogSamplingPolicyForAliasedModelIdentity() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-policy-catalog" })
+        let sourceURL = "https://github.com/Keith-CY/melix/blob/main/docs/plans/2026-07-11-issue-1385-model-policy-catalog.md"
+        let catalog = TextModelPolicyCatalog(entries: [
+            .init(
+                canonicalModelID: "melix-dev-policy",
+                aliases: ["melix-dev-policy-q4.gguf"],
+                sampling: .init(temperature: 0.42, topP: 0.91, maxTokens: 1_024),
+                sourceURL: sourceURL
+            ),
+        ])
+        var modelSettings = Melix_Controlplane_V1_ModelSettings()
+        modelSettings.alias = "Melix Dev Policy Q4"
+        modelSettings.ext["melix.model_path"] = "/models/melix-dev-policy-q4.gguf"
+        let modelSamplingPolicy = try #require(
+            ModelSamplingPolicy(
+                modelID: "/models/melix-dev-policy-q4.gguf",
+                modelSettings: modelSettings,
+                catalog: catalog
+            )
+        )
+
+        let normalized = try translator.normalize(
+            OpenAIChatCompletionsRequest(
+                model: "/models/melix-dev-policy-q4.gguf",
+                messages: [.init(role: "user", content: "Use the catalog policy.")]
+            )
+        )
+        let translated = try translator.translate(
+            normalized,
+            modelHandle: "worker-text",
+            modelSamplingPolicy: modelSamplingPolicy
+        )
+        let ext = translated.workerRequest.execution.ext
+        let sampling = try Self.effectivePolicySampling(from: translated.workerRequest)
+
+        #expect(translated.workerRequest.sampling.temperature == 0.42)
+        #expect(translated.workerRequest.sampling.topP == 0.91)
+        #expect(translated.workerRequest.sampling.maxOutputTokens == 1_024)
+        #expect(ext["melix.effective_policy.sampling.policy_lookup_status"] == "known")
+        #expect(ext["melix.effective_policy.sampling.policy_canonical_model"] == "melix-dev-policy")
+        #expect(ext["melix.effective_policy.sampling.policy_matched_alias"] == "melix-dev-policy-q4.gguf")
+        #expect(ext["melix.effective_policy.sampling.policy_source_url"] == sourceURL)
+        #expect(ext["melix.effective_policy.sampling.request_override_applied"] == "false")
+        #expect(sampling["policy_lookup_status"] as? String == "known")
+        #expect(sampling["policy_canonical_model"] as? String == "melix-dev-policy")
+        #expect(sampling["policy_matched_alias"] as? String == "melix-dev-policy-q4.gguf")
+        #expect(sampling["policy_source_url"] as? String == sourceURL)
+        #expect(sampling["request_override_applied"] as? Bool == false)
+    }
+
+    @Test("chat translation records operator override while retaining catalog fallback fields")
+    func chatTranslationRecordsOperatorOverrideWhileRetainingCatalogFallbackFields() throws {
+        let translator = ChatRequestTranslator(requestIDGenerator: { "req-policy-override" })
+        let catalog = TextModelPolicyCatalog(entries: [
+            .init(
+                canonicalModelID: "melix-dev-policy",
+                aliases: ["melix-dev-policy-q4.gguf"],
+                sampling: .init(temperature: 0.42, topP: 0.91, maxTokens: 1_024),
+                sourceURL: "https://github.com/Keith-CY/melix/blob/main/docs/plans/2026-07-11-issue-1385-model-policy-catalog.md"
+            ),
+        ])
+        let modelSamplingPolicy = try #require(
+            ModelSamplingPolicy(
+                modelID: "melix-dev-policy-q4.gguf",
+                modelSettings: .init(),
+                catalog: catalog
+            )
+        )
+
+        let normalized = try translator.normalize(
+            OpenAIChatCompletionsRequest(
+                model: "melix-dev-policy-q4.gguf",
+                messages: [.init(role: "user", content: "Use one request override.")],
+                temperature: 0.64
+            )
+        )
+        let translated = try translator.translate(
+            normalized,
+            modelHandle: "worker-text",
+            modelSamplingPolicy: modelSamplingPolicy
+        )
+        let sampling = try Self.effectivePolicySampling(from: translated.workerRequest)
+
+        #expect(translated.workerRequest.sampling.temperature == 0.64)
+        #expect(translated.workerRequest.sampling.topP == 0.91)
+        #expect(translated.workerRequest.sampling.maxOutputTokens == 1_024)
+        #expect(translated.workerRequest.execution.ext["melix.effective_policy.sampling.temperature_source"] == "request")
+        #expect(translated.workerRequest.execution.ext["melix.effective_policy.sampling.top_p_source"] == "model")
+        #expect(translated.workerRequest.execution.ext["melix.effective_policy.sampling.policy_lookup_status"] == "operator_override")
+        #expect(translated.workerRequest.execution.ext["melix.effective_policy.sampling.request_override_applied"] == "true")
+        #expect(sampling["policy_lookup_status"] as? String == "operator_override")
+        #expect(sampling["request_override_applied"] as? Bool == true)
+    }
+
     @Test("chat translation wrapper falls back to gateway serving defaults when no model policy exists")
     func chatTranslationWrapperFallsBackToGatewayServingDefaults() throws {
         let translator = ChatRequestTranslator(requestIDGenerator: { "req-chat-serving-defaults" })
@@ -2977,6 +3089,11 @@ struct TextEndpointContractTests {
         #expect(translated.workerRequest.sampling.temperature == 0.35)
         #expect(translated.workerRequest.sampling.topP == 0.92)
         #expect(translated.workerRequest.sampling.maxOutputTokens == 384)
+        let sampling = try Self.effectivePolicySampling(from: translated.workerRequest)
+        #expect(sampling["policy_lookup_status"] as? String == "unknown")
+        #expect(sampling["request_override_applied"] as? Bool == false)
+        #expect(translated.workerRequest.execution.ext["melix.effective_policy.sampling.policy_lookup_status"] == "unknown")
+        #expect(translated.workerRequest.execution.ext["melix.effective_policy.sampling.request_override_applied"] == "false")
         #expect(translated.workerRequest.execution.ext["melix.stream.interval_tokens"] == "3")
         #expect(translated.workerRequest.execution.ext["melix.gateway.max_concurrent_requests"] == "5")
         #expect(translated.workerRequest.execution.ext["melix.gateway.concurrent_processing"] == "true")

--- a/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
@@ -2888,6 +2888,8 @@ struct TextEndpointContractTests {
         #expect(translated.workerRequest.sampling.temperature == 0.2)
         #expect(translated.workerRequest.sampling.topP == 0.88)
         #expect(translated.workerRequest.sampling.maxOutputTokens == 512)
+        let sampling = try Self.effectivePolicySampling(from: translated.workerRequest)
+        #expect(sampling["policy_lookup_status"] as? String == "unknown")
     }
 
     @Test("chat translation emits effective policy receipt for merged sampling template and reasoning policy")
@@ -3011,6 +3013,32 @@ struct TextEndpointContractTests {
         #expect(sampling["policy_matched_alias"] as? String == "melix-dev-policy-q4.gguf")
         #expect(sampling["policy_source_url"] as? String == sourceURL)
         #expect(sampling["request_override_applied"] as? Bool == false)
+    }
+
+    @Test("text model policy catalog prefers canonical identities over earlier aliases")
+    func textModelPolicyCatalogPrefersCanonicalIdentitiesOverEarlierAliases() throws {
+        let catalog = TextModelPolicyCatalog(entries: [
+            .init(
+                canonicalModelID: "legacy-policy",
+                aliases: ["canonical-policy"],
+                sampling: .init(temperature: 0.11),
+                sourceURL: "https://example.invalid/legacy"
+            ),
+            .init(
+                canonicalModelID: "canonical-policy",
+                aliases: [],
+                sampling: .init(temperature: 0.72, topP: 0.93),
+                sourceURL: "https://example.invalid/canonical"
+            ),
+        ])
+
+        let result = try #require(catalog.lookup(identities: ["canonical-policy"]))
+
+        #expect(result.canonicalModelID == "canonical-policy")
+        #expect(result.matchedAlias == "canonical-policy")
+        #expect(result.sampling.temperature == 0.72)
+        #expect(result.sampling.topP == 0.93)
+        #expect(result.sourceURL == "https://example.invalid/canonical")
     }
 
     @Test("chat translation records operator override while retaining catalog fallback fields")


### PR DESCRIPTION
## Summary
- Add a shared text model sampling policy catalog with alias/path normalization and catalog-aware request shaping.
- Extend effective policy receipts with sampling policy provenance: lookup status, canonical model, matched alias, source URL, and request override state.
- Wire catalog-aware shaping through OpenAI gateway, XPC service, and gateway serving defaults.
- Address review feedback by making catalog canonical identities take precedence over aliases and by treating `policy_lookup_status` as catalog lookup provenance.

## Plan or Spec
- Governing issue: Refs #1385.
- Plan: `docs/plans/2026-07-11-issue-1385-model-policy-catalog.md`.

## Commands Run
```text
xcrun swift test --package-path services/control-plane-swift --filter 'TextEndpointContractTests/textModelPolicyCatalogPrefersCanonicalIdentitiesOverEarlierAliases|TextEndpointContractTests/chatTranslationWrapperFallsBackToImportedGenerationConfigDefaults'
# Red before review fix: 2 tests failed as expected.
# Green after review fix: 2 tests passed.

xcrun swift test --package-path services/control-plane-swift --filter ControlPlaneTests.TextEndpointContractTests
# Passed after review fix: 76 tests in 1 suite.

xcrun swift test --package-path services/control-plane-swift --filter 'ControlPlaneTests.TextEndpointContractTests|ControlPlaneTests.GatewayServingDefaultsStoreTests|HTTPGatewayTests.OpenAIHandlerTests|ControlPlaneTests.ControlPlaneServiceTests|ControlPlaneTests.ControlPlaneChatExecutionTests'
# Passed after review fix: 551 tests in 5 suites.

xcrun swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'ControlPlaneTests.TextEndpointContractTests|ControlPlaneTests.GatewayServingDefaultsStoreTests|HTTPGatewayTests.OpenAIHandlerTests|ControlPlaneTests.ControlPlaneServiceTests|ControlPlaneTests.ControlPlaneChatExecutionTests' > .runtime/issue-1385-coverage-swift-test-review-fix.log 2>&1
# Passed after review fix: 551 tests in 5 suites.

uv run --python 3.12 python scripts/swift_changed_line_coverage.py --diff-from origin/main --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/Requests/TextModelPolicyCatalog.swift services/control-plane-swift/Sources/Requests/TextRequestShaper.swift services/control-plane-swift/Sources/Requests/TextEffectivePolicyReceipt.swift services/control-plane-swift/Sources/Requests/ChatRequestTranslator.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIHandler.swift services/control-plane-swift/Sources/XPCService/ControlPlaneService.swift services/control-plane-swift/Sources/HTTPGateway/OpenAI/GatewayServingDefaultsStore.swift services/control-plane-swift/Tests/ControlPlaneTests/TextEndpointContractTests.swift
# Passed after review fix: TOTAL 99.10% (329/332).

git diff --check
# Passed.

uv run --python 3.12 python scripts/pr_scoped_performance_scope.py --registry infra/perf/pr_scoped_probes.json --changed-files-json .runtime/issue-1385-changed-files-review-fix.json --output .runtime/issue-1385-pr-scope-review-fix.json
# Passed: selected_count 0.

uv run --python 3.12 python scripts/pr_scoped_performance_report.py --scope .runtime/issue-1385-pr-scope-review-fix.json --results-dir .runtime/issue-1385-pr-results-review-fix --format terminal --output-dir .runtime/issue-1385-pr-report-review-fix
# Passed: status ok, 0 regressions.

git commit -m "Add text model policy catalog receipts"
# Pre-commit passed before origin/main merge:
# - make swift-test: passed, elapsed 691.5s.
# - make py-test: 4898 passed, 14 skipped, 2 warnings, elapsed 177.9s.
# - make integration-test: 123 passed, 1 skipped, elapsed 807.0s.
# - pre-commit scoped performance: status ok, 0 regressions.

git commit -m "Address policy catalog review feedback"
# Pre-commit passed:
# - make swift-test: passed, elapsed 309.8s.
# - make py-test: 4898 passed, 14 skipped, 2 warnings, elapsed 180.8s.
# - make integration-test: 123 passed, 1 skipped, elapsed 511.8s.
# - pre-commit scoped performance: status ok, changed files 4, selected probes 0, regressions 0.
```

## Coverage and Metrics
- Changed-line coverage: 99.10% (329/332) for the Swift request-shaping/catalog/receipt scope after review fix.
- PR-scoped performance report: status `ok`, changed files 9, selected probes 0, regressions 0, context regressions 0, verification failures 0.
- Review-fix scoped performance report: status `ok`, changed files 4, selected probes 0, regressions 0, context regressions 0, verification failures 0.
- Report artifacts: `.runtime/issue-1385-pr-report-review-fix/report.md` and `.runtime/pre-commit-performance/20260710-231837-0a49f67d/report/report.md`.
- Observability mode: `minimal` receipt metadata only; no runtime counters, sampled probes, evidence-mode probes, or debug artifacts were added.
- Probe overhead: N/A because no registered performance probe was selected and no new probe was added.

## Known Gaps
- The repository default catalog intentionally starts empty until production entries have source-verified recommendations.
- Strict unknown-model rejection, public opt-in API wiring, benchmark/evaluation propagation, and CLI/desktop inspection remain deferred #1385 slices.
- `make bootstrap` and `make proto` were not rerun because this change does not modify dependencies, protobuf schemas, or generated artifacts; the installed pre-commit hook ran the full local test gate before each feature/review-fix commit.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A because no protocol schemas changed.
- [x] Dependency changes include updated lockfiles, or N/A because dependencies did not change.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
