### PR TITLE
perf: bind pr-scoped registry stat lookup

### DIFF
--- a/docs/plans/2026-05-23-pr-scoped-registry-scope-os-stat.md
+++ b/docs/plans/2026-05-23-pr-scoped-registry-scope-os-stat.md
@@ -40,3 +40,17 @@ Accept the slice only if the registered probe reports directionally lower
 changed-scope coverage. `load_probe_registry_ms_mean` and
 `cold_load_probe_registry_ms_mean` are expected to be neutral because the slice
 only touches the scope loader path.
+
+## 2026-07-11 follow-up: module-local stat binding
+
+This follow-up keeps the same Python-only boundary and registered
+`pr-scoped-performance-registry-cache` probe. Both registry loaders already use
+absolute string cache keys before checking file metadata; the hot repeated path
+still resolves `os.stat` through the module on every cached registry lookup. Bind
+`os.stat` once as `_OS_STAT` and use that local binding in `load_probe_registry()`
+and `load_probe_registry_for_scope()` while preserving the same `(mtime_ns, size)`
+cache invalidation semantics.
+
+Accept this follow-up only if the registered probe is neutral-or-better for cached
+registry loads and scope report construction, with focused tests and changed-scope
+coverage still passing.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -5264,7 +5264,7 @@ def test_build_scope_report_reuses_scope_cached_registry_without_double_stat(
         return original_os_stat(path, *args, **kwargs)
 
     monkeypatch.setattr(Path, "stat", fail_path_stat)
-    monkeypatch.setattr(os, "stat", tracked_os_stat)
+    monkeypatch.setattr(pr_scoped_performance_module, "_OS_STAT", tracked_os_stat)
 
     try:
         first = build_scope_report(

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -56,6 +56,7 @@ _FORCE_ALL_DIRECT_PROBE_IDS_BY_EXACT_PATH = {
 _COVERAGE_PERCENT_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
 _TEXT_FILE_SUFFIXES = {".md", ".py", ".json", ".txt", ".yaml", ".yml"}
 _COMMAND_HEARTBEAT_SECONDS = 30.0
+_OS_STAT = os.stat
 _MATCH_PROBE_INDEXES_CACHE: dict[tuple[int, int, tuple[str, ...]], frozenset[int]] = {}
 _PROBE_ID_INDEX_CACHE: dict[tuple[int, int], dict[str, int]] = {}
 _PROBE_SCOPE_DICT_CACHE: dict[tuple[int, str], dict[str, object]] = {}
@@ -218,7 +219,7 @@ def _load_probe_registry_uncached(
 
 def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
     cache_key = _probe_registry_cache_key(path)
-    stat_result = os.stat(cache_key)
+    stat_result = _OS_STAT(cache_key)
     cached = _PROBE_REGISTRY_CACHE.get(cache_key)
     if cached is not None and cached[0] == stat_result.st_mtime_ns and cached[1] == stat_result.st_size:
         return cached[2]
@@ -233,7 +234,7 @@ def load_probe_registry(path: str | Path) -> tuple[ProbeDefinition, ...]:
 
 def load_probe_registry_for_scope(path: str | Path) -> tuple[ProbeDefinition, ...]:
     cache_key = _probe_registry_cache_key(path)
-    stat_result = os.stat(cache_key)
+    stat_result = _OS_STAT(cache_key)
     return _load_probe_registry_for_scope_cached(
         cache_key,
         stat_result.st_mtime_ns,


### PR DESCRIPTION
## Summary
- Bind `os.stat` once as `_OS_STAT` for PR-scoped registry metadata checks.
- Update the focused registry-cache test to monkeypatch the module-local stat binding while still proving `Path.stat()` is not used.
- Document the 2026-07-11 follow-up slice in the governing PR-scoped registry stat plan.

## Plan or Spec
- `docs/plans/2026-05-23-pr-scoped-registry-scope-os-stat.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
# 8 passed in 4.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
import json
from pathlib import Path
from worker.productization.pr_scoped_performance import _probe_pr_scoped_performance_registry_cache as probe
print(json.dumps(probe(Path.cwd()), sort_keys=True))
PY
# {"build_scope_report_iterations": 200.0, "build_scope_report_ms_mean": 2.231624, "cold_load_probe_registry_iterations": 60.0, "cold_load_probe_registry_ms_mean": 319.039585, "load_probe_registry_iterations": 400.0, "load_probe_registry_ms_mean": 0.89758, "sample_count": 6.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-registry-cache --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/pr_scoped_registry_stat_bind_probe.json
# head verification ok; base/head metrics recorded below

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered probe: `pr-scoped-performance-registry-cache`.
- Representative local base-vs-head probe runs:
  - Run A: `load_probe_registry_ms_mean` 1.283412 -> 0.931422 ms, `build_scope_report_ms_mean` 2.335653 -> 2.134968 ms, `cold_load_probe_registry_ms_mean` 313.511366 -> 339.145956 ms.
  - Run B: `load_probe_registry_ms_mean` 1.195749 -> 0.947079 ms, `build_scope_report_ms_mean` 2.200600 -> 1.895434 ms, `cold_load_probe_registry_ms_mean` 345.842250 -> 331.828608 ms.
  - Run C: `load_probe_registry_ms_mean` 0.946919 -> 0.989677 ms, `build_scope_report_ms_mean` 2.286387 -> 2.003421 ms, `cold_load_probe_registry_ms_mean` 328.547809 -> 320.019212 ms.
- CI PR-scoped performance report is required as the final registered probe validation source before merge.

## Known Gaps
- Full repository gates were not run locally; this Python-only slice used the registered focused test, coverage, and probe commands.
- Local Linux validation only; no Swift runtime behavior is touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
