### PR TITLE
perf: append export manifest file row errors directly

### DIFF
--- a/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
+++ b/docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md
@@ -224,10 +224,17 @@ already read for protobuf JSON parsing instead of issuing a second filesystem
 stat call on every validation. Its metrics pass should accumulate generated,
 required, and evidence byte totals while iterating each manifest file section
 once instead of materializing a combined file-row tuple solely to count evidence
-bytes. Repeated validation policy gates should also reuse module-level enum
-membership constants for derived-model activation modes, runtime-binary-required
-target types, load-check-required target types, and the GGUF runtime-unavailable
-waiver instead of constructing short-lived sets on every manifest validation.
+bytes. The 2026-07 file-row append slice keeps generated, required, and
+intermediate file-row validation semantics unchanged while appending directly
+into the manifest-level error accumulator instead of allocating three short-lived
+per-section error lists and extending them back into the same accumulator. The
+affected path remains covered by the registered PR-scoped performance probe
+`runtime-export-manifest-validation`, including focused `test_command`,
+`coverage_command`, and `probe_command` entries. Repeated validation policy gates
+should also reuse module-level enum membership constants for derived-model
+activation modes, runtime-binary-required target types, load-check-required
+target types, and the GGUF runtime-unavailable waiver instead of constructing
+short-lived sets on every manifest validation.
 
 ### Export Plan Receipt
 

--- a/services/mlx-worker-python/worker/productization/export_target_manifest.py
+++ b/services/mlx-worker-python/worker/productization/export_target_manifest.py
@@ -198,18 +198,23 @@ def _validate_manifest(manifest: export_target_manifest_pb2.ExportTargetManifest
         errors.append("activation_mode must be specified")
 
     seen_file_paths: set[str] = set()
-    errors.extend(
-        _validate_file_rows("generated_files", manifest.generated_files, seen_file_paths)
+    _append_file_row_errors(
+        errors,
+        "generated_files",
+        manifest.generated_files,
+        seen_file_paths,
     )
-    errors.extend(
-        _validate_file_rows("required_files", manifest.required_files, seen_file_paths)
+    _append_file_row_errors(
+        errors,
+        "required_files",
+        manifest.required_files,
+        seen_file_paths,
     )
-    errors.extend(
-        _validate_file_rows(
-            "intermediate_files",
-            manifest.intermediate_files,
-            seen_file_paths,
-        )
+    _append_file_row_errors(
+        errors,
+        "intermediate_files",
+        manifest.intermediate_files,
+        seen_file_paths,
     )
     if not manifest.generated_files:
         errors.append("generated_files must not be empty")
@@ -225,12 +230,12 @@ def _validate_manifest(manifest: export_target_manifest_pb2.ExportTargetManifest
     return errors
 
 
-def _validate_file_rows(
+def _append_file_row_errors(
+    errors: list[str],
     field_name: str,
     rows: list[export_target_manifest_pb2.ExportTargetFile],
     seen_paths: set[str],
-) -> list[str]:
-    errors: list[str] = []
+) -> None:
     for index, row in enumerate(rows):
         prefix = f"{field_name}[{index}]"
         if not row.path:
@@ -254,7 +259,6 @@ def _validate_file_rows(
             errors.append(f"{prefix}.source_provenance is required")
         if row.redaction_class == export_target_manifest_pb2.EXPORT_REDACTION_CLASS_UNSPECIFIED:
             errors.append(f"{prefix}.redaction_class must be specified")
-    return errors
 
 
 def _validate_runtime_requirements(


### PR DESCRIPTION
## Summary
- Appends export target manifest file-row validation errors directly into the manifest-level accumulator.
- Avoids three short-lived per-section error lists during repeated manifest validation while preserving generated/required/intermediate file-row semantics.

## Plan or Spec
- `docs/plans/2026-06-21-runtime-aware-export-and-serving-verification.md`
- Registered PR-scoped probe: `runtime-export-manifest-validation` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 46 passed in 0.26s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_manifest_validation_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_manifest.py services/mlx-worker-python/tests/test_export_target_manifest_contract.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_manifest_metrics_report.py scripts/runtime_export_manifest_validation_probe.py
# 46 passed; changed-line coverage TOTAL 4 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-manifest-validation --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/runtime-export-file-row-append-report.json
# base elapsed_ms_mean=2123.391854; head elapsed_ms_mean=2100.827148; delta=-22.564706ms; speedup=1.062673%; schema_error_count=0.0 both
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local registered probe (`runtime-export-manifest-validation`): `old_mean=2123.391854ms`, `new_mean=2100.827148ms`, `delta_ms=-22.564706`, `speedup=1.062673%`.
- Guard rails unchanged: `fixture_count=4.0`, `manifest_byte_size=21400.0`, `schema_error_count=0.0` for both base and head.
- CI PR-scoped performance workflow is required as the merge-gate validation source.

## Known Gaps
- Full repository `make` gates were not run locally; this Linux slice was verified with the registered focused Python test, coverage, and probe commands.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability or probe overhead added.
- [x] Deferred work and known gaps are stated explicitly.
