### PR TITLE
perf: stream prefix cache byte estimates

### DIFF
--- a/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
+++ b/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
@@ -1,0 +1,32 @@
+# Prefix cache snapshot byte streaming
+
+This Python-only performance slice is limited to `estimate_cache_snapshot_bytes()` in `services/mlx-worker-python/worker/runtime/prefix_block_store.py`.
+
+## Scope
+
+The prefix-cache hot path estimates resident KV-cache bytes after prompt-cache snapshots are cloned or restored. The previous implementation created an intermediate per-layer tensor list before summing `.nbytes` or `size * itemsize`. This slice keeps the same supported cache shapes while streaming each layer's state, keys, and values directly into the byte accumulator.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `prefix-cache-snapshot-byte-streaming` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports:
+
+- `elapsed_ms_mean`, `elapsed_ms_min`, and `elapsed_ms_p95` for repeated byte-estimation calls over a synthetic multi-layer cache.
+- `peak_bytes_mean` from `tracemalloc`.
+- informational `iteration_count` and `layer_count`.
+
+The older `prefix-cold-index-scandir` probe remains registered for the same module, but this new probe is the merge-gating performance signal for this byte-estimation slice.
+
+## Plan
+
+1. Add direct behavior coverage for state-list, key/value, scalar-state, and missing-layer cache shapes.
+2. Add the registered probe script and PR-scoped registry entry for cache snapshot byte estimation.
+3. Replace the per-layer temporary tensor list with direct streaming accumulation.
+4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the final merge gate.
+
+## Success criteria
+
+- Behavior remains equivalent for existing `.state`, `.keys/.values`, `.nbytes`, and `size * itemsize` cache shapes.
+- Changed-scope coverage for touched Python paths is at least 95%.
+- The local registered probe shows lower elapsed time for the synthetic cache byte-estimation workload.
+- GitHub Actions and the PR-scoped performance workflow complete successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -6933,5 +6933,58 @@
         "direction": "informational"
       }
     ]
+  },
+  {
+    "id": "prefix-cache-snapshot-byte-streaming",
+    "name": "Prefix cache snapshot byte streaming",
+    "runner": "ubuntu-latest",
+    "watch_globs": [
+      "services/mlx-worker-python/worker/runtime/prefix_block_store.py",
+      "services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py",
+      "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
+      "scripts/prefix_cache_snapshot_bytes_probe.py",
+      "infra/perf/pr_scoped_probes.json",
+      "docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md"
+    ],
+    "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
+    "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py",
+    "probe_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT=\"$PWD\" uv run --project services/mlx-worker-python bash -c 'SCRIPT=\"scripts/prefix_cache_snapshot_bytes_probe.py\"; for CANDIDATE in \"../head/$SCRIPT\" \"${GITHUB_WORKSPACE:-}/head/$SCRIPT\" \"$SCRIPT\"; do if [ -f \"$CANDIDATE\" ]; then python3 \"$CANDIDATE\"; exit $?; fi; done; echo \"missing probe script fallback for $SCRIPT\" >&2; exit 2'",
+    "probe_impl": "command_json",
+    "coverage_replays_tests": true,
+    "metrics": [
+      {
+        "key": "elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "peak_bytes_mean",
+        "unit": "bytes",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "iteration_count",
+        "unit": "calls",
+        "direction": "informational"
+      },
+      {
+        "key": "layer_count",
+        "unit": "layers",
+        "direction": "informational"
+      }
+    ]
   }
 ]

