### PR TITLE
perf: streamline trajectory manifest pathlike loads

### DIFF
--- a/docs/plans/2026-07-11-trajectory-manifest-pathlike-fspath.md
+++ b/docs/plans/2026-07-11-trajectory-manifest-pathlike-fspath.md
@@ -1,0 +1,17 @@
+# Trajectory manifest pathlike fspath performance slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.trajectory_provenance.load_trajectory_provenance_from_snapshot_manifest(...)` in `services/mlx-worker-python/worker/trajectory_provenance.py`.
+
+The affected path is covered by registered PR-scoped probe `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches the trajectory provenance module, focused tests, probe script, and registry.
+
+## Change
+
+Path-like manifest inputs now use `os.fspath(...)` and the same direct binary `open(...).read()` path used by exact `str` and `Path` inputs. This preserves the existing pathlike contract while avoiding the fallback `Path(...)` wrapper allocation and `Path.read_bytes()` bound-method path for custom `os.PathLike` manifest references.
+
+## Verification Plan
+
+Run the registered focused trajectory manifest tests, changed-scope coverage, `git diff --check`, and the registered `trajectory-manifest-json-load` probe locally on Linux before opening the PR. The PR-scoped performance workflow remains the merge gate for the registered probe report.
+
+No Swift runtime behavior is changed or locally claimed by this slice.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -309,6 +309,7 @@ def test_load_trajectory_provenance_from_snapshot_manifest_path_uses_direct_open
 
 def test_load_trajectory_provenance_from_snapshot_manifest_keeps_pathlike_support(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class PathLikeManifest:
         def __fspath__(self) -> str:
@@ -327,6 +328,11 @@ def test_load_trajectory_provenance_from_snapshot_manifest_keeps_pathlike_suppor
             }
         ).encode("utf-8")
     )
+
+    def fail_path_read_bytes(_self: Path) -> bytes:
+        raise AssertionError("pathlike manifest paths should not allocate Path.read_bytes")
+
+    monkeypatch.setattr(trajectory_provenance_module, "_PATH_READ_BYTES", fail_path_read_bytes)
 
     assert load_trajectory_provenance_from_snapshot_manifest(PathLikeManifest()) == {
         "trajectory_dataset_id": "agentic-snapshot",

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -11,6 +11,7 @@ from typing import Any
 _JSON_LOADS = json.loads
 _PATH_READ_BYTES = Path.read_bytes
 _OPEN = _builtin_open
+_OS_FSPATH = os.fspath
 _STR = str
 _TYPE = type
 
@@ -347,22 +348,15 @@ def _trajectory_provenance_from_snapshot_manifest(
 def load_trajectory_provenance_from_snapshot_manifest(
     manifest_path: Path | str | os.PathLike[str],
 ) -> dict[str, Any]:
-    read_bytes = _PATH_READ_BYTES
     open_file = _OPEN
     loads = _JSON_LOADS
     extract_provenance = _trajectory_provenance_from_snapshot_manifest
     if type(manifest_path) is str:
         manifest_path_text = manifest_path
-        with open_file(manifest_path, "rb") as manifest_file:
-            payload = loads(manifest_file.read())
-    elif isinstance(manifest_path, Path):
-        manifest_path_text = _STR(manifest_path)
-        with open_file(manifest_path, "rb") as manifest_file:
-            payload = loads(manifest_file.read())
     else:
-        manifest_path = Path(manifest_path)
-        manifest_path_text = _STR(manifest_path)
-        payload = loads(read_bytes(manifest_path))
+        manifest_path_text = _OS_FSPATH(manifest_path)
+    with open_file(manifest_path_text, "rb") as manifest_file:
+        payload = loads(manifest_file.read())
     if type(payload) is dict:
         return extract_provenance(
             payload,


### PR DESCRIPTION
## Summary
- Streamline trajectory snapshot manifest loading for custom `os.PathLike` inputs by using `os.fspath(...)` and the existing direct binary `open(...).read()` path.
- Preserve exact `str` and `Path` behavior while avoiding the fallback `Path(...)` wrapper allocation for pathlike manifest references.
- Strengthen focused regression coverage so pathlike inputs do not fall back to `Path.read_bytes()`.

## Plan or Spec
- `docs/plans/2026-07-11-trajectory-manifest-pathlike-fspath.md`
- Registered probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Initial registered command without PYTHONPATH failed in this locked-down shell because repo/service import roots were absent; reran with a temporary local pytest wrapper that inserts the same repo roots without exporting PYTHONPATH.
uv run --project services/mlx-worker-python pytest -q ...
# exit 4: ModuleNotFoundError for packages/worker imports

uv run --project services/mlx-worker-python python3 .runtime/pytest_with_repo_path.py -q \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_string_path_uses_direct_open \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_path_uses_direct_open \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_keeps_pathlike_support \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_defaulted_schema_and_split \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_path_falls_back_for_defaulted_required_fields \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass \
  services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands \
  services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 19 passed in 1.47s

uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance .runtime/pytest_with_repo_path.py -q [same focused tests] && \
  uv run --project services/mlx-worker-python coverage json -o coverage.json && \
  python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# exit 0; changed_line_coverage=100.00%; TOTAL 4 0 100%

MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT=$PWD uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# exit 0; old_mean_ms=1634.632668015547; new_mean_ms=769.1425340250134; delta_ms=-865.4901339905336; speedup=2.125266248716375; new_peak_bytes_mean=53944.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines.
- Registered local probe (`trajectory-manifest-json-load`, Linux): `old_mean_ms=1634.632668015547`, `new_mean_ms=769.1425340250134`, `delta_ms=-865.4901339905336`, `speedup=2.125266248716375`, `new_peak_bytes_mean=53944.0`.
- Observability mode: `N/A` (no observability changes).
- Probe overhead: `N/A` (existing registered synthetic probe reused).

## Known Gaps
- Local verification was Linux/Python-only. No Swift runtime behavior changed.
- The final merge gate is the PR-scoped performance workflow report for the registered probe on GitHub Actions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
