### PR TITLE
perf: defer prefix snapshot fallback coercion

### DIFF
--- a/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
+++ b/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
@@ -75,3 +75,15 @@ iterator overhead in the synthetic and MLX prompt-cache hot path.
 Success is accepted only after the local focused test command, changed-scope
 coverage command, and registered probe all pass, and after the PR-scoped CI
 probe validates the same registry entry.
+
+## Follow-up Slice: Deferred Fallback Multiplication Coercion
+
+The next 2026-07-12 follow-up keeps the same registered probe and narrows to the
+`size * itemsize` fallback in `_tensor_nbytes()`. The hot fallback path now
+multiplies the exposed numeric attributes directly and leaves the public
+`estimate_cache_snapshot_bytes()` return coercion in place, preserving caller
+behavior while avoiding per-tensor `int()` coercions inside the loop.
+
+Success is accepted only if focused tests, changed-scope coverage, and the local
+registered Linux probe pass with lower elapsed time, and if the PR-scoped CI
+probe completes successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -433,7 +433,7 @@ def _tensor_nbytes(tensor: Any) -> Any:
     itemsize = getattr(tensor, "itemsize", None)
     if itemsize is None:
         return 0
-    return int(size) * int(itemsize)
+    return size * itemsize
 
 
 def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:


### PR DESCRIPTION
## Summary
- Defer `size * itemsize` fallback coercion inside `_tensor_nbytes()` so the prefix snapshot byte estimator avoids per-tensor `int()` conversions in the hot loop.
- Keep the public `estimate_cache_snapshot_bytes()` return coercion unchanged and leave `.nbytes`, `.state`, and `.keys/.values` behavior intact.
- Update the prefix cache snapshot byte-streaming plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md`
- Registered probe: `prefix-cache-snapshot-byte-streaming` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 10 passed in 1.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py
# 10 passed; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" MELIX_PREFIX_CACHE_SNAPSHOT_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
# head: elapsed_ms_mean=440.9584767085367, elapsed_ms_min=395.58187895454466, elapsed_ms_p95=446.0393179906532, peak_bytes_mean=216.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id prefix-cache-snapshot-byte-streaming --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/prefix-cache-snapshot-byte-streaming-result.json
# base elapsed_ms_mean=479.6941558131948, head elapsed_ms_mean=417.5475247669965; base p95=503.3624320058152, head p95=435.2830720599741; coverage TOTAL 1 0 100%

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/runtime/prefix_block_store.py`.
- Local registered probe comparison (`prefix-cache-snapshot-byte-streaming`): `elapsed_ms_mean` improved from `479.6941558131948` to `417.5475247669965` ms (`-62.14663104619834` ms, about `12.96%` faster); `elapsed_ms_p95` improved from `503.3624320058152` to `435.2830720599741` ms; `peak_bytes_mean` stayed `216.0` bytes.
- CI PR-scoped performance workflow is required as the final registered-probe validation before merge.

## Known Gaps
- Linux-local validation covers this Python worker path. CI remains the merge gate for the registered PR-scoped performance report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