--- a/scripts/prefix_cache_snapshot_bytes_probe.py
+++ b/scripts/prefix_cache_snapshot_bytes_probe.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import time
+import tracemalloc
+from types import SimpleNamespace
+
+from pathlib import Path
+
+REPO_ROOT = Path(os.environ.get("MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT", Path.cwd()))
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
+
+from worker.runtime.prefix_block_store import estimate_cache_snapshot_bytes  # noqa: E402
+
+
+class FakeTensor:
+    __slots__ = ("nbytes",)
+
+    def __init__(self, nbytes: int) -> None:
+        self.nbytes = nbytes
+
+
+class FakeFallbackTensor:
+    __slots__ = ("itemsize", "size")
+
+    def __init__(self, size: int, itemsize: int) -> None:
+        self.size = size
+        self.itemsize = itemsize
+
+
+def _build_cache(layer_count: int) -> tuple[list[SimpleNamespace], int]:
+    cache: list[SimpleNamespace] = []
+    expected = 0
+    for index in range(layer_count):
+        first = FakeTensor(128 + (index % 17))
+        second = FakeFallbackTensor(16 + (index % 11), 4)
+        if index % 3 == 0:
+            state = [first, second]
+            cache.append(SimpleNamespace(state=state))
+        elif index % 3 == 1:
+            cache.append(SimpleNamespace(keys=first, values=second))
+        else:
+            cache.append(SimpleNamespace(state=first))
+        expected += first.nbytes + second.size * second.itemsize if index % 3 != 2 else first.nbytes
+    return cache, expected
+
+
+def measure(*, layer_count: int, iterations: int, samples: int) -> dict[str, float]:
+    cache, expected = _build_cache(layer_count)
+    elapsed_ms: list[float] = []
+    peak_bytes: list[float] = []
+    checksum = 0
+    for _ in range(samples):
+        tracemalloc.start()
+        started = time.perf_counter()
+        checksum = 0
+        for _iteration in range(iterations):
+            observed = estimate_cache_snapshot_bytes(cache)
+            if observed != expected:
+                raise RuntimeError(f"unexpected cache byte estimate: {observed} != {expected}")
+            checksum += observed
+        elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        peak_bytes.append(float(peak))
+    return {
+        "checksum": float(checksum),
+        "elapsed_ms_mean": statistics.fmean(elapsed_ms),
+        "elapsed_ms_min": min(elapsed_ms),
+        "elapsed_ms_p95": sorted(elapsed_ms)[int((len(elapsed_ms) - 1) * 0.95)],
+        "iteration_count": float(iterations),
+        "layer_count": float(layer_count),
+        "peak_bytes_mean": statistics.fmean(peak_bytes),
+        "sample_count": float(samples),
+    }
+
+
+def main() -> int:
+    layer_count = int(os.environ.get("MELIX_PREFIX_CACHE_SNAPSHOT_LAYERS", "4096"))
+    iterations = int(os.environ.get("MELIX_PREFIX_CACHE_SNAPSHOT_ITERATIONS", "80"))
+    samples = int(os.environ.get("MELIX_PREFIX_CACHE_SNAPSHOT_SAMPLES", "5"))
+    print(json.dumps(measure(layer_count=layer_count, iterations=iterations, samples=samples), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -534,6 +534,26 @@ def test_scope_report_selects_prefix_cold_index_probe() -> None:
         changed_files=["services/mlx-worker-python/worker/runtime/prefix_block_store.py"],
     )
     assert "prefix-cold-index-scandir" in _selected_probe_ids(scope)
+    assert "prefix-cache-snapshot-byte-streaming" in _selected_probe_ids(scope)
+
+
+def test_prefix_cache_snapshot_bytes_probe_script_emits_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("MELIX_PREFIX_CACHE_SNAPSHOT_LAYERS", "8")
+    monkeypatch.setenv("MELIX_PREFIX_CACHE_SNAPSHOT_ITERATIONS", "2")
+    monkeypatch.setenv("MELIX_PREFIX_CACHE_SNAPSHOT_SAMPLES", "1")
+    probe_script = runpy.run_path(str(REPO_ROOT / "scripts/prefix_cache_snapshot_bytes_probe.py"))
+
+    assert probe_script["main"]() == 0
+
+    metrics = json.loads(capsys.readouterr().out)
+    assert metrics["elapsed_ms_mean"] >= 0.0
+    assert metrics["iteration_count"] == 2.0
+    assert metrics["layer_count"] == 8.0
+    assert metrics["peak_bytes_mean"] >= 0.0
+    assert metrics["sample_count"] == 1.0
 
 
 def test_prefix_cold_index_probe_script_emits_metrics(
@@ -4310,6 +4330,7 @@ def test_text_family_config_probe_script_emits_metrics(
 def test_registered_probes_expose_focused_commands() -> None:
     replaying_probe_ids = {
         "prefix-cold-index-scandir",
+        "prefix-cache-snapshot-byte-streaming",
         "dataset-registry-limited-read-streaming",
         "dataset-registry-snapshot-inference-single-pass",
         "event-extraction-alignment-accepted-edge-cache",

--- a/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
+++ b/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from worker.runtime.prefix_block_store import (
     ColdPrefixStore,
     PrefixBlockStore,
+    estimate_cache_snapshot_bytes,
 )
 
 
@@ -37,6 +39,30 @@ def _make_cold(tmp_path: Path, **kwargs: Any) -> ColdPrefixStore:
 def _make_snapshot(value: str = "snapshot") -> list[dict[str, str]]:
     # List-shaped like a prompt-cache layer list; restore() requires a list.
     return [{"data": value}]
+
+
+def test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers() -> None:
+    class TensorWithNbytes:
+        def __init__(self, nbytes: int) -> None:
+            self.nbytes = nbytes
+
+    class TensorWithSize:
+        size = 7
+        itemsize = 8
+
+    cache_snapshot = [
+        SimpleNamespace(state=[TensorWithNbytes(10), TensorWithSize()]),
+        SimpleNamespace(keys=TensorWithNbytes(20), values=TensorWithSize()),
+        SimpleNamespace(state=TensorWithNbytes(30)),
+        SimpleNamespace(state=TensorWithSize()),
+        SimpleNamespace(keys=TensorWithSize(), values=TensorWithNbytes(40)),
+        SimpleNamespace(),
+    ]
+
+    assert (
+        estimate_cache_snapshot_bytes(cache_snapshot)
+        == 10 + 56 + 20 + 56 + 30 + 56 + 56 + 40
+    )
 
 
 def _put(store: PrefixBlockStore, session_id: str, tokens: list[int], **kwargs: Any) -> None:

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -433,25 +433,45 @@ def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:
         return 0
     total = 0
     for layer_cache in cache_snapshot:
-        tensors: list[Any] = []
         state = getattr(layer_cache, "state", None)
         if state is not None:
             if isinstance(state, list | tuple):
-                tensors.extend(state)
-            else:
-                tensors.append(state)
-        else:
-            keys = getattr(layer_cache, "keys", None)
-            values = getattr(layer_cache, "values", None)
-            if keys is not None:
-                tensors.append(keys)
-            if values is not None:
-                tensors.append(values)
-        for tensor in tensors:
-            nbytes = getattr(tensor, "nbytes", None)
+                for tensor in state:
+                    nbytes = getattr(tensor, "nbytes", None)
+                    if nbytes is None:
+                        size = getattr(tensor, "size", None)
+                        itemsize = getattr(tensor, "itemsize", None)
+                        if size is not None and itemsize is not None:
+                            nbytes = int(size) * int(itemsize)
+                    if nbytes is not None:
+                        total += int(nbytes)
+                continue
+            nbytes = getattr(state, "nbytes", None)
             if nbytes is None:
-                size = getattr(tensor, "size", None)
-                itemsize = getattr(tensor, "itemsize", None)
+                size = getattr(state, "size", None)
+                itemsize = getattr(state, "itemsize", None)
+                if size is not None and itemsize is not None:
+                    nbytes = int(size) * int(itemsize)
+            if nbytes is not None:
+                total += int(nbytes)
+            continue
+
+        keys = getattr(layer_cache, "keys", None)
+        if keys is not None:
+            nbytes = getattr(keys, "nbytes", None)
+            if nbytes is None:
+                size = getattr(keys, "size", None)
+                itemsize = getattr(keys, "itemsize", None)
+                if size is not None and itemsize is not None:
+                    nbytes = int(size) * int(itemsize)
+            if nbytes is not None:
+                total += int(nbytes)
+        values = getattr(layer_cache, "values", None)
+        if values is not None:
+            nbytes = getattr(values, "nbytes", None)
+            if nbytes is None:
+                size = getattr(values, "size", None)
+                itemsize = getattr(values, "itemsize", None)
                 if size is not None and itemsize is not None:
                     nbytes = int(size) * int(itemsize)
             if nbytes is not None:


### PR DESCRIPTION
## Summary
- Stream prefix-cache snapshot byte estimation directly over `.state`, `.keys`, and `.values` tensors instead of allocating a per-layer temporary tensor list.
- Add a dedicated PR-scoped performance probe for `estimate_cache_snapshot_bytes()` and focused regression coverage for supported cache shapes.
- Document the slice in `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md`.

## Plan or Spec
- `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md`

## Commands Run
```text
# Baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_LAYERS=4096 MELIX_PREFIX_CACHE_SNAPSHOT_ITERATIONS=80 MELIX_PREFIX_CACHE_SNAPSHOT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
-> exit 0; elapsed_ms_mean=1219.576284813229; peak_bytes_mean=318.4

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
-> exit 0; 10 passed in 1.36s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py
-> exit 0; TOTAL 57 0 100%

# Registered PR-scoped probe run, base vs head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id prefix-cache-snapshot-byte-streaming --base-repo /tmp/melix-prefix-cache-snapshot-pr-perf/base --head-repo "$PWD" --output .runtime/prefix-cache-snapshot-byte-streaming-result.json
-> exit 0; base elapsed_ms_mean=1243.3474674005993; head elapsed_ms_mean=1032.5890576117672

# Final smoke after formatting-only test adjustment
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics
-> exit 0; 2 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_LAYERS=4096 MELIX_PREFIX_CACHE_SNAPSHOT_ITERATIONS=80 MELIX_PREFIX_CACHE_SNAPSHOT_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
-> exit 0; elapsed_ms_mean=1107.5483263819478; peak_bytes_mean=264.0

python3 -m json.tool infra/perf/pr_scoped_probes.json >/tmp/pr_scoped_probes.json.check
-> exit 0

git diff --check
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 57 0 100%`.
- Registered local PR-scoped probe: base `elapsed_ms_mean=1243.3474674005993`, head `elapsed_ms_mean=1032.5890576117672`, delta `-210.7584097888321 ms` (`~16.95%` faster); base `peak_bytes_mean=318.4`, head `peak_bytes_mean=264.0`.
- Direct same-worktree probe after implementation: `elapsed_ms_mean=1107.5483263819478`, `peak_bytes_mean=264.0`.
- GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

## Known Gaps
- Swift runtime effects are N/A; this is a Python-only prefix-cache byte-estimation slice validated locally on Linux.
- CI must still complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: off; probe overhead is isolated to the PR-scoped benchmark script.
- [x] Deferred work and known gaps are stated explicitly.
