### PR TITLE
perf: hoist video URI validation constants

### DIFF
--- a/docs/plans/2026-07-11-video-preprocessing-uri-constants.md
+++ b/docs/plans/2026-07-11-video-preprocessing-uri-constants.md
@@ -1,0 +1,27 @@
+# Video Preprocessing URI Constant Membership Fast Path
+
+## Scope
+
+This Python-only performance slice keeps video URI preprocessing behavior equivalent while hoisting repeated membership literals from the URI parsing and validation hot path into module-level constants.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`.
+
+The existing probe already provides focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_video_preprocessing.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/video_preprocessing_uri_probe.py`
+
+## Expected Behavior
+
+- Remote HTTPS video URI validation remains unchanged.
+- Local/file URI validation remains unchanged.
+- Parsed video reference handling still preserves decoded path name and suffix behavior.
+- Byte-length and parse-call counts stay at the registered probe baseline of one call per preprocessing request.
+
+## Verification Plan
+
+Run the registered focused video preprocessing tests, changed-scope coverage, and the registered probe locally on Linux before pushing. GitHub Actions PR-scoped performance remains the merge gate after PR creation.

--- a/services/mlx-worker-python/worker/runtime/video_preprocessing.py
+++ b/services/mlx-worker-python/worker/runtime/video_preprocessing.py
@@ -20,6 +20,9 @@ SUPPORTED_VIDEO_MIME_TYPES = {
 }
 MAX_VIDEO_FRAME_BUDGET = 128
 VIDEO_REFERENCE_PARSE_CACHE_SIZE = 512
+_VIDEO_REFERENCE_PARSE_SCHEMES = frozenset(("http", "https", "file"))
+_LOCAL_VIDEO_URI_SCHEMES = frozenset(("", "file"))
+_LOCALHOST_LAST_CHARS = frozenset(("t", "T"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,7 +147,7 @@ def _validate_bounds(duration_ms: int, frame_budget: int, start_ms: int, end_ms:
 @lru_cache(maxsize=VIDEO_REFERENCE_PARSE_CACHE_SIZE)
 def _parse_video_reference(reference: str) -> ParsedVideoReference:
     parsed = urlparse(reference)
-    if parsed.scheme in {"http", "https", "file"}:
+    if parsed.scheme in _VIDEO_REFERENCE_PARSE_SCHEMES:
         parsed_path = parsed.path
         decoded_path = parsed_path if "%" not in parsed_path else unquote(parsed_path)
         path_name, path_suffix = _path_name_and_suffix(decoded_path)
@@ -181,7 +184,7 @@ def _validate_video_uri(reference: str | ParsedVideoReference) -> None:
 
 def _validate_parsed_video_uri(reference: ParsedVideoReference) -> None:
     scheme = reference.scheme
-    if scheme in {"", "file"}:
+    if scheme in _LOCAL_VIDEO_URI_SCHEMES:
         return
     if scheme == "https":
         authority = reference.authority
@@ -195,7 +198,7 @@ def _validate_parsed_video_uri(reference: ParsedVideoReference) -> None:
             and ":" not in authority
             and (
                 len(authority) < len("localhost")
-                or authority[-1] not in {"t", "T"}
+                or authority[-1] not in _LOCALHOST_LAST_CHARS
                 or not _authority_mentions_localhost(authority.lower())
             )
         ):
@@ -237,7 +240,7 @@ def _is_plain_allowed_remote_authority(authority: str) -> bool:
         return False
     if len(authority) < len("localhost"):
         return True
-    if authority[-1] not in {"t", "T"}:
+    if authority[-1] not in _LOCALHOST_LAST_CHARS:
         return True
     return not _authority_mentions_localhost(authority.lower())
 


### PR DESCRIPTION
## Summary
- Hoist video URI parsing and validation membership literals into module-level constants.
- Keep video preprocessing behavior unchanged while trimming repeated hot-path constant construction/lookup overhead.

## Plan or Spec
- `docs/plans/2026-07-11-video-preprocessing-uri-constants.md`
- Registered probe: `video-preprocessing-uri-byte-length-reuse` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 39 passed in 2.85s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py::test_validate_video_uri_accepts_parsed_and_string_remote_references services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_video_preprocessing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_video_preprocessing_uri_probe_script_emits_metrics
# 39 passed in 7.57s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/video_preprocessing.py services/mlx-worker-python/tests/test_video_preprocessing.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/video_preprocessing_uri_probe.py
# TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/video_preprocessing_uri_probe.py
# head samples: 512.617, 531.198, 548.472 ms mean outputs across repeated probe runs
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%` for `video_preprocessing.py` changed lines.
- Local Linux registered probe comparison:
  - `old_mean=552.990 ms` from `origin/main` repeated probe runs.
  - `new_mean=530.762 ms` from this branch repeated probe runs.
  - `delta_ms=-22.228`, `speedup=1.0419x`, `improvement=4.02%`.
- Probe counters remained stable: `byte_length_getattrs_per_call=1.0`, `parse_calls_per_call=1.0`.
- CI PR-scoped performance is still required as the registered merge-gate validation.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python hot-path slice.
- Swift/macOS runtime effects are N/A; this slice only touches Python video preprocessing.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
