### PR TITLE
perf: localize prefix cache tensor byte accounting

### DIFF
--- a/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
+++ b/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
@@ -1,33 +1,41 @@
-# Prefix cache snapshot byte streaming
+# Prefix Cache Snapshot Byte Streaming Local nbytes Slice
 
-This Python-only performance slice is limited to `estimate_cache_snapshot_bytes()` in `services/mlx-worker-python/worker/runtime/prefix_block_store.py`.
+## Context
+
+The registered PR-scoped probe `prefix-cache-snapshot-byte-streaming` covers
+`services/mlx-worker-python/worker/runtime/prefix_block_store.py` and the
+snapshot byte estimator used by prefix-cache accounting.
+
+The current estimator repeatedly performs the same `nbytes` / `size * itemsize`
+lookup pattern for state, key, and value tensors. This slice keeps behavior
+unchanged while reducing duplicated attribute lookup code in the hot loop.
 
 ## Scope
 
-The prefix-cache hot path estimates resident KV-cache bytes after prompt-cache snapshots are cloned or restored. The previous implementation created an intermediate per-layer tensor list before summing `.nbytes` or `size * itemsize`. This follow-up slice keeps the same supported cache shapes while avoiding repeated runtime construction of the `list | tuple` type-union check inside the streamed state path.
+- Add a tiny local helper for tensor byte extraction in
+  `estimate_cache_snapshot_bytes`.
+- Preserve support for both older `.state` caches and newer `.keys` / `.values`
+  cache shapes.
+- Add focused regression coverage for state sequence fallback tensors so the
+  helper preserves `size * itemsize` behavior.
+- Run the registered test, coverage, and probe commands locally on Linux.
 
-## Registered probe
+## Measurement
 
-The affected path is covered by the registered PR-scoped probe `prefix-cache-snapshot-byte-streaming` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and reports:
+Registered probe: `prefix-cache-snapshot-byte-streaming`
 
-- `elapsed_ms_mean`, `elapsed_ms_min`, and `elapsed_ms_p95` for repeated byte-estimation calls over a synthetic multi-layer cache.
-- `peak_bytes_mean` from `tracemalloc`.
-- informational `iteration_count` and `layer_count`.
+Required commands:
 
-The older `prefix-cold-index-scandir` probe remains registered for the same module, but this new probe is the merge-gating performance signal for this byte-estimation slice.
+- Focused tests from the registry entry.
+- Changed-scope coverage from the registry entry.
+- Registered probe command from the registry entry.
 
-## Plan
+Success is accepted only if behavior tests pass, changed-scope coverage remains
+at or above the repository threshold, and the probe reports a clear non-regressive
+or improved elapsed-time result versus the baseline measurement captured before
+this slice.
 
-1. Add direct behavior coverage for state-list, key/value, scalar-state, and missing-layer cache shapes.
-2. Add the registered probe script and PR-scoped registry entry for cache snapshot byte estimation.
-3. Replace the per-layer temporary tensor list with direct streaming accumulation.
-4. Reuse a module-level state-sequence type tuple so the streamed state path does not rebuild `list | tuple` during every layer check.
-5. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
-6. Use GitHub Actions PR-scoped performance as the final merge gate.
+## Linux Boundary
 
-## Success criteria
-
-- Behavior remains equivalent for existing `.state`, `.keys/.values`, `.nbytes`, and `size * itemsize` cache shapes.
-- Changed-scope coverage for touched Python paths is at least 95%.
-- The local registered probe shows lower elapsed time for the synthetic cache byte-estimation workload.
-- GitHub Actions and the PR-scoped performance workflow complete successfully before merge.
+This is a Python worker path and can be validated locally on Linux. CI remains
+the source of truth for the PR-scoped performance workflow report after push.

--- a/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
+++ b/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
@@ -65,6 +65,18 @@ def test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers() -> None
     )
 
 
