### PR TITLE
perf: bind embedding runtime call locals

### DIFF
--- a/docs/plans/2026-07-12-embedding-core-runtime-local-binds.md
+++ b/docs/plans/2026-07-12-embedding-core-runtime-local-binds.md
@@ -1,0 +1,28 @@
+# Embedding Core Runtime Local Bindings Slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.engine.embedding_core.EmbeddingCore.embed` on the hot path between model validation and response assembly. The runtime still receives the protobuf `request.inputs` repeated-field view without list materialization, and response contents/error behavior stay unchanged.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/engine/embedding_core.py`
+- `services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/embedding_core_inputs_probe.py`
+
+## Plan
+
+1. Keep the registered `embedding-core-inputs-view` probe unchanged.
+2. Bind the embedding runtime method, loaded runtime model, and protobuf input view once before the guarded runtime call.
+3. Verify with the registered focused test command, changed-scope coverage command, and local registered Linux probe.
+4. Use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Success is measured by `elapsed_ms_mean` from `scripts/embedding_core_inputs_probe.py` with unchanged checksum, input count, dimensions, and runtime input view metrics. Changed-scope coverage must stay at or above 95%.

--- a/services/mlx-worker-python/worker/engine/embedding_core.py
+++ b/services/mlx-worker-python/worker/engine/embedding_core.py
@@ -25,10 +25,14 @@ class EmbeddingCore:
                 )
             )
 
+        runtime_embed_inputs = registry.embedding_runtime.embed_inputs
+        runtime_model = loaded_model.runtime_model
+        request_inputs = request.inputs
+
         try:
-            vectors = registry.embedding_runtime.embed_inputs(
-                loaded_model.runtime_model,
-                request.inputs,
+            vectors = runtime_embed_inputs(
+                runtime_model,
+                request_inputs,
             )
         except Exception as exc:  # pragma: no cover - defensive branch
             return inference_pb2.EmbedResponse(


### PR DESCRIPTION
## Summary
- Bind the embedding runtime method, loaded runtime model, and protobuf input view once before the guarded embedding runtime call.
- Keep the runtime input forwarding behavior unchanged: `request.inputs` is still passed as the protobuf repeated-field view without list materialization.

## Plan or Spec
- `docs/plans/2026-07-12-embedding-core-runtime-local-binds.md`
- Registered PR-scoped probe: `embedding-core-inputs-view` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main before changes (3 local probe runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py
run1 elapsed_ms_mean=5666.599854 peak_bytes_mean=794436.8 checksum=3085500.0 runtime_input_is_view=1.0
run2 elapsed_ms_mean=5698.721564 peak_bytes_mean=794436.8 checksum=3085500.0 runtime_input_is_view=1.0
run3 elapsed_ms_mean=5539.648930 peak_bytes_mean=794436.8 checksum=3085500.0 runtime_input_is_view=1.0

# Changed local probe (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py
run1 elapsed_ms_mean=5596.737901 peak_bytes_mean=794596.8 checksum=3085500.0 runtime_input_is_view=1.0
run2 elapsed_ms_mean=5585.866453 peak_bytes_mean=794596.8 checksum=3085500.0 runtime_input_is_view=1.0
run3 elapsed_ms_mean=5624.036280 peak_bytes_mean=794596.8 checksum=3085500.0 runtime_input_is_view=1.0

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics
7 passed in 2.33s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_passes_request_inputs_without_list_materialization services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_returns_stable_vectors_for_loaded_embedding_models services/mlx-worker-python/tests/test_embedding_runtime.py::test_embed_runtime_reuses_duplicate_inputs_within_one_request services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_embedding_core_inputs_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_embedding_core_inputs_probe_script_emits_metrics
7 passed in 1.08s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/embedding_core.py services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/embedding_core_inputs_probe.py
TOTAL 4 0 100%

# Registered probe script local equivalent
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EMBEDDING_CORE_INPUTS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/embedding_core_inputs_probe.py
elapsed_ms_mean=5639.860751 peak_bytes_mean=794596.8 checksum=3085500.0 runtime_input_is_view=1.0

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local probe old_mean=(5666.599854+5698.721564+5539.648930)/3 = `5634.990116 ms`.
- Local probe new_mean=(5596.737901+5585.866453+5624.036280)/3 = `5602.213545 ms`.
- Local delta: `-32.776571 ms` (`0.58%` faster) with unchanged checksum/input count/dimensions and `runtime_input_is_view=1.0`.
- Peak memory changed from `794436.8` to `794596.8` bytes (`+160 bytes`, below the registered 5% warning threshold).
- CI is required for the registered PR-scoped performance report validation before merge.

## Known Gaps
- Local Linux validation covers the Python embedding core path only. No Swift runtime effect is claimed.
- The local elapsed improvement is small; the registered CI probe is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
