### PR TITLE
perf: reuse prefix cache state sequence types

### DIFF
--- a/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
+++ b/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
@@ -4,7 +4,7 @@ This Python-only performance slice is limited to `estimate_cache_snapshot_bytes(
 
 ## Scope
 
-The prefix-cache hot path estimates resident KV-cache bytes after prompt-cache snapshots are cloned or restored. The previous implementation created an intermediate per-layer tensor list before summing `.nbytes` or `size * itemsize`. This slice keeps the same supported cache shapes while streaming each layer's state, keys, and values directly into the byte accumulator.
+The prefix-cache hot path estimates resident KV-cache bytes after prompt-cache snapshots are cloned or restored. The previous implementation created an intermediate per-layer tensor list before summing `.nbytes` or `size * itemsize`. This follow-up slice keeps the same supported cache shapes while avoiding repeated runtime construction of the `list | tuple` type-union check inside the streamed state path.
 
 ## Registered probe
 
@@ -21,8 +21,9 @@ The older `prefix-cold-index-scandir` probe remains registered for the same modu
 1. Add direct behavior coverage for state-list, key/value, scalar-state, and missing-layer cache shapes.
 2. Add the registered probe script and PR-scoped registry entry for cache snapshot byte estimation.
 3. Replace the per-layer temporary tensor list with direct streaming accumulation.
-4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
-5. Use GitHub Actions PR-scoped performance as the final merge gate.
+4. Reuse a module-level state-sequence type tuple so the streamed state path does not rebuild `list | tuple` during every layer check.
+5. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
+6. Use GitHub Actions PR-scoped performance as the final merge gate.
 
 ## Success criteria
 

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -21,6 +21,7 @@ _DEFAULT_MAX_MEMORY_BYTES = 4 * 1024 ** 3  # 4 GiB
 _DEFAULT_COLD_MAX_BYTES = 8 * 1024 ** 3  # 8 GiB
 _COLD_DIR_ENV = "MELIX_PREFIX_CACHE_COLD_DIR"
 _COLD_MAX_BYTES_ENV = "MELIX_PREFIX_CACHE_COLD_MAX_BYTES"
+_CACHE_STATE_SEQUENCE_TYPES = (list, tuple)
 
 
 def _is_active_kv_quant_mode(acceleration_mode: str) -> bool:
@@ -435,7 +436,7 @@ def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:
     for layer_cache in cache_snapshot:
         state = getattr(layer_cache, "state", None)
         if state is not None:
-            if isinstance(state, list | tuple):
+            if isinstance(state, _CACHE_STATE_SEQUENCE_TYPES):
                 for tensor in state:
                     nbytes = getattr(tensor, "nbytes", None)
                     if nbytes is None:


### PR DESCRIPTION
## Summary
- Reuses a module-level `(list, tuple)` type tuple in `estimate_cache_snapshot_bytes()` so the hot state-list path does not rebuild a `list | tuple` union for every layer check.
- Updates the governing prefix-cache snapshot-byte performance plan for this follow-up slice.

## Plan or Spec
- `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 10 passed in 0.32s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py
# 10 passed in 0.54s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
# before: {"elapsed_ms_mean": 979.0559359942563, "elapsed_ms_min": 960.2860540035181, "elapsed_ms_p95": 982.5233949813992, "peak_bytes_mean": 264.0}
# after:  {"elapsed_ms_mean": 893.8388002105057, "elapsed_ms_min": 832.6178889838047, "elapsed_ms_p95": 908.261314034462, "peak_bytes_mean": 264.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%` for `services/mlx-worker-python/worker/runtime/prefix_block_store.py` and registered probe scope.
- Registered local probe: `prefix-cache-snapshot-byte-streaming`.
  - `elapsed_ms_mean`: 979.0559 ms -> 893.8388 ms (`-85.2171 ms`, ~8.70% faster)
  - `elapsed_ms_p95`: 982.5234 ms -> 908.2613 ms (`-74.2621 ms`, ~7.56% faster)
  - `peak_bytes_mean`: unchanged at 264 bytes
- CI PR-scoped performance is required as the merge-gating registered probe validation.

## Known Gaps
- Linux local validation covers Python behavior and the registered probe. No Swift runtime effect is claimed for this Python-only slice.
- Full repository gates were left to GitHub Actions for this small registered performance slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via PR-scoped performance; probe overhead is isolated to the synthetic registered probe.
- [x] Deferred work and known gaps are stated explicitly.