+def test_estimate_cache_snapshot_bytes_ignores_tensors_without_byte_shape() -> None:
+    class TensorWithoutBytes:
+        size = 4
+
+    cache_snapshot = [
+        SimpleNamespace(state=[TensorWithoutBytes(), SimpleNamespace(itemsize=8)]),
+        SimpleNamespace(keys=TensorWithoutBytes(), values=SimpleNamespace(itemsize=8)),
+    ]
+
+    assert estimate_cache_snapshot_bytes(cache_snapshot) == 0
+
+
 def _put(store: PrefixBlockStore, session_id: str, tokens: list[int], **kwargs: Any) -> None:
     store.put(
         session_id=session_id,

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -424,6 +424,19 @@ class ColdPrefixStore:
             _remove_quietly(meta.meta_path)
 
 
+def _tensor_nbytes(tensor: Any) -> int:
+    nbytes = getattr(tensor, "nbytes", None)
+    if nbytes is not None:
+        return int(nbytes)
+    size = getattr(tensor, "size", None)
+    if size is None:
+        return 0
+    itemsize = getattr(tensor, "itemsize", None)
+    if itemsize is None:
+        return 0
+    return int(size) * int(itemsize)
+
+
 def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:
     """Estimate the live in-memory bytes of a prompt-cache layer list.
 
@@ -433,50 +446,24 @@ def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:
     if not isinstance(cache_snapshot, list):
         return 0
     total = 0
+    tensor_nbytes = _tensor_nbytes
+    sequence_types = _CACHE_STATE_SEQUENCE_TYPES
     for layer_cache in cache_snapshot:
         state = getattr(layer_cache, "state", None)
         if state is not None:
-            if isinstance(state, _CACHE_STATE_SEQUENCE_TYPES):
+            if isinstance(state, sequence_types):
                 for tensor in state:
-                    nbytes = getattr(tensor, "nbytes", None)
-                    if nbytes is None:
-                        size = getattr(tensor, "size", None)
-                        itemsize = getattr(tensor, "itemsize", None)
-                        if size is not None and itemsize is not None:
-                            nbytes = int(size) * int(itemsize)
-                    if nbytes is not None:
-                        total += int(nbytes)
+                    total += tensor_nbytes(tensor)
                 continue
-            nbytes = getattr(state, "nbytes", None)
-            if nbytes is None:
-                size = getattr(state, "size", None)
-                itemsize = getattr(state, "itemsize", None)
-                if size is not None and itemsize is not None:
-                    nbytes = int(size) * int(itemsize)
-            if nbytes is not None:
-                total += int(nbytes)
+            total += tensor_nbytes(state)
             continue
 
         keys = getattr(layer_cache, "keys", None)
         if keys is not None:
-            nbytes = getattr(keys, "nbytes", None)
-            if nbytes is None:
-                size = getattr(keys, "size", None)
-                itemsize = getattr(keys, "itemsize", None)
-                if size is not None and itemsize is not None:
-                    nbytes = int(size) * int(itemsize)
-            if nbytes is not None:
-                total += int(nbytes)
+            total += tensor_nbytes(keys)
         values = getattr(layer_cache, "values", None)
         if values is not None:
-            nbytes = getattr(values, "nbytes", None)
-            if nbytes is None:
-                size = getattr(values, "size", None)
-                itemsize = getattr(values, "itemsize", None)
-                if size is not None and itemsize is not None:
-                    nbytes = int(size) * int(itemsize)
-            if nbytes is not None:
-                total += int(nbytes)
+            total += tensor_nbytes(values)
     return total
 
 


### PR DESCRIPTION
## Summary
- Refactors prefix-cache snapshot byte accounting through a local `_tensor_nbytes` helper to avoid duplicated hot-loop attribute probing.
- Preserves `.state` and `.keys` / `.values` cache-shape behavior, including `nbytes` and `size * itemsize` fallbacks.
- Adds focused regression coverage for tensors that do not expose a complete byte shape.

## Plan or Spec
- Updated `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md` for this local nbytes extraction slice.
- Registered PR-scoped probe already exists: `prefix-cache-snapshot-byte-streaming` with focused test, coverage, and probe commands.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_ignores_tensors_without_byte_shape services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py`
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py`
- Slice probe on this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 11 passed.
- Changed-scope coverage: 100.00% (23/23 measurable changed lines).
- Baseline registered probe on `origin/main`: `elapsed_ms_mean=867.7249638130888`, `elapsed_ms_min=839.5931150298566`, `elapsed_ms_p95=877.9261090094224`, `peak_bytes_mean=264.0`.
- Branch registered probe: `elapsed_ms_mean=578.8314644014463`, `elapsed_ms_min=549.5035760104656`, `elapsed_ms_p95=598.4638460213318`, `peak_bytes_mean=264.0`.
- Local delta: `mean -288.8934994116425 ms` (~33.3% faster), `p95 -279.4622629880905 ms`.

## Known Gaps
- This is a Python worker path and was locally validated on Linux.
- The PR-scoped performance workflow in GitHub Actions remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused behavior tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally and improved versus baseline.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance workflow completed successfully.
