### PR TITLE
perf: speed up PR scope command summaries

### DIFF
--- a/docs/plans/2026-07-13-pr-scope-command-summary-lstrip.md
+++ b/docs/plans/2026-07-13-pr-scope-command-summary-lstrip.md
@@ -1,0 +1,24 @@
+# PR Scoped Command Summary Lstrip Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `_summarize_command(...)` in `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`. The helper is used by PR-scoped performance command logging and is exercised by the scope matcher probe workload.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`. The registry entry provides focused `test_command`, `coverage_command`, and `probe_command` entries, and the probe reports `command_summary_ms_mean` for repeated command summary rendering.
+
+## Optimization
+
+The previous helper trimmed leading and first-line trailing whitespace with Python-level character loops. This slice switches those trims to `str.lstrip()` and `str.rstrip()` while preserving the existing first-line/newline behavior, empty-command fallback, and max-length truncation rules.
+
+## Verification Plan
+
+Run locally on Linux before PR:
+
+1. Focused `test_pr_scoped_performance.py` command-summary and registered-probe tests.
+2. Changed-scope coverage using the registered coverage command for `pr-scoped-performance-scope-matcher`.
+3. Registered probe locally with `pr-scoped-performance-scope-matcher` against `origin/main` and the candidate branch.
+4. `git diff --check`.
+
+GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -75,26 +75,15 @@ def _log_progress(message: str) -> None:
 
 
 def _summarize_command(command: str, *, max_length: int = 180) -> str:
-    command_length = len(command)
-    start_index = 0
-    while start_index < command_length and command[start_index].isspace():
-        start_index += 1
-    if start_index >= command_length:
+    summary = command.lstrip().rstrip()
+    if not summary:
         return "<empty command>"
 
-    end_index = command_length - 1
-    while end_index > start_index and command[end_index].isspace():
-        end_index -= 1
-    end_index += 1
-
-    newline_index = command.find("\n", start_index, end_index)
+    newline_index = summary.find("\n")
     if newline_index < 0:
-        summary = command[start_index:end_index]
+        summary = summary.rstrip()
     else:
-        line_end = newline_index
-        while line_end > start_index and command[line_end - 1].isspace():
-            line_end -= 1
-        summary = command[start_index:line_end] + " ..."
+        summary = summary[:newline_index].rstrip() + " ..."
     if len(summary) > max_length:
         if max_length <= 0:
             return ""


### PR DESCRIPTION
## Summary
- Speed up PR-scoped performance command summary rendering by using C-level `str.lstrip()`/`str.rstrip()` trimming instead of Python character loops.
- Preserve existing empty-command, first-line, multiline, and max-length truncation behavior.
- Add a plan note for the command-summary performance slice.

## Plan or Spec
- `docs/plans/2026-07-13-pr-scope-command-summary-lstrip.md`
- Registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered pr-scoped-performance-scope-matcher test selection>
# 24 passed in 15.75s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered pr-scoped-performance-scope-matcher test selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 24 passed in 50.35s
# TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 -c "import json; from pathlib import Path; from worker.productization.pr_scoped_performance import _probe_pr_scoped_scope_matcher as probe; print(json.dumps(probe(Path.cwd()), sort_keys=True))"
# {"build_scope_report_ms_mean": 2.308782, "build_scope_report_ms_min": 0.725122, "changed_file_count": 3205.0, "command_summary_iterations": 20000.0, "command_summary_ms_mean": 10.700269, "force_all_selected_mean": 0.0, "sample_count": 6.0, "selected_probe_count_mean": 7.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/pr_scope_command_summary_probe.json
# head verification OK; coverage 100%; base/head probes OK

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%` for `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
- Local registered probe comparison (`pr-scoped-performance-scope-matcher`):
  - `command_summary_ms_mean`: base `11.815505` ms → head `9.821386` ms (`-1.994119` ms, ~16.88% faster).
  - `build_scope_report_ms_mean`: base `4.174299` ms → head `1.481806` ms (`-2.692493` ms; noisy but non-regressing in this run).
  - `selected_probe_count_mean`: base/head `7.0`; `force_all_selected_mean`: base/head `0.0`.
- CI PR-scoped performance report is still required as the registered probe merge gate.

## Known Gaps
- Linux local validation only; this is a Python tooling slice and does not require Swift runtime validation.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. (N/A: no observability mode change; existing PR-scoped evidence probe used.)
- [x] Deferred work and known gaps are stated explicitly.
