### PR TITLE
perf: skip strip for normalized tool selections

### DIFF
--- a/docs/plans/2026-07-11-tool-registry-select-normalized-fastpath.md
+++ b/docs/plans/2026-07-11-tool-registry-select-normalized-fastpath.md
@@ -1,0 +1,42 @@
+# Tool registry selection normalized-name fast path
+
+This Python-only performance slice covers `ToolRegistry.select(...)` in
+`worker.runtime.tool_registry` when callers pass multiple already-normalized tool
+names.
+
+## Scope
+
+The multi-name selection path still preserves the existing semantics:
+
+- empty names are skipped;
+- whitespace-only names are skipped;
+- names with leading or trailing whitespace are stripped before lookup;
+- duplicate normalized names are collapsed in request order;
+- unknown normalized names still raise `ToolRegistryError`.
+
+The optimization avoids calling `str.strip()` for names that are already
+normalized by first checking the first and last character. This mirrors the
+single-name selection fast path and keeps the slower strip path only for inputs
+that can actually need normalization.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`.
+The registered entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries, and this plan is listed in the probe watch globs.
+
+## Verification plan
+
+1. Run the registered focused pytest command for
+   `tool-registry-select-name-index-cache`.
+2. Run the registered changed-scope coverage command and require at least 95%
+   coverage for the touched Python scope.
+3. Run the registered local probe on Linux and compare base vs head metrics.
+4. Use GitHub Actions PR-scoped performance as the final base-vs-head merge gate
+   before merging.
+
+## Linux validation boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+behavior is changed or claimed.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -404,8 +404,15 @@ class ToolRegistry:
         tool_by_name = self._tool_by_name
         missing_tool_sentinel = _MISSING_TOOL_SENTINEL
         for name in names:
-            normalized_name = name.strip()
-            if not normalized_name or normalized_name in seen_names:
+            if not name:
+                continue
+            if name[0].isspace() or name[-1].isspace():
+                normalized_name = name.strip()
+                if not normalized_name:
+                    continue
+            else:
+                normalized_name = name
+            if normalized_name in seen_names:
                 continue
             seen_names.add(normalized_name)
             requested_names_list.append(normalized_name)


### PR DESCRIPTION
## Summary
- Optimize `ToolRegistry.select(...)` multi-name selection by skipping `str.strip()` for names that are already normalized.
- Add the governing plan for the Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-11-tool-registry-select-normalized-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 117 passed in 1.40s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# 117 passed in 0.54s; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/tool_registry_select_probe.py"; if [ -f "$SCRIPT" ]; then python3 "$SCRIPT"; else for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2; fi'
# {"elapsed_ms_mean": 21.913153980858624, "select_calls_mean": 80000.0, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%` for the touched `tool_registry.py` lines.
- Registered local Linux probe: `tool-registry-select-name-index-cache`.
- Pre-change local probe sample from this worktree: `elapsed_ms_mean=23.046430782414973`, `missing_selection_elapsed_ms_mean=14.41410700790584`, `selector_planning_elapsed_ms_mean=31.831265822984278`, `no_keyword_fallback_planning_elapsed_ms_mean=61.756841419264674`.
- Post-change local probe sample: `elapsed_ms_mean=21.913153980858624`, `missing_selection_elapsed_ms_mean=13.65528260357678`, `selector_planning_elapsed_ms_mean=30.805965419858694`, `no_keyword_fallback_planning_elapsed_ms_mean=58.901908178813756`.
- Approximate local delta: `elapsed_ms_mean` improved by `-1.133276801556349 ms` (`~4.92%`) over 80,000 select calls. GitHub Actions PR-scoped performance is the final registered base-vs-head validation source.

## Known Gaps
- No Swift runtime behavior is changed or claimed; this is a Python-only slice validated locally on Linux.
- CI must still run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
