### PR TITLE
perf: bind event response json parser helpers

### DIFF
--- a/docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md
+++ b/docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md
@@ -61,6 +61,18 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-
 The PR-scoped performance workflow must select and complete
 `event-extraction-response-json-fence-trim` in CI before merge.
 
+## Follow-up: parser helper local bindings
+
+This follow-up slice keeps the same parsing behavior and registered probe while
+binding the shared raw decoder and trailer validators once at the start of
+`_parse_response_json(...)`. That removes repeated global lookups across the
+direct-object, leading-whitespace object, fenced-json, and generic fallback paths
+without changing the existing raw-decode fast paths or JSON error behavior.
+
+The existing focused tests cover direct object parsing, leading whitespace,
+fenced payloads, trailing-text rejection, non-object rejection, and the sentinel
+that object fast paths do not fall back to `json.loads(...)`.
+
 ## Success criteria
 
 - Focused behavior tests pass.

--- a/docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md
+++ b/docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md
@@ -64,10 +64,10 @@ The PR-scoped performance workflow must select and complete
 ## Follow-up: parser helper local bindings
 
 This follow-up slice keeps the same parsing behavior and registered probe while
-binding the shared raw decoder and trailer validators once at the start of
-`_parse_response_json(...)`. That removes repeated global lookups across the
-direct-object, leading-whitespace object, fenced-json, and generic fallback paths
-without changing the existing raw-decode fast paths or JSON error behavior.
+binding the shared raw decoder and trailer validators once after the direct
+object fast path in `_parse_response_json(...)`. That removes repeated global
+lookups across the leading-whitespace object, fenced-json, and generic fallback
+paths while preserving the direct-object path's minimal work before raw decode.
 
 The existing focused tests cover direct object parsing, leading whitespace,
 fenced payloads, trailing-text rejection, non-object rejection, and the sentinel

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2888,15 +2888,15 @@ def _coerce_string_list(value: object) -> list[str]:
 
 def _parse_response_json(response_text: str) -> dict[str, object]:
     response_length = len(response_text)
-    raw_decode = _JSON_RAW_DECODE
-    has_only_trailing_whitespace = _has_only_trailing_whitespace
-    has_only_optional_closing_fence = _has_only_optional_closing_fence
     if response_length and response_text[0] == "{":
-        parsed, end_index = raw_decode(response_text, 0)
-        if not has_only_trailing_whitespace(response_text, end_index, response_length):
+        parsed, end_index = _JSON_RAW_DECODE(response_text, 0)
+        if not _has_only_trailing_whitespace(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
+    raw_decode = _JSON_RAW_DECODE
+    has_only_trailing_whitespace = _has_only_trailing_whitespace
+    has_only_optional_closing_fence = _has_only_optional_closing_fence
     if response_length and response_text[0] == "`" and response_text.startswith(_JSON_FENCE_PREFIX):
         parsed, end_index = raw_decode(
             response_text,

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2888,18 +2888,21 @@ def _coerce_string_list(value: object) -> list[str]:
 
 def _parse_response_json(response_text: str) -> dict[str, object]:
     response_length = len(response_text)
+    raw_decode = _JSON_RAW_DECODE
+    has_only_trailing_whitespace = _has_only_trailing_whitespace
+    has_only_optional_closing_fence = _has_only_optional_closing_fence
     if response_length and response_text[0] == "{":
-        parsed, end_index = _JSON_RAW_DECODE(response_text, 0)
-        if not _has_only_trailing_whitespace(response_text, end_index, response_length):
+        parsed, end_index = raw_decode(response_text, 0)
+        if not has_only_trailing_whitespace(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
     if response_length and response_text[0] == "`" and response_text.startswith(_JSON_FENCE_PREFIX):
-        parsed, end_index = _JSON_RAW_DECODE(
+        parsed, end_index = raw_decode(
             response_text,
             _JSON_FENCE_PREFIX_LENGTH,
         )
-        if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+        if not has_only_optional_closing_fence(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         if not isinstance(parsed, dict):
             raise ValueError("LLM response must be a JSON object")
@@ -2908,17 +2911,17 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
     response_start = _skip_json_whitespace(response_text, 0, response_length)
 
     if response_start < response_length and response_text[response_start] == "{":
-        parsed, end_index = _JSON_RAW_DECODE(response_text, response_start)
-        if not _has_only_trailing_whitespace(response_text, end_index, response_length):
+        parsed, end_index = raw_decode(response_text, response_start)
+        if not has_only_trailing_whitespace(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
     if response_text.startswith(_JSON_FENCE_PREFIX, response_start):
-        parsed, end_index = _JSON_RAW_DECODE(
+        parsed, end_index = raw_decode(
             response_text,
             response_start + _JSON_FENCE_PREFIX_LENGTH,
         )
-        if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+        if not has_only_optional_closing_fence(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         if not isinstance(parsed, dict):
             raise ValueError("LLM response must be a JSON object")
@@ -2927,14 +2930,14 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
     if response_text.startswith("```", response_start):
         newline_index = response_text.find("\n", response_start)
         if newline_index >= 0:
-            parsed, end_index = _JSON_RAW_DECODE(response_text, newline_index + 1)
-            if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+            parsed, end_index = raw_decode(response_text, newline_index + 1)
+            if not has_only_optional_closing_fence(response_text, end_index, response_length):
                 raise json.JSONDecodeError("Extra data", response_text, end_index)
             if not isinstance(parsed, dict):
                 raise ValueError("LLM response must be a JSON object")
             return parsed
-    parsed, end_index = _JSON_RAW_DECODE(response_text, response_start)
-    if not _has_only_trailing_whitespace(response_text, end_index, response_length):
+    parsed, end_index = raw_decode(response_text, response_start)
+    if not has_only_trailing_whitespace(response_text, end_index, response_length):
         raise json.JSONDecodeError("Extra data", response_text, end_index)
     if not isinstance(parsed, dict):
         raise ValueError("LLM response must be a JSON object")


### PR DESCRIPTION
## Summary
- Bind the event-extraction response JSON parser's raw decoder and trailer validators once per parse call.
- Keep the existing raw-decode fast paths, fenced/direct JSON behavior, and error handling unchanged.

## Plan or Spec
- `docs/plans/2026-05-18-event-response-json-fence-trailer-strip.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id event-extraction-response-json-fence-trim --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-event-response-json-open-fence-bind-20260712 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-event-response-json-open-fence-bind-20260712 --output .runtime/pr-scoped-local-event-response/result.json
# exit 0; focused coverage/test verification passed as part of the registered runner (21 passed, changed-line coverage 100%).

git diff --check
# exit 0
```

## Coverage and Metrics
- Registered probe: `event-extraction-response-json-fence-trim`.
- Changed-scope coverage: 100.00% (15/15 changed lines) for `services/mlx-worker-python/worker/productization/event_extraction.py`.
- Local Linux probe metrics:
  - `elapsed_ms_mean`: base 1241.456725 ms → head 1223.022155 ms (`delta=-18.434570 ms`, ~1.48% faster)
  - `direct_elapsed_ms_mean`: base 1214.046405 ms → head 1197.534580 ms (`delta=-16.511825 ms`, ~1.36% faster)
  - `peak_bytes_mean`: base 2999220.0 → head 2999220.0 (no regression)
  - `direct_peak_bytes_mean`: base 2999224.8 → head 2999224.8 (no regression)
- GitHub Actions PR-scoped performance is required as the merge gate before merge.

## Known Gaps
- No Swift/macOS runtime effect is claimed; this is a Python-only parser slice validated locally on Linux and gated by CI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
