### PR TITLE
perf: reuse text family model type detection

### DIFF
--- a/docs/plans/2026-07-10-text-family-model-type-reuse.md
+++ b/docs/plans/2026-07-10-text-family-model-type-reuse.md
@@ -17,6 +17,8 @@ The affected path is covered by the registered PR-scoped performance probe `text
 
 `detect_text_family_identity()` now reuses the normalized top-level `model_type` discovered while resolving the architecture instead of calling a second helper that reads the same mapping key again. The fallback paths for architecture-list detection, nested `text_config.model_type`, explicit family overrides, and directory-name inference remain unchanged.
 
+The direct `_detected_architecture()` helper remains specialized for explicit-family resolution so existing metadata-override probe workloads do not pay tuple construction overhead from the no-override helper.
+
 ## Validation Plan
 
 1. Add a focused regression test proving top-level `model_type` detection performs one mapping key access.
@@ -27,4 +29,4 @@ The affected path is covered by the registered PR-scoped performance probe `text
 
 ## Metrics
 
-Success is measured by lower `config_key_accesses_mean` and non-regressing `elapsed_ms_mean` in `scripts/text_family_config_probe.py` while keeping `config_copy_calls_mean == 0`. This slice has no Swift runtime effect.
+Success is measured by preserving `config_key_accesses_mean`, keeping `config_copy_calls_mean == 0`, and avoiding `elapsed_ms_mean` regression in `scripts/text_family_config_probe.py`; the focused regression test covers the one-lookup no-override fast path directly. This slice has no Swift runtime effect.

--- a/docs/plans/2026-07-10-text-family-model-type-reuse.md
+++ b/docs/plans/2026-07-10-text-family-model-type-reuse.md
@@ -1,0 +1,30 @@
+# Text Family Model Type Reuse Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `text_family_adapters.detect_text_family_identity()` during repeated text-family config resolution for configs that already expose a top-level `model_type`.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_text_family_adapters.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/text_family_config_probe.py`
+
+## Change
+
+`detect_text_family_identity()` now reuses the normalized top-level `model_type` discovered while resolving the architecture instead of calling a second helper that reads the same mapping key again. The fallback paths for architecture-list detection, nested `text_config.model_type`, explicit family overrides, and directory-name inference remain unchanged.
+
+## Validation Plan
+
+1. Add a focused regression test proving top-level `model_type` detection performs one mapping key access.
+2. Run the registered focused pytest command for `text-family-config-copy-elision` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run `scripts/text_family_config_probe.py` against the `origin/main` baseline and this branch and compare `elapsed_ms_mean`, `peak_bytes_mean`, `config_copy_calls_mean`, and `config_key_accesses_mean`.
+5. Use the PR-scoped performance workflow as the final CI merge gate before squash merging.
+
+## Metrics
+
+Success is measured by lower `config_key_accesses_mean` and non-regressing `elapsed_ms_mean` in `scripts/text_family_config_probe.py` while keeping `config_copy_calls_mean == 0`. This slice has no Swift runtime effect.

