### PR TITLE
perf: avoid upload receipt relative path branch

### DIFF
--- a/docs/plans/2026-07-11-upload-receipt-relative-prefix-fastpath.md
+++ b/docs/plans/2026-07-11-upload-receipt-relative-prefix-fastpath.md
@@ -1,0 +1,47 @@
+# Upload receipt relative-prefix fast path
+
+This Python-only performance slice is limited to published-file discovery in
+`worker.model_ops.upload_receipt_pipeline._collect_published_file_list(...)`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`upload-receipt-published-files-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/upload_receipt_published_files_probe.py`
+
+## Optimization
+
+Published-file traversal already uses `os.scandir(...)`, but each directory
+entry still checked whether the current relative directory was empty before
+constructing the published path. This slice stores a relative prefix in the
+explicit traversal stack: the root prefix is empty and child directory prefixes
+already include the trailing slash. Each entry can then construct its relative
+path with one string concatenation and no per-entry conditional branch.
+
+The output remains sorted and uses the same slash-separated relative paths for
+files, file symlinks, and special entries. Directory symlink exclusion behavior
+is unchanged.
+
+## Verification plan
+
+1. Extend focused upload receipt tests to assert nested published paths still use
+   slash-separated relative names after prefix-based traversal.
+2. Run the registered focused test command for
+   `upload-receipt-published-files-scandir` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe locally before and after the change.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage for touched files remains at or above 95%.
+- The registered local and CI probes show non-regression or improvement for
+  `elapsed_ms_mean`, and `special_entry_follow_dir_checks_mean` stays at `0.0`.

--- a/services/mlx-worker-python/tests/test_maintenance_service.py
+++ b/services/mlx-worker-python/tests/test_maintenance_service.py
@@ -2351,6 +2351,9 @@ def test_upload_receipt_pipeline_collect_published_file_list_uses_scandir_stack(
     nested_root = source_root / "nested"
     nested_root.mkdir()
     (nested_root / "config.json").write_text("{}", encoding="utf-8")
+    shard_root = nested_root / "shard"
+    shard_root.mkdir()
+    (shard_root / "part-0001.safetensors").write_text("weights", encoding="utf-8")
 
     def fail_os_walk(*args, **kwargs):
         raise AssertionError("published file collection should avoid os.walk")  # pragma: no cover
@@ -2359,6 +2362,7 @@ def test_upload_receipt_pipeline_collect_published_file_list_uses_scandir_stack(
 
     assert UploadReceiptPipeline._collect_published_file_list(source_root) == [
         "nested/config.json",
+        "nested/shard/part-0001.safetensors",
         "weights.bin",
     ]
 

--- a/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/upload_receipt_pipeline.py
@@ -198,12 +198,12 @@ def _collect_published_file_list(source_dir: Path) -> list[str]:
     pending: list[tuple[str, str]] = [(source_dir_str, "")]
     published_files: list[str] = []
     while pending:
-        current_dir, relative_dir = pending.pop()
+        current_dir, relative_prefix = pending.pop()
         with os.scandir(current_dir) as entries:
             for entry in entries:
-                relative_path = entry.name if not relative_dir else f"{relative_dir}/{entry.name}"
+                relative_path = relative_prefix + entry.name
                 if entry.is_dir(follow_symlinks=False):
-                    pending.append((entry.path, relative_path))
+                    pending.append((entry.path, relative_path + "/"))
                 elif entry.is_file(follow_symlinks=False):
                     published_files.append(relative_path)
                 elif entry.is_symlink():


### PR DESCRIPTION
## Summary
- Store upload receipt traversal stack entries as relative prefixes with a trailing slash so each published path uses one concatenation instead of a per-entry root/nested conditional.
- Extend the focused scandir-stack test to cover a second nested directory level.

## Plan or Spec
- `docs/plans/2026-07-11-upload-receipt-relative-prefix-fastpath.md`
- Registered PR-scoped probe: `upload-receipt-published-files-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/upload_receipt_published_files_probe.py
# baseline on origin/main: elapsed_ms_mean=5.784963, special_entry_follow_dir_checks_mean=0.0
# head direct probe: elapsed_ms_mean=5.006673, special_entry_follow_dir_checks_mean=0.0

sh /tmp/upload_receipt_test_command.sh
# 27 passed in 3.14s

sh /tmp/upload_receipt_coverage_command.sh
# 27 passed in 2.39s; changed_line_coverage=100.00%; TOTAL 6 0 100%

python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id upload-receipt-published-files-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/upload_receipt_pr_scoped_perf.json
# test_ok=true; coverage_ok=true; base elapsed_ms_mean=4.905068; head elapsed_ms_mean=4.799567; special_entry_follow_dir_checks_mean=0.0 for both

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`aggregate_measurable_changed_lines=6`, `aggregate_covered_changed_lines=6`).
- Registered local probe (`upload-receipt-published-files-scandir`) base/head via `scripts/pr_scoped_performance_run.py`:
  - `elapsed_ms_mean`: 4.905068 ms -> 4.799567 ms (`delta_ms=-0.105501`, `speedup=1.021981x`, `improvement=2.151%`).
  - `special_entry_follow_dir_checks_mean`: 0.0 -> 0.0.
- CI PR-scoped performance report is required as the merge gate.

## Known Gaps
- None for the Python/Linux slice. CI must publish and pass the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; probe overhead is limited to CI/local probe execution and not runtime production instrumentation.
- [x] Deferred work and known gaps are stated explicitly.
