### PR TITLE
Add tool-call parser policy conformance evidence

### DIFF
--- a/docs/plans/2026-07-11-issue-1384-tool-call-parser-policy-conformance.md
+++ b/docs/plans/2026-07-11-issue-1384-tool-call-parser-policy-conformance.md
@@ -1,0 +1,268 @@
+# Issue 1384 Tool-Call Parser Policy Conformance Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development for implementation. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an OpenAI conformance slice that makes tool-call parser policy evidence machine-readable by model family, parser mode, and tag dialect.
+
+**Architecture:** Keep the proof at the Swift control-plane boundary described by ADR 0002. Extend `OpenAIConformanceRow` with optional metadata fields so existing rows and harness output remain compatible, then add stream and non-stream malformed tool-call fixtures that build their report rows from real request-local compatibility receipts in `GenerateRequest.execution.ext`.
+
+**Tech Stack:** Swift Testing, `OpenAIConformanceReport`, `OpenAIConformanceMatrixTests`, `TextCompatibilityPolicyReceipt`, `ChatRequestTranslator`, and the existing `RecordingConformanceWorker` fixture.
+
+---
+
+## Scope
+
+This slice covers:
+
+- `OpenAIConformanceRow` optional metadata for `model_family`, `parser_mode`, `tag_dialect`, `requested_parser`, `resolved_parser`, `parser_fallback_mode`, and `parser_refusal_reason`.
+- Request-local compatibility receipt fields for the same parser policy evidence: `requested_parser`, `resolved_parser`, `parser_fallback_mode`, and `parser_refusal_reason`.
+- A table-driven conformance fixture keyed by `{model_family, parser_mode, tag_dialect}`.
+- Stream and non-stream malformed tool-call text fixtures proving raw delimiters are suppressed and no backend text skeleton is promoted to an OpenAI `tool_calls` payload.
+
+This slice does not implement worker-side parser recovery, bounded retry nudges, or real backend proxy parity.
+
+## Success Metrics
+
+- Existing conformance report JSON remains schema `melix.openai_conformance_report.v1`.
+- Rows without parser metadata still encode and decode with the existing field set.
+- Parser fixture rows include the new snake-case metadata fields in JSON.
+- Compatibility receipts include requested, resolved, fallback, and refusal parser evidence.
+- Focused Swift tests pass with coverage at or above 95 percent for touched Swift scope.
+- PR-scoped performance report is `ok` with no in-scope regression.
+
+## Implementation Tasks
+
+### Task 1: Conformance Row Metadata
+
+**Files:**
+
+- Modify: `services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceReport.swift`
+- Modify: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift`
+
+- [x] **Step 1: Write the failing report metadata test**
+
+Add a test that constructs an `OpenAIConformanceRow` with parser metadata:
+
+```swift
+@Test("conformance report rows can carry parser policy fixture metadata")
+func conformanceReportRowsCanCarryParserPolicyFixtureMetadata() throws {
+    let row = OpenAIConformanceRow(
+        field: "tool_call_parser_policy:qwen3moe:qwen:qwen_xml_tool_call",
+        route: "/v1/chat/completions -> parser policy evidence",
+        expectedBehavior: "parser policy fixtures expose model family, parser mode, tag dialect, and resolved parser receipt evidence.",
+        observedStatus: .pass,
+        observedReason: "parser_policy=resolved",
+        modelFamily: "qwen3moe",
+        parserMode: "qwen",
+        tagDialect: "qwen_xml_tool_call",
+        requestedParser: "qwen",
+        resolvedParser: "qwen",
+        parserFallbackMode: "xml",
+        parserRefusalReason: ""
+    )
+    let reportJSON = try OpenAIConformanceReport(rows: [row]).jsonString()
+
+    #expect(reportJSON.contains(#""model_family":"qwen3moe""#))
+    #expect(reportJSON.contains(#""parser_mode":"qwen""#))
+    #expect(reportJSON.contains(#""tag_dialect":"qwen_xml_tool_call""#))
+    #expect(reportJSON.contains(#""requested_parser":"qwen""#))
+    #expect(reportJSON.contains(#""resolved_parser":"qwen""#))
+    #expect(reportJSON.contains(#""parser_fallback_mode":"xml""#))
+    #expect(reportJSON.contains(#""parser_refusal_reason":"""#))
+}
+```
+
+- [x] **Step 2: Run the focused red test**
+
+Run:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests/conformanceReportRowsCanCarryParserPolicyFixtureMetadata
+```
+
+Expected: fail to compile because `OpenAIConformanceRow` does not accept the parser metadata arguments.
+
+- [x] **Step 3: Add optional metadata fields**
+
+Extend `OpenAIConformanceRow` with optional `String?` properties and defaulted initializer arguments:
+
+```swift
+public let modelFamily: String?
+public let parserMode: String?
+public let tagDialect: String?
+public let requestedParser: String?
+public let resolvedParser: String?
+public let parserFallbackMode: String?
+public let parserRefusalReason: String?
+```
+
+Add coding keys:
+
+```swift
+case modelFamily = "model_family"
+case parserMode = "parser_mode"
+case tagDialect = "tag_dialect"
+case requestedParser = "requested_parser"
+case resolvedParser = "resolved_parser"
+case parserFallbackMode = "parser_fallback_mode"
+case parserRefusalReason = "parser_refusal_reason"
+```
+
+- [x] **Step 4: Run the focused green test**
+
+Run the same focused Swift test. Expected: pass.
+
+### Task 2: Parser Policy Receipts and Malformed Fixtures
+
+**Files:**
+
+- Modify: `services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift`
+- Modify: `services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift`
+- Modify: `services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift`
+
+- [x] **Step 1: Write failing receipt assertions**
+
+Extend `translated text requests attach request-local compatibility policy receipts` to require:
+
+```swift
+#expect(ext["melix.compat.requested_parser"] == "qwen")
+#expect(ext["melix.compat.resolved_parser"] == "qwen")
+#expect(ext["melix.compat.parser_fallback_mode"] == "")
+#expect(ext["melix.compat.parser_refusal_reason"] == "")
+#expect(receipt.contains(#""requested_parser":"qwen""#))
+#expect(receipt.contains(#""resolved_parser":"qwen""#))
+```
+
+Also extend `compatReceiptFieldNames()` with the four new JSON fields.
+
+- [x] **Step 2: Run the focused red receipt test**
+
+Run:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedTextRequestsAttachRequestLocalCompatibilityPolicyReceipts
+```
+
+Expected: fail because the new compatibility receipt fields are absent.
+
+- [x] **Step 3: Implement receipt fields**
+
+Add these `TextCompatibilityPolicyReceipt` properties:
+
+```swift
+public let requestedParser: String
+public let resolvedParser: String
+public let parserFallbackMode: String
+public let parserRefusalReason: String
+```
+
+Populate them from `ShapedTextRequest`:
+
+```swift
+"requested_parser": shapedRequest.toolParser?.source == "request" ? shapedRequest.toolParser?.mode.rawValue ?? "none" : "none",
+"resolved_parser": shapedRequest.toolParser?.mode.rawValue ?? "none",
+"parser_fallback_mode": shapedRequest.toolParser?.fallbackMode?.rawValue ?? "",
+"parser_refusal_reason": shapedRequest.toolParserSuppressedReason ?? "",
+```
+
+Mirror them in `extFields` under `melix.compat.*` and include them in the canonical receipt dictionary so the effective config hash changes when parser policy changes.
+
+- [x] **Step 4: Add parser fixture conformance rows**
+
+Add a table-driven matrix test with two fixtures:
+
+```swift
+private struct ToolCallParserPolicyFixture: Sendable {
+    let modelFamily: String
+    let parserMode: String
+    let tagDialect: String
+    let stream: Bool
+}
+```
+
+Use `tool_parser: { "mode": "qwen", "namespaces": ["tools.search"], "xml_fallback": true }` and `tools: [weatherToolJSON]`. For the non-stream fixture, return malformed assistant text containing an unclosed `<tool_call>` block. For the stream fixture, split a `<|tool_call>` marker across token events. Assert:
+
+```swift
+#expect(payload.contains("<tool_call>") == false)
+#expect(payload.contains("<|tool_call>") == false)
+#expect(payload.contains("\"tool_calls\"") == false)
+#expect(ext["melix.compat.requested_parser"] == fixture.parserMode)
+#expect(ext["melix.compat.resolved_parser"] == fixture.parserMode)
+#expect(ext["melix.compat.parser_fallback_mode"] == "xml")
+```
+
+Build `OpenAIConformanceRow` values from the fixture and ext receipt fields, then assert report JSON contains the parser metadata.
+
+- [x] **Step 5: Run focused conformance tests**
+
+Run:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
+```
+
+Expected: pass.
+
+### Task 3: Verification and PR Evidence
+
+**Files:**
+
+- Modify: `docs/plans/2026-07-11-issue-1384-tool-call-parser-policy-conformance.md`
+- Read before PR: `.github/pull_request_template.md`, `docs/contributing.md`, `docs/templates/pr-evidence-checklist.md`
+
+- [x] **Step 1: Run diff hygiene**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected: no whitespace errors; only the planned files are modified.
+
+- [x] **Step 2: Run focused coverage**
+
+Run:
+
+```bash
+HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
+```
+
+Expected: tests pass and changed-scope coverage is at least 95 percent.
+
+- [x] **Step 3: Run repository gates**
+
+Run:
+
+```bash
+make swift-test
+make py-test
+make integration-test
+```
+
+Expected: all pass.
+
+Actual:
+
+- `make swift-test` passed.
+- `make py-test` passed: 4908 passed, 14 skipped, 2 warnings in 194.15s.
+- `make integration-test` passed: 123 passed, 1 skipped in 712.07s.
+
+- [x] **Step 4: Run scoped performance report**
+
+Run:
+
+```bash
+.githooks/pre-commit
+```
+
+Expected: scoped performance report status is `ok` with zero in-scope regressions.
+
+Actual: `.githooks/pre-commit` passed. Performance report status was `ok` with 0 regressions, 0 context regressions, 0 verification failures, and no selected probes for this change set. Report path: `.runtime/pre-commit-performance/20260711-105700-4d3915c0/report/report.md`.
+
+## Known Deferred Work
+
+- Worker-side parser recovery and retry/nudge behavior remain part of broader #1384/#1382 follow-up work.
+- Real remote-provider proxy parity remains out of scope for this in-process conformance slice.
+- Additional parser families can reuse the metadata fields and fixture table after their backend parser behavior is stable enough to pin.

