### PR TITLE
perf: avoid report result suffix slicing

### DIFF
--- a/docs/plans/2026-07-12-pr-scoped-performance-report-suffix-check.md
+++ b/docs/plans/2026-07-12-pr-scoped-performance-report-suffix-check.md
@@ -1,0 +1,30 @@
+# PR-scoped Performance Report Result Suffix Check
+
+## Scope
+
+This Python-only performance slice is limited to `scripts/pr_scoped_performance_report.py` result loading.
+
+`_load_results(...)` scans a PR-scoped performance results directory with `os.scandir()`, filters JSON result files, sorts the discovered paths for deterministic report output, and then parses each result. The remaining per-entry filter used `entry.name[-5:] == ".json"`, allocating a short suffix string for every directory entry.
+
+This slice keeps the same `os.scandir()` traversal, deterministic sorting, binary JSON reads, non-dict filtering, and missing-directory behavior, but uses `entry.name.endswith(".json")` for the suffix check. That avoids per-entry slice allocation while preserving accepted filenames.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `pr-scoped-performance-report-results-scandir` in `infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/pr_scoped_performance_report.py`
+- `scripts/pr_scoped_performance_report_results_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+The probe creates 2,000 JSON result files plus a non-JSON file and measures `_load_results(...)` latency.
+
+## Validation Plan
+
+- Run the focused registered pytest command.
+- Run changed-scope coverage via the registered coverage command.
+- Run `scripts/pr_scoped_performance_report_results_probe.py` locally on Linux.
+- Let the PR-scoped performance workflow validate the registered probe in CI before merge.
+
+## Expected Impact
+
+The registered probe should report lower or stable `elapsed_ms_mean` / `elapsed_ms_min` for report result loading by avoiding one short-lived string allocation per scanned directory entry.

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -29,7 +29,7 @@ def _load_results(results_dir: Path) -> list[dict[str, object]]:
     try:
         with os.scandir(results_dir) as entries:
             for entry in entries:
-                if entry.name[-5:] == ".json":
+                if entry.name.endswith(".json"):
                     result_paths_append(entry.path)
     except OSError:
         return []


### PR DESCRIPTION
## Summary
- Avoid per-entry suffix slicing while filtering PR-scoped performance result JSON files.
- Keep the existing `os.scandir()` traversal, deterministic path sorting, binary JSON parsing, and non-dict filtering behavior unchanged.

## Plan or Spec
- `docs/plans/2026-07-12-pr-scoped-performance-report-suffix-check.md`
- Registered probe: `pr-scoped-performance-report-results-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke
# 6 passed in 7.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_report.py scripts/pr_scoped_performance_report_results_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 6 passed in 43.09s; changed-line coverage TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report_results_probe.py
# head: {"elapsed_ms_mean": 24.680385, "elapsed_ms_min": 23.19116, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report_results_probe.py
# origin/main baseline in sibling worktree: {"elapsed_ms_mean": 28.886496, "elapsed_ms_min": 26.265717, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}
```

## Coverage and Metrics
- Changed-scope coverage: `scripts/pr_scoped_performance_report.py` changed line coverage 100.00%; aggregate changed-line coverage 100.00%.
- Local registered probe (`pr-scoped-performance-report-results-scandir`) improved on this Linux run: `elapsed_ms_mean` 28.886496 ms -> 24.680385 ms (delta -4.206111 ms, ~1.17x speedup); `elapsed_ms_min` 26.265717 ms -> 23.19116 ms (delta -3.074557 ms).
- CI PR-scoped performance workflow is still required as the merge validation source.

## Known Gaps
- Full repository `make py-test` / integration gates were not run locally; this is a focused Python tooling slice.
- Metrics are local Linux measurements and can be noisy; the registered CI probe must pass before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
