### PR TITLE
perf: short-circuit exact evaluation answers

### DIFF
--- a/docs/plans/2026-07-12-evaluation-answer-exact-nonempty.md
+++ b/docs/plans/2026-07-12-evaluation-answer-exact-nonempty.md
@@ -1,0 +1,27 @@
+# Evaluation Answer Exact Nonempty Fast Path Slice
+
+## Scope
+
+This Python-only performance slice is limited to `worker.engine.evaluation_core.EvaluationCore._answers_match`. It preserves empty-prediction rejection and normalized fallback matching while moving the non-empty exact-match short circuit before the whitespace-only check.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/engine/evaluation_core.py`
+- `services/mlx-worker-python/tests/test_evaluation_core.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/evaluation_answer_normalization_probe.py`
+
+## Plan
+
+1. Keep the registered `evaluation-answer-normalization-fast-path` probe unchanged.
+2. Check `expected == predicted and predicted` before calling `predicted.strip()` so the common non-empty exact-match path avoids an unnecessary allocation/scan.
+3. Preserve the existing empty-string and whitespace-only false result by requiring `predicted` to be truthy in the exact-match branch and retaining the strip guard afterward.
+4. Verify with the registered focused test command, changed-scope coverage command, and local registered Linux probe before PR creation. Use PR-scoped performance CI as the merge gate.
+
+## Metrics
+
+Success is measured by `answer_match_elapsed_ms_mean` from `scripts/evaluation_answer_normalization_probe.py` with unchanged match checksum and exact-pair count. Changed-scope coverage must stay at or above 95%.

--- a/services/mlx-worker-python/worker/engine/evaluation_core.py
+++ b/services/mlx-worker-python/worker/engine/evaluation_core.py
@@ -4112,10 +4112,10 @@ class EvaluationCore:
 
     @staticmethod
     def _answers_match(*, expected: str, predicted: str) -> bool:
+        if expected == predicted and predicted:
+            return True
         if not predicted.strip():
             return False
-        if expected == predicted:
-            return True
         normalized_expected = EvaluationCore._normalized_answer(expected)
         normalized_predicted = EvaluationCore._normalized_answer(predicted)
         return normalized_expected == normalized_predicted


### PR DESCRIPTION
## Summary
- Move the non-empty exact-answer short circuit in `EvaluationCore._answers_match` before the whitespace-only guard.
- Preserve empty-prediction rejection while avoiding an unnecessary `predicted.strip()` scan/allocation for the common exact-match path.
- Add a focused plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-07-12-evaluation-answer-exact-nonempty.md`
- Registered probe: `evaluation-answer-normalization-fast-path` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline on origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_answer_normalization_probe.py
exit 0
{"answer_match_elapsed_ms_mean": 83.026446, "elapsed_ms_mean": 132.322597, "answer_match_checksum": 324000.0, "answer_match_exact_pair_count": 2400.0}

# Head/local registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/evaluation_answer_normalization_probe.py
exit 0
{"answer_match_elapsed_ms_mean": 74.259726, "elapsed_ms_mean": 134.915817, "answer_match_checksum": 324000.0, "answer_match_exact_pair_count": 2400.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_core.py::test_evaluation_helpers_cover_numeric_option_and_normalization_paths services/mlx-worker-python/tests/test_evaluation_core.py::test_normalized_answer_skips_extractors_for_free_text services/mlx-worker-python/tests/test_evaluation_core.py::test_answers_match_exact_nonempty_short_circuit_skips_normalization services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_answer_normalization_probe_fallback_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_persists_agentic_tool_evidence services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_writes_agentic_judge_prompt_snapshot_and_audit services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_prompt_snapshot_rejects_hidden_gold_context services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_forbidden_keys services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_allows_explicit_answer_values services/mlx-worker-python/tests/test_evaluation_core.py::test_agentic_judge_payload_no_leak_validator_rejects_extra_payload_fields services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_returns_agentic_judge_artifacts_without_jobs_root services/mlx-worker-python/tests/test_evaluation_core.py::test_run_local_suite_injects_agentic_tool_trace_before_scoring
exit 0: 19 passed in 7.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/evaluation_core.py services/mlx-worker-python/tests/test_evaluation_core.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_answer_normalization_probe.py
exit 0: 19 passed in 5.71s; TOTAL 2 0 100%

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered local probe target metric: `answer_match_elapsed_ms_mean` improved from `83.026446 ms` to `74.259726 ms` (`-8.766720 ms`, about `10.56%` faster).
- Structural/behavior metrics unchanged: `answer_match_checksum=324000.0`, `answer_match_exact_pair_count=2400.0`.
- Non-target `elapsed_ms_mean` changed from `132.322597 ms` to `134.915817 ms`; this normalization metric is not touched by this slice and remained within the 5% probe threshold locally.
- CI PR-scoped performance is required for the registered probe validation before merge.

## Known Gaps
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this PR uses the registered focused Python test/coverage/probe commands on Linux plus GitHub Actions.
- No Swift runtime validation is applicable; this is a Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped performance probe; no new runtime observability or probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
