### PR TITLE
revert: restore runtime export diagnostic row paths

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -247,12 +247,6 @@ target-relative resolution, file read, and source-line extension behavior, but
 avoids repeated protobuf attribute lookups for rows that enter the diagnostic
 source collection path.
 
-A follow-up 2026-07-11 runtime-log predicate slice keeps the same runtime-log
-row eligibility contract while passing the caller's already-read row path into
-`_is_runtime_log_row()`. This avoids a second protobuf `path` attribute lookup
-when the generated, required, and intermediate file rows are scanned for log
-sources, while role and retention-class checks remain unchanged.
-
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -36,7 +36,6 @@ from worker.productization.export_target_diagnostics import (
     _has_named_secret_marker,
     _has_private_text_line_marker,
     _has_secret_redaction_marker,
-    _is_runtime_log_row,
     _split_source_lines,
     _target_relative_text,
 )
@@ -89,17 +88,6 @@ def test_export_target_diagnostics_source_line_extension_matches_split_helper() 
 
     _extend_source_lines(lines, "logs/empty.log", "")
     assert len(lines) == 2
-
-
-def test_export_target_diagnostics_runtime_log_row_reuses_caller_path() -> None:
-    row = SimpleNamespace(
-        role=export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_UNSPECIFIED,
-        retention_class=export_target_manifest_pb2.EXPORT_RETENTION_CLASS_UNSPECIFIED,
-        path="not-used-by-helper",
-    )
-
-    assert _is_runtime_log_row(row, "logs/ollama-create.log") is True
-    assert _is_runtime_log_row(row, "artifacts/model.gguf") is False
 
 
 def test_export_target_diagnostics_target_relative_text_handles_root_slash_boundary() -> None:

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -501,7 +501,7 @@ def _collect_source_lines(
     for rows in (manifest.generated_files, manifest.required_files, manifest.intermediate_files):
         for row in rows:
             row_path = row.path
-            if not _is_runtime_log_row(row, row_path):
+            if not _is_runtime_log_row(row):
                 continue
             if row_path in seen_paths:
                 continue
@@ -548,11 +548,11 @@ def _collect_source_lines(
     return lines
 
 
-def _is_runtime_log_row(row: export_target_manifest_pb2.ExportTargetFile, row_path: str) -> bool:
+def _is_runtime_log_row(row: export_target_manifest_pb2.ExportTargetFile) -> bool:
     return (
         row.role == export_target_manifest_pb2.EXPORT_TARGET_FILE_ROLE_RUNTIME_LOG
         or row.retention_class == export_target_manifest_pb2.EXPORT_RETENTION_CLASS_RUNTIME_LOG
-        or row_path.startswith("logs/")
+        or row.path.startswith("logs/")
     )
 
 


### PR DESCRIPTION
## Summary
- Reverts #2750 because the official PR-scoped performance report marked the runtime export diagnostic parser slice as a regression.
- Restores the prior diagnostic row predicate signature, test set, and plan text.

## Plan or Spec
- `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 82 passed in 1.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 82 passed in 1.51s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json docs/plans/2026-06-24-runtime-export-diagnostic-parser.md services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_diagnostics.py
# TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py
# {"diagnosis_matching_elapsed_ms_mean": 0.18841142300516367, "diagnostic_parser_coverage": 1.0, "elapsed_ms_mean": 3010.0146766053513, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` because this PR removes the previously added executable lines.
- Registered probe: `runtime-export-diagnostic-parser`.
- Revert reason: #2750 official PR-scoped performance report completed successfully but reported `Status: regression`, with `diagnosis_matching_elapsed_ms_mean` base `0.191`, head `0.202`, `+0.011 (+5.54%)`, status `regression`.
- GitHub Actions PR-scoped performance must validate this revert before merge.

## Known Gaps
- This is a corrective revert, not a new optimization slice. It restores main to the pre-#2750 behavior after the official performance report rejected the attempted row-path reuse slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
