### PR TITLE
perf: skip native MTP basename scan for model shards

### DIFF
--- a/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
+++ b/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
@@ -18,6 +18,8 @@ The probe is extended to measure the model safetensor listing path directly agai
 
 2026-06-19 probe-gating note: the shared registered probe keeps `weight_load_new_mean_ms` as the gated shard-load timing metric, but treats `weight_load_delta_ms` as informational. That delta is derived from the historical and optimized helpers within one probe run, so cross-run comparisons can flag noise in an unrelated helper as a PR regression even when the optimized weight-load mean remains neutral or improved.
 
+2026-07-12 follow-up slice: `_extra_mtp_safetensor_file_paths()` now short-circuits top-level `model*.safetensors` sidecar candidates before scanning for `os.sep`. Nested `*/model*.safetensors` candidates still use the basename check and remain excluded, preserving the historical base-shard elision semantics while reducing string scans for noisy index maps with many duplicate base-model MTP entries.
+
 ## Verification plan
 
 ```bash

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -2873,6 +2873,7 @@ def test_native_mtp_extra_safetensor_files_filters_names_before_path_join(
             "language_model.mtp.layers.4.weight": "mtp-missing.safetensors",
             "language_model.mtp.layers.5.weight": "nested/mtp-00002.safetensors",
             "language_model.mtp.layers.5.duplicate_weight": "nested/mtp-00002.safetensors",
+            "language_model.mtp.layers.6.weight": "nested/model-mtp-00003.safetensors",
             "language_model.layers.0.weight": "ignored-mtp.safetensors",
         }
     }

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -104,9 +104,11 @@ def _extra_mtp_safetensor_file_paths(model_path: Path) -> list[str]:
             continue
         if seen_contains(file_name_text):
             continue
+        if str_startswith(file_name_text, model_prefix):
+            seen_add(file_name_text)
+            continue
         separator_index = str_rfind(file_name_text, path_sep)
-        file_basename = file_name_text if separator_index < 0 else file_name_text[separator_index + 1 :]
-        if str_startswith(file_basename, model_prefix):
+        if separator_index >= 0 and str_startswith(file_name_text[separator_index + 1 :], model_prefix):
             seen_add(file_name_text)
             continue
         seen_add(file_name_text)


### PR DESCRIPTION
## Summary
- Short-circuit native-MTP sidecar entries whose file names start with `model` before scanning for a path separator.
- Preserve nested `*/model*.safetensors` base-shard exclusion with a focused regression fixture.
- Update the native-MTP safetensor scan plan with this 2026-07-12 performance slice.

## Plan or Spec
- `docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md`
- Registered PR-scoped performance probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_weight_load_probe_tolerates_loader_timer_noise_without_weakening_counts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_model_listing_probe_tolerates_loader_timer_noise_without_weakening_counts
13 passed in 0.35s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing
9 passed in 0.40s

$ uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
changed_line_coverage=100.00%; TOTAL 4 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0; JSON metrics recorded below.

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed lines 107-109 and 111: 4/4 covered, 100.00%.
- Local registered probe (`native-mtp-loader-safetensor-scandir`, Linux):
  - `extra_old_mean_ms=304.11096622701734`
  - `extra_new_mean_ms=40.71362358517945`
  - `extra_delta_ms=-263.3973426418379`
  - `extra_speedup=7.46951362830106`
  - `model_listing_old_mean_ms=23.167068790644407`
  - `model_listing_new_mean_ms=10.30023219063878`
  - `model_listing_speedup=2.24917927691955`
  - `weight_load_old_mean_ms=514.2459758091718`
  - `weight_load_new_mean_ms=439.28356340620667`
  - `weight_load_speedup=1.1706469775962165`
- CI PR-scoped performance remains required before merge.

## Known Gaps
- Full repository gates (`make py-test`, `make swift-test`, `make integration-test`) were not run locally; this is a focused Python performance slice and GitHub Actions remains the full gate.
- No Swift runtime validation is claimed or needed for this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
