### PR TITLE
perf: reuse runtime export diagnostic row paths

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -247,6 +247,12 @@ target-relative resolution, file read, and source-line extension behavior, but
 avoids repeated protobuf attribute lookups for rows that enter the diagnostic
 source collection path.
 
+A follow-up 2026-07-11 runtime-log predicate slice keeps the same runtime-log
+row eligibility contract while passing the caller's already-read row path into
+`_is_runtime_log_row()`. This avoids a second protobuf `path` attribute lookup
+when the generated, required, and intermediate file rows are scanned for log
+sources, while role and retention-class checks remain unchanged.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -36,6 +36,7 @@ from worker.productization.export_target_diagnostics import (
     _has_named_secret_marker,
     _has_private_text_line_marker,
     _has_secret_redaction_marker,
+    _is_runtime_log_row,
     _split_source_lines,
     _target_relative_text,
 )
@@ -88,6 +89,17 @@ def test_export_target_diagnostics_source_line_extension_matches_split_helper() 
 
     _extend_source_lines(lines, "logs/empty.log", "")
     assert len(lines) == 2
+
+
+def test_export_target_diagnostics_runtime_log_row_reuses_caller_path() -> None:
+    row = SimpleNamespace(
+        role=export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_UNSPECIFIED,
+        retention_class=export_target_manifest_pb2.EXPORT_RETENTION_CLASS_UNSPECIFIED,
+        path="not-used-by-helper",
+    )
+
+    assert _is_runtime_log_row(row, "logs/ollama-create.log") is True
+    assert _is_runtime_log_row(row, "artifacts/model.gguf") is False
 
 
 def test_export_target_diagnostics_target_relative_text_handles_root_slash_boundary() -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -501,7 +501,7 @@ def _collect_source_lines(
     for rows in (manifest.generated_files, manifest.required_files, manifest.intermediate_files):
         for row in rows:
             row_path = row.path
-            if not _is_runtime_log_row(row):
+            if not _is_runtime_log_row(row, row_path):
                 continue
             if row_path in seen_paths:
                 continue
@@ -548,11 +548,11 @@ def _collect_source_lines(
     return lines
 
 
-def _is_runtime_log_row(row: export_target_manifest_pb2.ExportTargetFile) -> bool:
+def _is_runtime_log_row(row: export_target_manifest_pb2.ExportTargetFile, row_path: str) -> bool:
     return (
         row.role == export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_RUNTIME_LOG
         or row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_RUNTIME_LOG
-        or row.path.startswith("logs/")
+        or row_path.startswith("logs/")
     )
 
 


### PR DESCRIPTION
## Summary
- Reuses the already-read manifest row path when checking runtime export diagnostic log rows.
- Adds a regression test for the runtime-log row predicate path argument.
- Updates the runtime export diagnostic parser plan for this focused performance slice.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 83 passed in 0.70s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py
# 83 passed in 1.56s; TOTAL 6 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# {"diagnostic_latency_ms": 8.196480106562376, "elapsed_ms_mean": 2900.3138334024698, "peak_bytes_mean": 203326.0, ...}

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-runtime-export-diagnostic-parser-base-20260711 --head-repo "$PWD" --output .runtime/perf/runtime-export-diagnostic-parser-local.json
# completed with test_ok=true, coverage_ok=true, base_probe.ok=true, head_probe.ok=true

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Registered probe: `runtime-export-diagnostic-parser`.
- Local registered base/head probe result:
  - `diagnostic_latency_ms`: base `8.168466039933264`, head `7.197595899924636` (`-0.970870140008628`, about `11.89%` lower).
  - `elapsed_ms_mean`: base `2894.2235722206533`, head `2916.143949958496` (`+21.9203777378425`, about `0.76%` higher; within the 5% warning threshold and dominated by temp-dir/report workload noise).
  - `peak_bytes_mean`: base `198458.0`, head `203726.6` (`+5268.6`, about `2.65%` higher; within the 5% warning threshold).
  - Functional counters remained stable: `diagnostic_parser_coverage=1.0`, `parsed_failure_count=27.0`, `unknown_failure_count=1.0`, `target_count=4.0`, `diagnosis_code_count=9.0`.
- GitHub Actions PR-scoped performance must run as the merge gate.

## Known Gaps
- Local Linux validation covers Python behavior and the registered command-json probe. CI remains required for the official PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
