### PR TITLE
perf: stream code eval nonblank line counts

### DIFF
--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -28,7 +28,6 @@ _ORD_OBJECT_START = ord("{")
 _ORD_OBJECT_END = ord("}")
 _ASSERT_PRECEDING_BOUNDARIES = frozenset("\n\r;:")
 _ASSERT_LINE_SPACING = frozenset(" \t")
-_NONBLANK_SPLITLINES_MIN_CHARS = 262_144
 
 
 @dataclass(frozen=True, slots=True)
@@ -380,9 +379,6 @@ def _count_assert_nodes(
 
 
 def _count_nonblank_test_lines(test_code: str) -> int:
-    if type(test_code) is str and len(test_code) >= _NONBLANK_SPLITLINES_MIN_CHARS:
-        return sum(1 for line in test_code.splitlines() if line.strip())
-
     count = 0
     line_has_content = False
     if test_code.isascii():


### PR DESCRIPTION
## Summary
- Streams code-eval nonblank fallback line counting for large plain `str` inputs instead of materializing `splitlines()` output.
- Keeps the registered `code-eval-test-count-nonblank-streaming` probe path focused on peak-memory reduction; elapsed time is informational for this probe.

## Plan or Spec
- N/A: behavior is unchanged for the existing code-eval test counting helper, and the affected path already has a registered PR-scoped probe (`code-eval-test-count-nonblank-streaming`) covering the slice.

## Commands Run
```text
# Baseline on origin/main before edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_counts_nonblank_lines services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_short_inputs_without_splitlines services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 10 passed in 1.84s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/code_eval_test_count_probe.py"; for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT" "$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2'
# {"elapsed_ms_mean": 39.66164800138878, "line_count": 60000.0, "nonblank_line_count_mean": 48000.0, "peak_bytes_mean": 4316951.0, "sample_count": 7.0}

# After edit
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_counts_nonblank_lines services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_short_inputs_without_splitlines services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 10 passed in 0.66s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/code_eval_test_count_probe.py"; for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT" "$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2'
# {"elapsed_ms_mean": 52.983134569201084, "line_count": 60000.0, "nonblank_line_count_mean": 48000.0, "peak_bytes_mean": 112.0, "sample_count": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_counts_nonblank_lines services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fast_path_skips_ast_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_ignores_assert_tokens_in_comments_and_strings services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_falls_back_when_no_asserts_are_present services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_tests_no_assert_fallback_uses_nonblank_line_counter services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_test_lines_matches_splitlines_semantics services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_without_filtered_list services/mlx-worker-python/tests/test_code_eval_runner.py::test_count_nonblank_lines_streams_short_inputs_without_splitlines services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_test_count_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_test_count_probe.py
# 10 passed in 43.25s; changed_line_coverage=100.00%; TOTAL 0 0 100%

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` from `scripts/changed_scope_coverage.py`.
- Registered local probe (`code-eval-test-count-nonblank-streaming`): `peak_bytes_mean` 4,316,951.0 -> 112.0 bytes (delta -4,316,839.0 bytes; ~38,544x lower).
- Probe elapsed is informational and changed 39.661648 ms -> 52.983135 ms for the memory-optimized streaming path.
- CI PR-scoped performance workflow is required for the registered base-vs-head probe report before merge.

## Known Gaps
- Full repository test suite not run locally; this slice only touches the registered code-eval nonblank line-count path and was verified with its focused tests, changed-scope coverage, and registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or documented as N/A above.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: existing PR-scoped evidence probe only; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
