### PR TITLE
perf: fast path dataset quality completion lengths

### DIFF
--- a/docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md
+++ b/docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md
@@ -12,6 +12,8 @@ The affected path is covered by the registered PR-scoped probe `dataset-quality-
 
 A 2026-07-06 follow-up keeps the same row helper and returns the accumulated output-length total while appending each length. `_sample_output_length_stats()` uses that inline total instead of rescanning the collected lengths with `sum()` before sorting for p95, preserving output semantics while removing one full pass over the hot length list. The registered probe default sample count also increases from 7 to 25 so the short dataset-quality timing path is less sensitive to single-sample scheduler noise in CI and local comparisons.
 
+A 2026-07-11 follow-up keeps the same row helper but checks key presence before reading prompt-completion rows. The synthetic registered probe is dominated by prompt-completion train rows, so the helper avoids `dict.get()` plus sentinel comparison on that common path while preserving the existing message-row behavior and p95/mean output-length semantics.
+
 ## Verification Plan
 
 1. Run the registered local probe on `origin/main` before the change and on `HEAD` after the change.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -221,6 +221,18 @@ def test_dataset_quality_output_lengths_preserve_completion_and_message_semantic
     assert _sample_output_length_stats([], []) == (0, 0, 0)
 
 
+def test_dataset_quality_completion_rows_use_key_presence_fast_path() -> None:
+    class CompletionRow(dict[str, object]):
+        def get(self, key: str, default: object = None) -> object:  # pragma: no cover - regression tripwire
+            if key == "completion":  # pragma: no cover - regression tripwire
+                raise AssertionError("completion rows should not call get() for completion")
+            return super().get(key, default)  # pragma: no cover - regression tripwire
+
+    row = CompletionRow({"completion": "hello"})
+
+    assert _sample_output_lengths([row], []) == [5]
+
+
 def test_dataset_quality_message_rows_skip_completion_key_lookup() -> None:
     class MessageRow(dict[str, object]):
         def __getitem__(self, key: str) -> object:  # pragma: no cover - regression tripwire

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -52,7 +52,6 @@ _CODE_SOURCE_LANGUAGE_BY_SUFFIX = {
 _SOURCE_KIND_NAME_CACHE_MAX = 4096
 _SOURCE_KIND_BY_NAME: dict[str, str | None] = {}
 _SHA256 = hashlib.sha256
-_MISSING = object()
 
 
 def preflight_workspace(*args: Any, **kwargs: Any) -> dict[str, Any]:
@@ -1871,11 +1870,9 @@ def _append_rows_output_lengths(
     append = lengths.append
     len_ = len
     str_ = str
-    missing = _MISSING
     output_length_total = 0
     for row in rows:
-        completion = row.get("completion", missing)
-        if completion is missing:
+        if "completion" not in row:
             messages = row.get("messages", [])
             if not isinstance(messages, list):
                 append(0)
@@ -1896,6 +1893,7 @@ def _append_rows_output_lengths(
             append(total)
             output_length_total += total
         else:
+            completion = row["completion"]
             if type(completion) is str:
                 length = len_(completion)
             else:


### PR DESCRIPTION
## Summary
- Fast-path dataset quality output-length extraction for prompt-completion rows by checking key presence before reading `completion`.
- Preserve existing message-row semantics and p95/mean output length behavior.
- Update the governing dataset-quality performance plan with the 2026-07-11 slice notes.

## Plan or Spec
- `docs/plans/2026-06-21-dataset-quality-output-length-row-helper.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_completion_rows_use_key_presence_fast_path services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_message_rows_skip_completion_key_lookup services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics
# 3 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics
# 60 passed in 2.14s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# 60 passed in 1.60s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
# head after change: elapsed_ms_mean=2.831098, elapsed_ms_p95=3.163716

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 6 0 100%`).
- Local Linux registered probe baseline on `origin/main` before change: `elapsed_ms_mean=3.373101`, `elapsed_ms_p95=4.953334`, `failed_partition_elapsed_ms_mean=1.038867`.
- Local Linux registered probe after change: `elapsed_ms_mean=2.831098`, `elapsed_ms_p95=3.163716`, `failed_partition_elapsed_ms_mean=1.014541`.
- Local delta: mean `-0.542003 ms` (`1.191446x`, `16.068%` faster); p95 `-1.789618 ms` (`36.13%` lower).
- CI PR-scoped performance workflow is required as the registered merge-gate validation source.

## Known Gaps
- No Swift runtime effect is claimed; this is a Python-only Linux-verified slice.
- Full repository `make` gates were not run locally; focused registered probe/test/coverage commands were run for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