--- a/docs/plans/2026-07-11-issue-1384-tool-call-parser-policy-conformance.md
+++ b/docs/plans/2026-07-11-issue-1384-tool-call-parser-policy-conformance.md
@@ -261,6 +261,18 @@ Expected: scoped performance report status is `ok` with zero in-scope regression
 
 Actual: `.githooks/pre-commit` passed. Performance report status was `ok` with 0 regressions, 0 context regressions, 0 verification failures, and no selected probes for this change set. Report path: `.runtime/pre-commit-performance/20260711-105700-4d3915c0/report/report.md`.
 
+- [x] **Step 5: Review follow-up legacy receipt decoding**
+
+After PR review identified that new non-optional parser policy receipt fields would break decoding for older receipt JSON payloads:
+
+- Added `compatibilityPolicyReceiptsDecodeLegacyPayloadsWithoutParserPolicyFields`.
+- Confirmed the RED failure was `DecodingError.keyNotFound` for `requested_parser`.
+- Added a custom `TextCompatibilityPolicyReceipt.init(from:)` that defaults missing parser policy fields to `requested_parser=none`, `resolved_parser=none`, `parser_fallback_mode=""`, and `parser_refusal_reason=""`.
+- Re-ran the focused legacy decode test: passed.
+- Re-ran the focused suite: `OpenAIConformanceMatrixTests|ToolParserRegistryTests` passed with 55 tests.
+- Re-ran focused coverage and changed-line coverage: `TOTAL 100.00% 50/50`.
+- The final pre-commit performance report for the amended PR branch is recorded in the PR evidence.
+
 ## Known Deferred Work
 
 - Worker-side parser recovery and retry/nudge behavior remain part of broader #1384/#1382 follow-up work.

