### PR TITLE
perf: unroll prefix cache state byte pairs

### DIFF
--- a/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
+++ b/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
@@ -63,3 +63,15 @@ Expected effect:
 - Changed-scope coverage for touched Python paths is at least 95%.
 - The local registered probe shows lower elapsed time for the synthetic cache byte-estimation workload.
 - GitHub Actions and the PR-scoped performance workflow complete successfully before merge.
+
+## Follow-up Slice: State Pair Unroll
+
+The 2026-07-12 follow-up keeps the same registered probe and targets the common
+two-tensor `.state` cache shape. `estimate_cache_snapshot_bytes()` now unrolls
+length-2 state sequences before falling back to the generic loop, preserving the
+existing behavior for empty, one-item, and longer state sequences while reducing
+iterator overhead in the synthetic and MLX prompt-cache hot path.
+
+Success is accepted only after the local focused test command, changed-scope
+coverage command, and registered probe all pass, and after the PR-scoped CI
+probe validates the same registry entry.

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -451,6 +451,9 @@ def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:
         state = getattr(layer_cache, "state", None)
         if state is not None:
             if isinstance(state, sequence_types):
+                if len(state) == 2:
+                    total += tensor_nbytes(state[0]) + tensor_nbytes(state[1])
+                    continue
                 for tensor in state:
                     total += tensor_nbytes(tensor)
                 continue


### PR DESCRIPTION
## Summary
- Unroll the common two-tensor `.state` prompt-cache byte-estimation path in `estimate_cache_snapshot_bytes()`.
- Keep existing behavior for empty, single-item, and longer state sequences by retaining the generic loop fallback.
- Folded review feedback into the hot-path addition so the two tensor byte counts are added in a single `+=` operation.

## Plan or Spec
- `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md`
- Registered PR-scoped probe: `prefix-cache-snapshot-byte-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline registered probe on origin/main-equivalent branch before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
# exit 0; elapsed_ms_mean=552.634691610001, elapsed_ms_p95=566.7802700772882, peak_bytes_mean=264.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 10 passed in 1.77s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py
# exit 0; 10 passed in 0.55s; TOTAL 4 0 100%

# After review feedback fold-in
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <same focused test list>
# exit 0; 10 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py
# exit 0; 10 passed in 0.59s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
# exit 0; elapsed_ms_mean=478.8704917766154, elapsed_ms_p95=495.83180400077254, peak_bytes_mean=216.0

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` after the final patch.
- Local registered probe delta:
  - baseline `elapsed_ms_mean=552.634691610001`
  - head `elapsed_ms_mean=478.8704917766154`
  - delta `-73.76419983338565 ms` (`~13.35%` faster)
  - baseline `elapsed_ms_p95=566.7802700772882`
  - head `elapsed_ms_p95=495.83180400077254`
  - peak bytes: `264.0 -> 216.0`
- CI PR-scoped performance workflow is required as the merge-source validation for the registered probe.

## Known Gaps
- Full repository gates were not run locally; this PR is limited to the focused registered Python probe scope.
- Swift runtime effects are not applicable for this Python worker slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
