### PR TITLE
perf: cache M9 release gate root lookup

### DIFF
--- a/docs/plans/release-gates-m9-failure-count-single-pass.md
+++ b/docs/plans/release-gates-m9-failure-count-single-pass.md
@@ -22,6 +22,7 @@ This slice is Python-only and can be verified on Linux with focused pytest, chan
 - Replace the suffix-based post-processing loop over `section_failures` with a counted section evaluator that returns missing and threshold-failure counts alongside the ordered failure strings.
 - Preserve failure ordering, metric names, and summary values exactly while avoiding failure-string suffix scans in `evaluate_m9_release_evidence(...)`.
 - Follow-up slice: keep flat metric-key lookup as the fast path and short-circuit dotted nested lookup when the first segment is absent from the metrics map. This preserves nested metric compatibility while avoiding `split(".")` list allocation for flat M9 policy misses.
+- 2026-07-12 follow-up slice: cache prefixed nested-root availability once per section in `_evaluate_section_metrics_with_counts(...)`. M9 rules usually pass fully qualified flat metric names under a shared `m9.<section>.` prefix; this keeps nested-metric fallback compatibility while avoiding repeated root membership checks for every missing flat key in the section.
 
 ## Probe definition
 

--- a/services/mlx-worker-python/tests/test_release_gates.py
+++ b/services/mlx-worker-python/tests/test_release_gates.py
@@ -1162,6 +1162,68 @@ def test_evaluate_section_metrics_counts_failure_types_without_suffix_scan() -> 
     ) == ["m9.mcp.above_max=2.00 exceeded maximum 1.00"]
 
 
+def test_evaluate_section_metrics_checks_prefixed_nested_root_once() -> None:
+    class RootCountingMetrics(dict[str, object]):
+        root_checks = 0
+
+        def __contains__(self, key: object) -> bool:
+            if key == "m9":
+                type(self).root_checks += 1
+            return super().__contains__(key)
+
+    metrics = RootCountingMetrics(
+        {
+            "m9.mcp.present": 1.0,
+        }
+    )
+
+    failures, missing_count, failed_threshold_count = (
+        release_gates_module._evaluate_section_metrics_with_counts(
+            metrics,
+            {
+                "m9.mcp.present": {"min": 1.0},
+                "m9.mcp.missing_a": {"min": 1.0},
+                "m9.mcp.missing_b": {"min": 1.0},
+            },
+            prefix="m9.mcp.",
+        )
+    )
+
+    assert failures == [
+        "m9.mcp.m9.mcp.missing_a is missing",
+        "m9.mcp.m9.mcp.missing_b is missing",
+    ]
+    assert missing_count == 2
+    assert failed_threshold_count == 0
+    assert metrics.root_checks == 1
+
+
+def test_evaluate_section_metrics_preserves_nested_lookup_for_unprefixed_rule_names() -> None:
+    failures, missing_count, failed_threshold_count = (
+        release_gates_module._evaluate_section_metrics_with_counts(
+            {"mcp": {"nested": 1.0}},
+            {"mcp.nested": {"min": 1.0}},
+            prefix="m9.mcp.",
+        )
+    )
+
+    assert failures == []
+    assert missing_count == 0
+    assert failed_threshold_count == 0
+
+    prefixed_failures, prefixed_missing_count, prefixed_failed_threshold_count = (
+        release_gates_module._evaluate_section_metrics_with_counts(
+            {"m9": {"mcp": {"nested": 1.0}}},
+            {"m9.mcp.nested": {"min": 1.0}},
+            prefix="m9.mcp.",
+        )
+    )
+
+    assert prefixed_failures == []
+    assert prefixed_missing_count == 0
+    assert prefixed_failed_threshold_count == 0
+
+
 def test_evaluate_section_metrics_preserves_non_string_rule_key_lookup() -> None:
     failures, missing_count, failed_threshold_count = (
         release_gates_module._evaluate_section_metrics_with_counts(

--- a/services/mlx-worker-python/worker/productization/release_gates.py
+++ b/services/mlx-worker-python/worker/productization/release_gates.py
@@ -2176,13 +2176,24 @@ def _evaluate_section_metrics_with_counts(
     missing = _MISSING
     values_get = values.get
     metric_value = _metric_value
+    prefix_root = ""
+    prefix_root_present = False
+    if prefix:
+        prefix_first_dot = prefix.find(".")
+        if prefix_first_dot != -1:
+            prefix_root = prefix[:prefix_first_dot]
+            prefix_root_present = prefix_root in values
     for name, rule in rules.items():
         if type(name) is str:
             value = values_get(name, missing)
             if value is missing:
-                first_dot = name.find(".")
-                if first_dot != -1 and name[:first_dot] in values:
-                    value = metric_value(values, name)
+                if prefix_root and name.startswith(prefix):
+                    if prefix_root_present:
+                        value = metric_value(values, name)
+                else:
+                    first_dot = name.find(".")
+                    if first_dot != -1 and name[:first_dot] in values:
+                        value = metric_value(values, name)
         else:
             value = metric_value(values, str(name))
         if value is missing:


### PR DESCRIPTION
## Summary
- Cache prefixed M9 nested-root availability once per release-gate section before scanning section rules.
- Preserve flat-key fast paths, nested metric fallback, and existing failure strings while avoiding repeated root membership checks for fully-qualified missing flat metrics.
- Add regression coverage for the once-per-section root lookup and nested fallback compatibility.

## Plan or Spec
- `docs/plans/release-gates-m9-failure-count-single-pass.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_checks_prefixed_nested_root_once services/mlx-worker-python/tests/test_release_gates.py::test_evaluate_section_metrics_counts_failure_types_without_suffix_scan
# 2 passed in 1.12s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 75 passed in 4.80s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_release_gates_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_release_gates_m9_failure_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/release_gates.py services/mlx-worker-python/tests/test_release_gates.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/release_gates_m9_failure_count_probe.py
# 75 passed in 6.43s; TOTAL 35 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id release-gates-m9-failure-count-single-pass --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/release_gates_m9_root_lookup_probe.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 35 0 100%`.
- Registered local probe: `release-gates-m9-failure-count-single-pass`.
- Local probe metrics:
  - `elapsed_ms_mean`: base `8.311089570634067` ms, head `7.458868972025812` ms, delta `-0.8522205986082554` ms (~10.25% faster).
  - `endswith_checks_mean`: base `0.0`, head `0.0`.
  - `failure_count_mean`: base `12800.0`, head `12800.0`.
- Observability mode/probe overhead: N/A; this changes PR-scoped release-gate evaluation code only and does not alter runtime observability mode or production probe overhead.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally for this focused Python slice.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
