### PR TITLE
perf: inline local job list dict copies

### DIFF
--- a/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
+++ b/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
@@ -45,6 +45,12 @@ This Python-only follow-up keeps the same registered `local-job-followup-scan-sc
 
 The focused regression guard covers dict/list/tuple subclasses to prove the fallback branch still deep-copies nested mutable payloads. The registered scalar-copy probe remains the local and CI metric source for the copy helper slice. No record schema, reconciliation, claim, prompt-context admission, scan ordering, or receipt payload fields change.
 
+## 2026-07-13 follow-up: exact list-of-dicts copy fast path
+
+This Python-only follow-up keeps the same registered `local-job-followup-scan-scandir` probe and narrows `_copy_json_like_value(...)` for the exact-list branch used by projected local-job follow-up payloads. Exact lists now build the destination list with a local `append` binding and copy exact dict items inline when their values are JSON scalars, avoiding one recursive helper call per list item in the common `items: [{...}, ...]` completion-summary shape. Non-scalar nested values still route through `_copy_json_like_value(...)`, and list subclasses still use the existing subclass-aware fallback branch.
+
+The existing scalar/container regression guards cover mutation isolation for the exact list/dict shape and subclass preservation. No record schema, reconciliation, claim, prompt-context admission, scan ordering, or receipt payload fields change.
+
 ## Linux validation boundary
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime behavior changes are included.

--- a/services/mlx-worker-python/tests/test_local_job_continuation.py
+++ b/services/mlx-worker-python/tests/test_local_job_continuation.py
@@ -857,6 +857,7 @@ def test_project_local_job_session_followup_copy_preserves_json_scalars_by_value
             "summary": scalar_payload,
             "items": [scalar_payload],
             "triple": ("a", scalar_payload, 3),
+            "mixed": ["leaf", {"nested": [scalar_payload]}, ("tuple-leaf",)],
         }
     )
 
@@ -864,6 +865,7 @@ def test_project_local_job_session_followup_copy_preserves_json_scalars_by_value
         "summary": scalar_payload,
         "items": [scalar_payload],
         "triple": ("a", scalar_payload, 3),
+        "mixed": ["leaf", {"nested": [scalar_payload]}, ("tuple-leaf",)],
     }
     assert copied is not scalar_payload
     assert copied["summary"] is not scalar_payload

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -1001,7 +1001,36 @@ def _copy_json_like_value(value: Any) -> Any:
                 copied[key] = _copy_json_like_value(nested)
         return copied
     if value_type is list:
-        return [_copy_json_like_value(item) for item in value]
+        copied_list: list[Any] = []
+        append = copied_list.append
+        for item in value:
+            item_type = type(item)
+            if (
+                item_type is str
+                or item_type is int
+                or item_type is float
+                or item_type is bool
+                or item is None
+            ):
+                append(item)
+            elif item_type is dict:
+                copied_item: dict[Any, Any] = {}
+                for key, nested in item.items():
+                    nested_type = type(nested)
+                    if (
+                        nested_type is str
+                        or nested_type is int
+                        or nested_type is float
+                        or nested_type is bool
+                        or nested is None
+                    ):
+                        copied_item[key] = nested
+                    else:
+                        copied_item[key] = _copy_json_like_value(nested)
+                append(copied_item)
+            else:
+                append(_copy_json_like_value(item))
+        return copied_list
     if value_type is tuple:
         if len(value) == 2:
             return (_copy_json_like_value(value[0]), _copy_json_like_value(value[1]))


### PR DESCRIPTION
## Summary
- Optimize the local-job follow-up JSON copy helper for exact lists containing exact dict items.
- Copy scalar-valued dict items inline with a local list append binding to avoid one recursive helper call per common `items: [{...}]` payload entry.
- Extend the existing regression guard to cover scalar list entries, nested dict-list values, and tuple fallback entries.

## Plan or Spec
- Updated `docs/plans/2026-06-15-local-job-followup-loop-bindings.md` with the 2026-07-13 exact list-of-dicts copy fast-path slice.
- Registered probe coverage remains `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json`, which already includes focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` (baseline before changes)
- `bash /tmp/local_job_test_command.sh`
- `bash /tmp/local_job_coverage_command.sh`
- `bash /tmp/local_job_probe_command.sh`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `19 passed in 0.48s`.
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered local probe before change: `projection_elapsed_ms_mean=168.682578`, `scalar_copy_optimized_elapsed_ms_mean=1706.179733`, `scalar_copy_speedup=1.654597`.
- Registered local probe after change: `projection_elapsed_ms_mean=143.403716`, `scalar_copy_optimized_elapsed_ms_mean=1674.544296`, `scalar_copy_speedup=1.669594`.
- Local deltas: projection `-25.278862 ms` (~14.99% faster); scalar-copy optimized `-31.635437 ms` (~1.85% faster).

## Known Gaps
- Linux-local validation covers this Python-only slice. No Swift runtime behavior changes are included.
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux and showed improvement.
- [ ] GitHub Actions completed successfully.
- [ ] PR-scoped performance report completed successfully.