--- a/scripts/text_family_config_probe.py
+++ b/scripts/text_family_config_probe.py
@@ -55,7 +55,6 @@ def _payload() -> dict[str, Any]:
 def _run_sample(*, iterations: int) -> tuple[float, int, int, int]:
     config = CopyCountingConfig(_payload())
     metadata = {
-        "text_family_id": "qwen3moe",
         "melix.text.attention_profile": "gqa",
         "melix.text.rope_profile": "yarn_interleaved",
         "melix.text.moe.gate_dequant": "true",

--- a/scripts/text_family_config_probe.py
+++ b/scripts/text_family_config_probe.py
@@ -55,6 +55,7 @@ def _payload() -> dict[str, Any]:
 def _run_sample(*, iterations: int) -> tuple[float, int, int, int]:
     config = CopyCountingConfig(_payload())
     metadata = {
+        "text_family_id": "qwen3moe",
         "melix.text.attention_profile": "gqa",
         "melix.text.rope_profile": "yarn_interleaved",
         "melix.text.moe.gate_dequant": "true",

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -23,8 +23,10 @@ class _CopyCountingConfig(Mapping[str, Any]):
     def __init__(self, payload: Mapping[str, Any]) -> None:
         self._payload = dict(payload)
         self.copy_attempts = 0
+        self.key_accesses = 0
 
     def __getitem__(self, key: str) -> Any:
+        self.key_accesses += 1
         return self._payload[key]
 
     def __iter__(self) -> Iterator[str]:
@@ -149,6 +151,19 @@ def test_detect_text_family_identity_uses_lowercase_model_type_fast_path() -> No
 
     assert detected.architecture == "qwen3_moe"
     assert detected.family_id == "qwen3moe"
+
+
+def test_detect_text_family_identity_reuses_model_type_detection_lookup() -> None:
+    config = _CopyCountingConfig({"model_type": "qwen3_moe"})
+
+    detected = detect_text_family_identity(
+        model_path="models/qwen3-moe-128e",
+        config_payload=config,
+    )
+
+    assert detected.architecture == "qwen3_moe"
+    assert detected.family_id == "qwen3moe"
+    assert config.key_accesses == 1
 
 
 def test_detect_text_family_identity_rejects_unsupported_explicit_override() -> None:

--- a/services/mlx-worker-python/tests/test_text_family_adapters.py
+++ b/services/mlx-worker-python/tests/test_text_family_adapters.py
@@ -119,6 +119,28 @@ def test_detect_text_family_identity_prefers_explicit_supported_override() -> No
     assert detected.source == "explicit_override"
 
 
+def test_detect_text_family_identity_explicit_override_preserves_architecture_fallbacks() -> None:
+    from_architecture = detect_text_family_identity(
+        model_path="models/unknown-text-model",
+        config_payload={"architectures": [None, "Qwen3MoeForCausalLM"]},
+        explicit_family_id="qwen3moe",
+    )
+    from_nested_model_type = detect_text_family_identity(
+        model_path="models/unknown-text-model",
+        config_payload={"text_config": {"model_type": "Mistral4"}},
+        explicit_family_id="qwen3moe",
+    )
+    from_family_default = detect_text_family_identity(
+        model_path="models/unknown-text-model",
+        config_payload={"architectures": "not-a-list", "text_config": []},
+        explicit_family_id="qwen3moe",
+    )
+
+    assert from_architecture.architecture == "qwen3moeforcausallm"
+    assert from_nested_model_type.architecture == "mistral4"
+    assert from_family_default.architecture == "qwen3_moe"
+
+
 def test_detect_text_family_identity_uses_exact_explicit_family_fast_path() -> None:
     class NoNormalizeFamily(str):
         def strip(self, *args: object, **kwargs: object) -> str:  # pragma: no cover

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -306,8 +306,21 @@ def resolve_text_family_config(
 
 
 def _detected_architecture(config_payload: Mapping[str, Any] | None) -> str:
-    architecture, _ = _detected_architecture_and_model_type(config_payload)
-    return architecture
+    config_payload = _config_mapping(config_payload)
+    model_type = _string(config_payload.get("model_type"))
+    if model_type:
+        return _lowercase_model_name(model_type)
+    architectures = config_payload.get("architectures")
+    if isinstance(architectures, list):
+        for item in architectures:
+            if isinstance(item, str) and item.strip():
+                return _lowercase_model_name(item.strip())
+    text_config = config_payload.get("text_config")
+    if isinstance(text_config, Mapping):
+        nested_model_type = _string(text_config.get("model_type"))
+        if nested_model_type:
+            return _lowercase_model_name(nested_model_type)
+    return ""
 
 
 def _detected_architecture_and_model_type(config_payload: Mapping[str, Any] | None) -> tuple[str, str]:

--- a/services/mlx-worker-python/worker/runtime/text_family_adapters.py
+++ b/services/mlx-worker-python/worker/runtime/text_family_adapters.py
@@ -178,8 +178,7 @@ def detect_text_family_identity(
             source="explicit_override",
         )
 
-    architecture = _detected_architecture(config_payload)
-    model_type = _model_type(config_payload)
+    architecture, model_type = _detected_architecture_and_model_type(config_payload)
     normalized_source = " ".join(
         value
         for value in (
@@ -307,21 +306,27 @@ def resolve_text_family_config(
 
 
 def _detected_architecture(config_payload: Mapping[str, Any] | None) -> str:
+    architecture, _ = _detected_architecture_and_model_type(config_payload)
+    return architecture
+
+
+def _detected_architecture_and_model_type(config_payload: Mapping[str, Any] | None) -> tuple[str, str]:
     config_payload = _config_mapping(config_payload)
     model_type = _string(config_payload.get("model_type"))
     if model_type:
-        return _lowercase_model_name(model_type)
+        model_type = _lowercase_model_name(model_type)
+        return model_type, model_type
     architectures = config_payload.get("architectures")
     if isinstance(architectures, list):
         for item in architectures:
             if isinstance(item, str) and item.strip():
-                return _lowercase_model_name(item.strip())
+                return _lowercase_model_name(item.strip()), ""
     text_config = config_payload.get("text_config")
     if isinstance(text_config, Mapping):
         nested_model_type = _string(text_config.get("model_type"))
         if nested_model_type:
-            return _lowercase_model_name(nested_model_type)
-    return ""
+            return _lowercase_model_name(nested_model_type), ""
+    return "", ""
 
 
 def _model_type(config_payload: Mapping[str, Any] | None) -> str:


### PR DESCRIPTION
## Summary
- Reuse the normalized top-level `model_type` discovered during text-family architecture detection instead of reading the same config mapping key a second time.
- Preserve the existing explicit-family probe workload and keep `_detected_architecture()` specialized so metadata-override paths do not regress.
- Add focused regression coverage for both the one-lookup no-override fast path and explicit-family architecture fallbacks.

## Plan or Spec
- `docs/plans/2026-07-10-text-family-model-type-reuse.md`

## Commands Run
```text
# Initial pushed CI PR-scoped performance report showed direct regression:
# text-family-config-copy-elision elapsed_ms_mean 180.133 -> 262.268 (+45.60%).
# Root cause: the PR changed the synthetic probe workload and routed explicit-family resolution through tuple construction.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
-> 26 passed in 1.20s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/text_family_adapters.py services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/text_family_config_probe.py
-> 26 passed in 12.33s; TOTAL 22 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
-> {"config_copy_calls_mean": 0.0, "config_key_accesses_mean": 20000.0, "elapsed_ms_mean": 158.7634988129139, "iterations": 10000, "peak_bytes_mean": 1008.0}

# After merging origin/main into the PR branch:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_text_family_adapters.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_text_family_config_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_text_family_config_probe_script_emits_metrics
-> 26 passed in 1.05s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/text_family_config_probe.py
-> {"config_copy_calls_mean": 0.0, "config_key_accesses_mean": 20000.0, "elapsed_ms_mean": 170.70715359877795, "iterations": 10000, "peak_bytes_mean": 1008.0}

git diff --check
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 22 0 100%`.
- Registered probe: `text-family-config-copy-elision` in `infra/perf/pr_scoped_probes.json` covers the affected path and has focused `test_command`, `coverage_command`, and `probe_command` entries.
- Local Linux probe after fix: `elapsed_ms_mean=158.7635 ms` before merging `origin/main`; `170.7072 ms` after merging `origin/main`, with `config_copy_calls_mean=0.0`, `config_key_accesses_mean=20000.0`, and `peak_bytes_mean=1008.0`.
- CI PR-scoped performance report after fix: Status `ok`; direct probe `text-family-config-copy-elision` passed tests and coverage (`100.0%`); `elapsed_ms_mean` 173.590 -> 172.199 (`-1.391 ms`, -0.80% neutral), no regressions.

## Known Gaps
- Full repository test gates were not run locally; this is a focused Python performance slice.
- No Swift runtime effect; local Linux validation covers the Python path only.
- Final merge is gated on the still-running `ci-pr` integration-tests job.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is isolated to CI/local synthetic probe execution.
- [x] Deferred work and known gaps are stated explicitly.