### PR TITLE
perf: reuse runtime export source row paths

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -239,6 +239,14 @@ excerpt scan. Exact-text, fast-phrase, and regex fallback matches now append the
 line number to that bound prefix instead of formatting the full evidence path in
 each matched branch.
 
+A follow-up 2026-07-11 source collection row-path reuse slice keeps runtime-log
+row collection and failure-check source semantics unchanged while reading
+`row.path` once per manifest row inside `_collect_source_lines()`. The manifest
+row loop still uses the same runtime-log predicate, duplicate suppression,
+target-relative resolution, file read, and source-line extension behavior, but
+avoids repeated protobuf attribute lookups for rows that enter the diagnostic
+source collection path.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -500,17 +500,18 @@ def _collect_source_lines(
 
     for rows in (manifest.generated_files, manifest.required_files, manifest.intermediate_files):
         for row in rows:
+            row_path = row.path
             if not _is_runtime_log_row(row):
                 continue
-            if row.path in seen_paths:
+            if row_path in seen_paths:
                 continue
-            seen_paths.add(row.path)
-            path = _target_relative_path(layout, row.path)
+            seen_paths.add(row_path)
+            path = _target_relative_path(layout, row_path)
             if not path.is_file():
                 continue
             with path.open("rb") as source:
                 text = source.read(source_read_bytes).decode("utf-8", errors="replace")
-            _extend_source_lines(lines, row.path, text)
+            _extend_source_lines(lines, row_path, text)
 
     for check in failure_checks:
         if isinstance(check, Mapping):


### PR DESCRIPTION
## Summary
- Reuse `row.path` once per manifest row in runtime export diagnostic source collection.
- Keep runtime-log filtering, duplicate suppression, target-relative resolution, file reads, and failure-check source semantics unchanged.
- Update the runtime export diagnostic parser plan with the 2026-07-11 row-path reuse slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json` (includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Sync / branch setup
cd /root/.hermes/profiles/coder/workspace/melix && git fetch origin && git reset --hard origin/main
git worktree add -b perf/runtime-export-source-collection-local-binds-20260711 /root/.hermes/profiles/coder/workspace/worktrees/melix-runtime-export-diagnostic-category-local-bind-20260711 origin/main

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 82 passed in 1.70s (initial focused run)

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 82 passed in 1.45s; TOTAL 5 0 100%

# Registered local PR-scoped probe, base vs head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=30 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/runtime-export-diagnostic-parser-row-path-pr-scope-5x30.json
# head verification: 82 passed in 1.44s; TOTAL 5 0 100%; base/head probes ok

# Direct head probe repeat
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=30 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# emitted JSON metrics successfully

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%` for the registered runtime export diagnostic parser coverage command.
- Registered local PR-scoped probe (`runtime-export-diagnostic-parser`, 5 samples x 30 iterations):
  - `elapsed_ms_mean`: base `2687.350445985794`, head `2641.691892396193` (`-45.65855358960107 ms`, `-1.699%`).
  - `path_redaction_elapsed_ms_mean`: base `20.274322596378624`, head `19.821763783693314` (`-0.45255881268531084 ms`, `-2.232%`).
  - `diagnosis_matching_elapsed_ms_mean`: base `0.17955059884116054`, head `0.17678760923445225` (`-0.002762989606708288 ms`, `-1.539%`).
  - Guardrails preserved: `diagnostic_parser_coverage=1.0`, `parsed_failure_count=27.0`, `unknown_failure_count=1.0`, `redaction_count=5.0`, `target_count=4.0`, `diagnosis_code_count=9.0`.
  - `peak_bytes_mean`: base `199338.0`, head `204251.4` (`+2.465%`, below the registered 5% warn threshold).
  - `diagnostic_latency_ms`: base `7.136627100408077`, head `8.751176006626338`; this submetric is low absolute value and noisy in local Linux sampling, while the full registered elapsed metric improved. CI registered probe remains the merge gate.
- Direct head probe repeat (5 samples x 30 iterations): `elapsed_ms_mean=2730.0576180103235`, `diagnostic_latency_ms=7.585397979710251`, `diagnostic_parser_coverage=1.0`.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this slice used the registered focused test, coverage, and probe commands.
- Swift runtime effects are not applicable; this is a Python-only Linux-validated slice.
- GitHub Actions PR-scoped performance is required as the final registered probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
