### PR TITLE
perf: streamline hub catalog model marker prefilter

### DIFF
--- a/docs/plans/2026-07-04-hub-catalog-mlx-atom-exact-fastpath.md
+++ b/docs/plans/2026-07-04-hub-catalog-mlx-atom-exact-fastpath.md
@@ -29,6 +29,12 @@ This slice is Python-only and is locally verifiable on Linux with focused pytest
   - `payload_compatibility_elapsed_ms_mean` lower is better
   - `size_hint_calls_mean`, compatibility call counts, checksum, and matched counts preserve behavior.
 
+## 2026-07-11 marker prefilter substring slice
+
+This follow-up Python-only slice stays within `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and the registered `hub-catalog-size-hint-regex-precompile` probe. `_may_contain_model_marker(...)` now checks the four case combinations for the adjacent `mo` marker directly instead of first scanning separately for `m`/`M` and `o`/`O`. Behavior remains conservative for every marker spelling the downstream size-hint parser can match, while avoiding redundant full-string membership scans in Hub readme/description size-hint prefiltering.
+
+Local Linux validation uses the same focused Hub catalog tests, changed-scope coverage command, and registered PR-scoped performance probe. GitHub Actions PR-scoped performance remains the merge gate.
+
 ## Success Metrics
 
 - Focused Hub catalog tests preserve exact and mixed-case MLX marker behavior.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -1076,8 +1076,11 @@ def _size_hint_from_text(text: str, *, allow_bare: bool) -> int:
 
 
 def _may_contain_model_marker(text: str) -> bool:
-    return ("m" in text or "M" in text) and ("o" in text or "O" in text) and (
-        "MO" in text or "Mo" in text or "mo" in text or "mO" in text
+    return (
+        "mo" in text
+        or "Mo" in text
+        or "mO" in text
+        or "MO" in text
     )
 
 


### PR DESCRIPTION
## Summary
- Streamline the Hub catalog model-size marker prefilter by checking the adjacent `mo` marker case variants directly.
- Keep size-hint parsing behavior unchanged while avoiding redundant `m`/`M` and `o`/`O` full-string membership scans.

## Plan or Spec
- `docs/plans/2026-07-04-hub-catalog-mlx-atom-exact-fastpath.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 96 passed in 0.51s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 96 passed in 0.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# changed_line_coverage=100.00%; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub_catalog_model_marker_probe.json
# base elapsed_ms_mean=1452.665; head elapsed_ms_mean=1401.860; delta=-50.805 ms (-3.50%)
# base payload_compatibility_elapsed_ms_mean=222.400; head=203.163; delta=-19.238 ms (-8.65%)
# peak_bytes_mean unchanged at 230837.2; checksum and matched_hint_count unchanged

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/model_ops/hub_catalog.py` changed line.
- Local registered probe `hub-catalog-size-hint-regex-precompile`:
  - `elapsed_ms_mean`: 1452.665 ms → 1401.860 ms (delta -50.805 ms, -3.50%).
  - `payload_compatibility_elapsed_ms_mean`: 222.400 ms → 203.163 ms (delta -19.238 ms, -8.65%).
  - `peak_bytes_mean`: unchanged at 230837.2 bytes.
  - Guardrails unchanged: `checksum=1545732096.0`, `matched_hint_count=120000.0`, `size_hint_calls_mean=0.0`.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- Local validation is Linux-only for this Python slice; no Swift runtime behavior is changed.
- Final registered probe validation depends on GitHub Actions PR-scoped performance.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, no observability behavior changed; probe overhead tracked by registered PR-scoped performance metrics.
- [x] Deferred work and known gaps are stated explicitly.