--- a/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceReport.swift
+++ b/services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceReport.swift
@@ -12,19 +12,40 @@ public struct OpenAIConformanceRow: Codable, Sendable, Equatable {
     public let expectedBehavior: String
     public let observedStatus: OpenAIConformanceObservedStatus
     public let observedReason: String
+    public let modelFamily: String?
+    public let parserMode: String?
+    public let tagDialect: String?
+    public let requestedParser: String?
+    public let resolvedParser: String?
+    public let parserFallbackMode: String?
+    public let parserRefusalReason: String?
 
     public init(
         field: String,
         route: String,
         expectedBehavior: String,
         observedStatus: OpenAIConformanceObservedStatus,
-        observedReason: String
+        observedReason: String,
+        modelFamily: String? = nil,
+        parserMode: String? = nil,
+        tagDialect: String? = nil,
+        requestedParser: String? = nil,
+        resolvedParser: String? = nil,
+        parserFallbackMode: String? = nil,
+        parserRefusalReason: String? = nil
     ) {
         self.field = field
         self.route = route
         self.expectedBehavior = expectedBehavior
         self.observedStatus = observedStatus
         self.observedReason = observedReason
+        self.modelFamily = modelFamily
+        self.parserMode = parserMode
+        self.tagDialect = tagDialect
+        self.requestedParser = requestedParser
+        self.resolvedParser = resolvedParser
+        self.parserFallbackMode = parserFallbackMode
+        self.parserRefusalReason = parserRefusalReason
     }
 
     enum CodingKeys: String, CodingKey {
@@ -33,6 +54,13 @@ public struct OpenAIConformanceRow: Codable, Sendable, Equatable {
         case expectedBehavior = "expected_behavior"
         case observedStatus = "observed_status"
         case observedReason = "observed_reason"
+        case modelFamily = "model_family"
+        case parserMode = "parser_mode"
+        case tagDialect = "tag_dialect"
+        case requestedParser = "requested_parser"
+        case resolvedParser = "resolved_parser"
+        case parserFallbackMode = "parser_fallback_mode"
+        case parserRefusalReason = "parser_refusal_reason"
     }
 }
 

--- a/services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift
@@ -77,6 +77,27 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
         self.effectiveConfigHash = effectiveConfigHash
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        compatSurface = try container.decode(String.self, forKey: .compatSurface)
+        streamMode = try container.decode(String.self, forKey: .streamMode)
+        reasoningMode = try container.decode(String.self, forKey: .reasoningMode)
+        reasoningSource = try container.decode(String.self, forKey: .reasoningSource)
+        reasoningEffort = try container.decode(String.self, forKey: .reasoningEffort)
+        toolParserMode = try container.decode(String.self, forKey: .toolParserMode)
+        toolParserSource = try container.decode(String.self, forKey: .toolParserSource)
+        requestedParser = try container.decodeIfPresent(String.self, forKey: .requestedParser) ?? "none"
+        resolvedParser = try container.decodeIfPresent(String.self, forKey: .resolvedParser) ?? "none"
+        parserFallbackMode = try container.decodeIfPresent(String.self, forKey: .parserFallbackMode) ?? ""
+        parserRefusalReason = try container.decodeIfPresent(String.self, forKey: .parserRefusalReason) ?? ""
+        toolNamespaces = try container.decode([String].self, forKey: .toolNamespaces)
+        toolChoiceRequested = try container.decode(String.self, forKey: .toolChoiceRequested)
+        toolChoiceResolved = try container.decode(String.self, forKey: .toolChoiceResolved)
+        structuredOutputMode = try container.decode(String.self, forKey: .structuredOutputMode)
+        outputModalities = try container.decode([String].self, forKey: .outputModalities)
+        effectiveConfigHash = try container.decode(String.self, forKey: .effectiveConfigHash)
+    }
+
     public init(shapedRequest: ShapedTextRequest) {
         let fields = Self.hashFields(shapedRequest: shapedRequest)
         let effectiveConfigHash = cacheScopeHash(Self.canonicalJSONString(fields))

--- a/services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift
+++ b/services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift
@@ -8,6 +8,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
     public let reasoningEffort: String
     public let toolParserMode: String
     public let toolParserSource: String
+    public let requestedParser: String
+    public let resolvedParser: String
+    public let parserFallbackMode: String
+    public let parserRefusalReason: String
     public let toolNamespaces: [String]
     public let toolChoiceRequested: String
     public let toolChoiceResolved: String
@@ -23,6 +27,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
         case reasoningEffort = "reasoning_effort"
         case toolParserMode = "tool_parser_mode"
         case toolParserSource = "tool_parser_source"
+        case requestedParser = "requested_parser"
+        case resolvedParser = "resolved_parser"
+        case parserFallbackMode = "parser_fallback_mode"
+        case parserRefusalReason = "parser_refusal_reason"
         case toolNamespaces = "tool_namespaces"
         case toolChoiceRequested = "tool_choice_requested"
         case toolChoiceResolved = "tool_choice_resolved"
@@ -39,6 +47,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
         reasoningEffort: String,
         toolParserMode: String,
         toolParserSource: String,
+        requestedParser: String,
+        resolvedParser: String,
+        parserFallbackMode: String,
+        parserRefusalReason: String,
         toolNamespaces: [String],
         toolChoiceRequested: String,
         toolChoiceResolved: String,
@@ -53,6 +65,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
         self.reasoningEffort = reasoningEffort
         self.toolParserMode = toolParserMode
         self.toolParserSource = toolParserSource
+        self.requestedParser = requestedParser
+        self.resolvedParser = resolvedParser
+        self.parserFallbackMode = parserFallbackMode
+        self.parserRefusalReason = parserRefusalReason
         self.toolNamespaces = toolNamespaces
         self.toolChoiceRequested = toolChoiceRequested
         self.toolChoiceResolved = toolChoiceResolved
@@ -72,6 +88,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
             reasoningEffort: fields["reasoning_effort"] as? String ?? "",
             toolParserMode: fields["tool_parser_mode"] as? String ?? "",
             toolParserSource: fields["tool_parser_source"] as? String ?? "",
+            requestedParser: fields["requested_parser"] as? String ?? "",
+            resolvedParser: fields["resolved_parser"] as? String ?? "",
+            parserFallbackMode: fields["parser_fallback_mode"] as? String ?? "",
+            parserRefusalReason: fields["parser_refusal_reason"] as? String ?? "",
             toolNamespaces: fields["tool_namespaces"] as? [String] ?? [],
             toolChoiceRequested: fields["tool_choice_requested"] as? String ?? "",
             toolChoiceResolved: fields["tool_choice_resolved"] as? String ?? "",
@@ -94,6 +114,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
             "melix.compat.reasoning_effort": reasoningEffort,
             "melix.compat.tool_parser_mode": toolParserMode,
             "melix.compat.tool_parser_source": toolParserSource,
+            "melix.compat.requested_parser": requestedParser,
+            "melix.compat.resolved_parser": resolvedParser,
+            "melix.compat.parser_fallback_mode": parserFallbackMode,
+            "melix.compat.parser_refusal_reason": parserRefusalReason,
             "melix.compat.tool_namespaces": toolNamespaces.joined(separator: ","),
             "melix.compat.tool_choice_requested": toolChoiceRequested,
             "melix.compat.tool_choice_resolved": toolChoiceResolved,
@@ -113,6 +137,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
             "reasoning_effort": reasoningEffort,
             "tool_parser_mode": toolParserMode,
             "tool_parser_source": toolParserSource,
+            "requested_parser": requestedParser,
+            "resolved_parser": resolvedParser,
+            "parser_fallback_mode": parserFallbackMode,
+            "parser_refusal_reason": parserRefusalReason,
             "tool_namespaces": toolNamespaces,
             "tool_choice_requested": toolChoiceRequested,
             "tool_choice_resolved": toolChoiceResolved,
@@ -124,6 +152,12 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
 
     private static func hashFields(shapedRequest: ShapedTextRequest) -> [String: Any] {
         let toolChoiceRequested = shapedRequest.toolChoice ?? ""
+        let requestedParser = if let toolParser = shapedRequest.toolParser,
+                                 toolParser.source == "request" {
+            toolParser.mode.rawValue
+        } else {
+            "none"
+        }
         return [
             "compat_surface": compatSurface(for: shapedRequest.endpoint),
             "stream_mode": shapedRequest.stream ? "stream" : "non_stream",
@@ -132,6 +166,10 @@ public struct TextCompatibilityPolicyReceipt: Codable, Sendable, Equatable {
             "reasoning_effort": shapedRequest.reasoningEffort ?? "",
             "tool_parser_mode": shapedRequest.toolParser?.mode.rawValue ?? "none",
             "tool_parser_source": shapedRequest.toolParser?.source ?? "none",
+            "requested_parser": requestedParser,
+            "resolved_parser": shapedRequest.toolParser?.mode.rawValue ?? "none",
+            "parser_fallback_mode": shapedRequest.toolParser?.fallbackMode?.rawValue ?? "",
+            "parser_refusal_reason": shapedRequest.toolParserSuppressedReason ?? "",
             "tool_namespaces": shapedRequest.toolParser?.namespaces ?? [],
             "tool_choice_requested": toolChoiceRequested,
             "tool_choice_resolved": resolvedToolChoice(requested: toolChoiceRequested, hasTools: !shapedRequest.tools.isEmpty),

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -278,6 +278,38 @@ struct ToolParserRegistryTests {
         #expect(Set(receiptObject.keys) == compatReceiptFieldNames())
     }
 
+    @Test("compatibility policy receipts decode legacy payloads without parser policy fields")
+    func compatibilityPolicyReceiptsDecodeLegacyPayloadsWithoutParserPolicyFields() throws {
+        let payload = Data(
+            """
+            {
+              "compat_surface": "openai.chat.completions",
+              "stream_mode": "non_stream",
+              "reasoning_mode": "disabled",
+              "reasoning_source": "default",
+              "reasoning_effort": "",
+              "tool_parser_mode": "none",
+              "tool_parser_source": "none",
+              "tool_namespaces": [],
+              "tool_choice_requested": "",
+              "tool_choice_resolved": "none",
+              "structured_output_mode": "text",
+              "output_modalities": ["text"],
+              "effective_config_hash": "legacy-hash"
+            }
+            """.utf8
+        )
+
+        let receipt = try JSONDecoder().decode(TextCompatibilityPolicyReceipt.self, from: payload)
+
+        #expect(receipt.requestedParser == "none")
+        #expect(receipt.resolvedParser == "none")
+        #expect(receipt.parserFallbackMode == "")
+        #expect(receipt.parserRefusalReason == "")
+        #expect(receipt.compatSurface == "openai.chat.completions")
+        #expect(receipt.effectiveConfigHash == "legacy-hash")
+    }
+
     @Test("translated text requests attach prompt context boundary receipts")
     func translatedTextRequestsAttachPromptContextBoundaryReceipts() throws {
         let translator = ChatRequestTranslator(requestIDGenerator: { "req-prompt-context" })

--- a/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
+++ b/services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift
@@ -258,6 +258,10 @@ struct ToolParserRegistryTests {
         #expect(ext["melix.compat.reasoning_effort"] == "low")
         #expect(ext["melix.compat.tool_parser_mode"] == "qwen")
         #expect(ext["melix.compat.tool_parser_source"] == "request")
+        #expect(ext["melix.compat.requested_parser"] == "qwen")
+        #expect(ext["melix.compat.resolved_parser"] == "qwen")
+        #expect(ext["melix.compat.parser_fallback_mode"] == "")
+        #expect(ext["melix.compat.parser_refusal_reason"] == "")
         #expect(ext["melix.compat.tool_namespaces"] == "tools.search")
         #expect(ext["melix.compat.tool_choice_requested"] == "required")
         #expect(ext["melix.compat.tool_choice_resolved"] == "required")
@@ -265,6 +269,10 @@ struct ToolParserRegistryTests {
         #expect(ext["melix.compat.output_modalities"] == "text")
         #expect(ext["melix.compat.effective_config_hash"]?.isEmpty == false)
         #expect(receipt.contains(#""compat_surface":"openai.chat.completions""#))
+        #expect(receipt.contains(#""requested_parser":"qwen""#))
+        #expect(receipt.contains(#""resolved_parser":"qwen""#))
+        #expect(receipt.contains(#""parser_fallback_mode":"""#))
+        #expect(receipt.contains(#""parser_refusal_reason":"""#))
         #expect(receipt.contains(#""tool_namespaces":["tools.search"]"#))
         #expect(receipt.contains(#""effective_config_hash":"\#(ext["melix.compat.effective_config_hash"] ?? "")""#))
         #expect(Set(receiptObject.keys) == compatReceiptFieldNames())
@@ -1312,6 +1320,10 @@ struct ToolParserRegistryTests {
             "reasoning_effort",
             "tool_parser_mode",
             "tool_parser_source",
+            "requested_parser",
+            "resolved_parser",
+            "parser_fallback_mode",
+            "parser_refusal_reason",
             "tool_namespaces",
             "tool_choice_requested",
             "tool_choice_resolved",

--- a/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
+++ b/services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
@@ -352,6 +352,33 @@ struct OpenAIConformanceMatrixTests {
         #expect(report.summary.skipped == 1)
     }
 
+    @Test("conformance report rows can carry parser policy fixture metadata")
+    func conformanceReportRowsCanCarryParserPolicyFixtureMetadata() throws {
+        let row = OpenAIConformanceRow(
+            field: "tool_call_parser_policy:qwen3moe:qwen:qwen_xml_tool_call",
+            route: "/v1/chat/completions -> parser policy evidence",
+            expectedBehavior: "parser policy fixtures expose model family, parser mode, tag dialect, and resolved parser receipt evidence.",
+            observedStatus: .pass,
+            observedReason: "parser_policy=resolved",
+            modelFamily: "qwen3moe",
+            parserMode: "qwen",
+            tagDialect: "qwen_xml_tool_call",
+            requestedParser: "qwen",
+            resolvedParser: "qwen",
+            parserFallbackMode: "xml",
+            parserRefusalReason: ""
+        )
+        let reportJSON = try OpenAIConformanceReport(rows: [row]).jsonString()
+
+        #expect(reportJSON.contains(#""model_family":"qwen3moe""#))
+        #expect(reportJSON.contains(#""parser_mode":"qwen""#))
+        #expect(reportJSON.contains(#""tag_dialect":"qwen_xml_tool_call""#))
+        #expect(reportJSON.contains(#""requested_parser":"qwen""#))
+        #expect(reportJSON.contains(#""resolved_parser":"qwen""#))
+        #expect(reportJSON.contains(#""parser_fallback_mode":"xml""#))
+        #expect(reportJSON.contains(#""parser_refusal_reason":"""#))
+    }
+
     @Test("payload model routes to selected served model in active roster")
     func payloadModelRoutesToSelectedServedModelInActiveRoster() async throws {
         var primary = warmConformanceModel(id: "melix-primary")
@@ -1179,6 +1206,106 @@ struct OpenAIConformanceMatrixTests {
         #expect(streamPayload.contains("data: [DONE]"))
     }
 
+    @Test("tool-call parser policy fixtures carry parser and dialect evidence")
+    func toolCallParserPolicyFixturesCarryParserAndDialectEvidence() async throws {
+        struct Fixture: Sendable {
+            let scenario: String
+            let modelFamily: String
+            let parserMode: String
+            let tagDialect: String
+            let stream: Bool
+        }
+
+        let fixtures = [
+            Fixture(
+                scenario: "non_stream_unclosed_tool_call",
+                modelFamily: "qwen3moe",
+                parserMode: "qwen",
+                tagDialect: "qwen_xml_tool_call",
+                stream: false
+            ),
+            Fixture(
+                scenario: "stream_split_tool_call_marker",
+                modelFamily: "qwen3moe",
+                parserMode: "qwen",
+                tagDialect: "qwen_pipe_tool_call",
+                stream: true
+            ),
+        ]
+        var reportRows: [OpenAIConformanceRow] = []
+
+        for fixture in fixtures {
+            let requestID = "req-parser-policy-\(fixture.scenario)"
+            let worker = RecordingConformanceWorker(
+                requestID: requestID,
+                events: parserPolicyEvents(requestID: requestID, stream: fixture.stream)
+            )
+            var model = warmConformanceModel(id: "melix-dev-text")
+            model.settings.ext["text_family_id"] = fixture.modelFamily
+
+            let response = try await Self.handler(worker: worker, model: model).handle(
+                HTTPRequest(
+                    method: .post,
+                    path: "/v1/chat/completions",
+                    headers: ["content-type": "application/json"],
+                    body: Data(Self.body(extra: parserPolicyExtra(stream: fixture.stream, parserMode: fixture.parserMode)).utf8)
+                )
+            )
+            let payload = try await collectConformanceBody(response.body)
+            let request = try #require(await worker.lastGenerateRequest)
+            let ext = request.execution.ext
+
+            #expect(response.statusCode == 200)
+            #expect(ext["melix.tool_parser.mode"] == fixture.parserMode)
+            #expect(ext["melix.tool_parser.source"] == "request")
+            #expect(ext["melix.tool_parser.namespaces"] == "tools.search")
+            #expect(ext["melix.tool_parser.fallback_mode"] == "xml")
+            #expect(ext["melix.compat.requested_parser"] == fixture.parserMode)
+            #expect(ext["melix.compat.resolved_parser"] == fixture.parserMode)
+            #expect(ext["melix.compat.parser_fallback_mode"] == "xml")
+            #expect(ext["melix.compat.parser_refusal_reason"] == "")
+            #expect(payload.contains(#""tool_calls""#) == false)
+            #expect(payload.contains("ghost") == false)
+            expectNoOpenAIWireLeaks(payload)
+
+            let rowPassed = response.statusCode == 200
+                && ext["melix.compat.requested_parser"] == fixture.parserMode
+                && ext["melix.compat.resolved_parser"] == fixture.parserMode
+                && ext["melix.compat.parser_fallback_mode"] == "xml"
+                && !payload.contains(#""tool_calls""#)
+                && !payload.contains("ghost")
+            reportRows.append(
+                OpenAIConformanceRow(
+                    field: "tool_call_parser_policy:\(fixture.modelFamily):\(fixture.parserMode):\(fixture.tagDialect):\(fixture.scenario)",
+                    route: "/v1/chat/completions -> parser policy evidence",
+                    expectedBehavior: "Malformed backend tool-call text is suppressed while parser policy receipts identify the requested and resolved parser.",
+                    observedStatus: rowPassed ? .pass : .fail,
+                    observedReason: "scenario=\(fixture.scenario);status=\(response.statusCode)",
+                    modelFamily: model.settings.ext["text_family_id"],
+                    parserMode: ext["melix.tool_parser.mode"],
+                    tagDialect: fixture.tagDialect,
+                    requestedParser: ext["melix.compat.requested_parser"],
+                    resolvedParser: ext["melix.compat.resolved_parser"],
+                    parserFallbackMode: ext["melix.compat.parser_fallback_mode"],
+                    parserRefusalReason: ext["melix.compat.parser_refusal_reason"]
+                )
+            )
+        }
+
+        let report = OpenAIConformanceReport(rows: reportRows)
+        #expect(report.summary.passed == fixtures.count)
+        #expect(report.summary.failed == 0)
+        let reportJSON = try report.jsonString()
+        #expect(reportJSON.contains(#""model_family":"qwen3moe""#))
+        #expect(reportJSON.contains(#""parser_mode":"qwen""#))
+        #expect(reportJSON.contains(#""tag_dialect":"qwen_xml_tool_call""#))
+        #expect(reportJSON.contains(#""tag_dialect":"qwen_pipe_tool_call""#))
+        #expect(reportJSON.contains(#""requested_parser":"qwen""#))
+        #expect(reportJSON.contains(#""resolved_parser":"qwen""#))
+        #expect(reportJSON.contains(#""parser_fallback_mode":"xml""#))
+        #expect(reportJSON.contains(#""parser_refusal_reason":"""#))
+    }
+
     @Test("legacy function_call codable values normalize into stable tool choices")
     func legacyFunctionCallCodableValuesNormalizeIntoStableToolChoices() throws {
         let decoder = JSONDecoder()
@@ -1444,6 +1571,48 @@ private func orderedConformanceRanges(in payload: String, needles: [String]) -> 
         cursor = range.upperBound
     }
     return true
+}
+
+private func parserPolicyExtra(stream: Bool, parserMode: String) -> String {
+    """
+    "stream": \(stream ? "true" : "false"),
+    "tool_parser": {
+      "mode": "\(parserMode)",
+      "namespaces": ["tools.search"],
+      "xml_fallback": true
+    },
+    "tools": [\(weatherToolJSON)],
+    "tool_choice": "auto"
+    """
+}
+
+private func parserPolicyEvents(requestID: String, stream: Bool) -> [Melix_Worker_V1_ExecuteEvent] {
+    if stream {
+        return [
+            makeTokenEvent(requestID: requestID, seq: 1, text: "Visible before "),
+            makeTokenEvent(requestID: requestID, seq: 2, text: "<|tool_"),
+            makeTokenEvent(
+                requestID: requestID,
+                seq: 3,
+                text: #"call>{"name":"ghost","arguments":{"q":"leak"}}"#
+            ),
+            makeCompletedEvent(
+                requestID: requestID,
+                seq: 4,
+                finishReason: "stop",
+                assistantText: #"Visible before <|tool_call>{"name":"ghost","arguments":{"q":"leak"}}"#
+            ),
+        ]
+    }
+
+    return [
+        makeCompletedEvent(
+            requestID: requestID,
+            seq: 1,
+            finishReason: "stop",
+            assistantText: #"Visible before <tool_call>{"name":"ghost","arguments":{"q":"leak"}}"#
+        ),
+    ]
 }
 
 private func expectNoOpenAIWireLeaks(_ payload: String) {


### PR DESCRIPTION
## Summary
- Extend OpenAI conformance rows with optional parser-policy metadata for model family, parser mode, tag dialect, requested/resolved parser, fallback mode, and refusal reason.
- Add request-local compatibility receipt fields for parser policy evidence and include them in the effective config hash input.
- Add stream and non-stream malformed Qwen tool-call fixtures that prove raw delimiters are suppressed and no backend skeleton is promoted into OpenAI `tool_calls`.
- Preserve decoding compatibility for legacy compatibility receipt JSON that predates the parser-policy fields.

Refs #1384.

## Plan or Spec
- `docs/plans/2026-07-11-issue-1384-tool-call-parser-policy-conformance.md`
- `docs/adr/0002-openai-conformance-at-control-plane-boundary.md`

## Commands Run
```text
HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests/conformanceReportRowsCanCarryParserPolicyFixtureMetadata
# red before implementation: compile failed because OpenAIConformanceRow did not accept parser metadata arguments
# green after implementation: passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter ToolParserRegistryTests/translatedTextRequestsAttachRequestLocalCompatibilityPolicyReceipts
# red before implementation: failed because the new melix.compat parser fields and JSON receipt fields were absent
# green after implementation: passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter OpenAIConformanceMatrixTests/toolCallParserPolicyFixturesCarryParserAndDialectEvidence
# passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
# passed: 54 tests in 2 suites

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
# passed: 54 tests in 2 suites

UV_PYTHON=3.12 uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceReport.swift services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
# passed: TOTAL 100.00% 208/208

git diff --check
# passed

make swift-test
# passed

make py-test
# passed: 4908 passed, 14 skipped, 2 warnings

make integration-test
# passed: 123 passed, 1 skipped

.githooks/pre-commit
# passed on final staged diff
# make swift-test rc=0 elapsed=149.4s
# make py-test rc=0: 4908 passed, 14 skipped, 2 warnings in 175.23s
# make integration-test rc=0: 123 passed, 1 skipped in 418.31s
# performance report status: ok; regressions=0; context_regressions=0; verification_failures=0

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'compatibilityPolicyReceiptsDecodeLegacyPayloadsWithoutParserPolicyFields'
# review follow-up red: failed with DecodingError.keyNotFound for requested_parser
# review follow-up green: passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
# review follow-up passed: 55 tests in 2 suites

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --enable-code-coverage --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
# review follow-up passed: 55 tests in 2 suites

UV_PYTHON=3.12 uv run --python 3.12 python scripts/swift_changed_line_coverage.py --binary services/control-plane-swift/.build/arm64-apple-macosx/debug/MelixControlPlanePackageTests.xctest/Contents/MacOS/MelixControlPlanePackageTests --profdata services/control-plane-swift/.build/arm64-apple-macosx/debug/codecov/default.profdata services/control-plane-swift/Sources/HTTPGateway/OpenAI/OpenAIConformanceReport.swift services/control-plane-swift/Sources/Requests/TextCompatibilityPolicyReceipt.swift services/control-plane-swift/Tests/ControlPlaneTests/ToolParserRegistryTests.swift services/control-plane-swift/Tests/HTTPGatewayTests/OpenAIConformanceMatrixTests.swift
# review follow-up passed: TOTAL 100.00% 50/50

git diff --cached --check
# review follow-up passed

.githooks/pre-commit
# review follow-up passed on final staged diff
# make swift-test rc=0 elapsed=222.1s
# make py-test rc=0: 4908 passed, 14 skipped, 2 warnings in 176.83s
# make integration-test rc=0: 123 passed, 1 skipped in 452.20s
# performance report status: ok; changed files=3; selected probes=0; regressions=0; context_regressions=0; verification_failures=0
# performance report path: .runtime/pre-commit-performance/20260711-114828-6c4e28f3/report/report.md

git fetch origin main
git merge --no-edit origin/main
# post-merge update from origin/main dfdc400b completed without conflicts

git diff --check
# post-merge passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
# post-merge passed: 55 tests in 2 suites

git fetch origin main
git merge --no-edit origin/main
# second post-merge update from origin/main 84de0ef8 completed without conflicts

git diff --check
# second post-merge passed

HOME="$PWD/.swift-home" CLANG_MODULE_CACHE_PATH="$PWD/.build/ModuleCache.noindex" swift test --package-path services/control-plane-swift --filter 'OpenAIConformanceMatrixTests|ToolParserRegistryTests'
# second post-merge passed: 55 tests in 2 suites
```

## Coverage and Metrics
- Initial parser-policy changed-line coverage: `TOTAL 100.00% 208/208`.
- Initial file coverage: `OpenAIConformanceReport.swift 100.00% 7/7`, `TextCompatibilityPolicyReceipt.swift 100.00% 26/26`, `ToolParserRegistryTests.swift 100.00% 12/12`, `OpenAIConformanceMatrixTests.swift 100.00% 163/163`.
- Review follow-up changed-line coverage: `TOTAL 100.00% 50/50`; `TextCompatibilityPolicyReceipt.swift 100.00% 20/20`, `ToolParserRegistryTests.swift 100.00% 30/30`.
- Initial PR scoped performance report: `Status: ok`; changed files `5`; selected probes `0`; direct/gated probes `0`; regressions `0`; context regressions `0`; verification failures `0`; path `.runtime/pre-commit-performance/20260711-111001-4d3915c0/report/report.md`.
- Review follow-up PR scoped performance report: `Status: ok`; changed files `3`; selected probes `0`; direct/gated probes `0`; regressions `0`; context regressions `0`; verification failures `0`; path `.runtime/pre-commit-performance/20260711-114828-6c4e28f3/report/report.md`.
- Observability mode: evidence. This change extends conformance report rows and compatibility receipts; it does not add runtime metrics or debug probes.
- Probe overhead: N/A, no registered performance probes were selected and no new runtime probe was added.

## Known Gaps
- Worker-side parser recovery and retry/nudge behavior remain deferred to broader #1384/#1382 follow-up work.
- Real remote-provider proxy parity is out of scope for this in-process conformance slice.
- Additional parser families can reuse the metadata fields after their backend parser behavior is stable enough to pin.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
