### PR TITLE
perf: skip disjoint direct probe scan

### DIFF
--- a/docs/plans/2026-07-13-pr-scope-direct-probe-disjoint.md
+++ b/docs/plans/2026-07-13-pr-scope-direct-probe-disjoint.md
@@ -1,0 +1,25 @@
+# PR-scoped Direct Probe Disjoint Fast Path
+
+## Summary
+
+Optimize the Python PR-scoped performance scope matcher by avoiding the direct
+force-all probe scan when the normalized changed-path set is disjoint from the
+small set of exact direct force-all paths.
+
+## Scope
+
+- Affected path: `services/mlx-worker-python/worker/productization/pr_scoped_performance.py`.
+- Registered probe: `pr-scoped-performance-scope-matcher` in
+  `infra/perf/pr_scoped_probes.json`.
+- Verification remains Linux-local for Python tests, changed-scope coverage, and
+  the registered probe.
+
+## Behavior and Metrics
+
+Behavior is unchanged: direct force-all probe IDs are still added whenever one of
+the registered exact direct paths is present. The fast path only skips the helper
+call for common changed-file sets that do not contain those exact paths.
+
+Success metric: lower or neutral `build_scope_report_ms_mean` from the registered
+`pr-scoped-performance-scope-matcher` probe, with unchanged selected probe count
+and force-all state.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3323,6 +3323,20 @@ def test_scope_selection_reuses_full_path_set_when_no_context_only_paths(
         tracked_normalized_match,
     )
 
+    def fail_direct_probe_scan(
+        *,
+        changed_paths: frozenset[str],
+        probes: tuple[ProbeDefinition, ...],
+    ) -> frozenset[int]:  # pragma: no cover - sentinel
+        _ = (changed_paths, probes)
+        raise AssertionError("disjoint direct probe paths should skip direct probe scan")
+
+    monkeypatch.setattr(
+        pr_scoped_performance_module,
+        "_force_all_direct_probe_indexes",
+        fail_direct_probe_scan,
+    )
+
     pr_scoped_performance_module._scope_selection_uncached(
         probes=probes,
         changed_paths=changed_paths,

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -53,6 +53,7 @@ _FORCE_ALL_DIRECT_PROBE_IDS_BY_EXACT_PATH = {
         }
     ),
 }
+_FORCE_ALL_DIRECT_EXACT_PATHS = frozenset(_FORCE_ALL_DIRECT_PROBE_IDS_BY_EXACT_PATH)
 _COVERAGE_PERCENT_RE = re.compile(r"TOTAL\s+\d+\s+\d+\s+(\d+)%")
 _TEXT_FILE_SUFFIXES = {".md", ".py", ".json", ".txt", ".yaml", ".yml"}
 _COMMAND_HEARTBEAT_SECONDS = 30.0
@@ -2438,10 +2439,11 @@ def _scope_selection_uncached(
             probes=probes,
         )
     )
-    matched_probe_indexes = matched_probe_indexes | _force_all_direct_probe_indexes(
-        changed_paths=changed_path_set,
-        probes=probes,
-    )
+    if not _FORCE_ALL_DIRECT_EXACT_PATHS.isdisjoint(changed_path_set):
+        matched_probe_indexes = matched_probe_indexes | _force_all_direct_probe_indexes(
+            changed_paths=changed_path_set,
+            probes=probes,
+        )
     matched_probe_index_tuple = tuple(sorted(matched_probe_indexes))
     matched_probe_entries = tuple(probes[index] for index in matched_probe_index_tuple)
     if force_all:


### PR DESCRIPTION
## Summary
- Skip the direct force-all probe helper when changed paths are disjoint from the exact direct probe path set.
- Extend the existing scope-selection regression test to prove the disjoint path avoids the direct scan.
- Add a scoped plan for the PR-scoped matcher slice.

## Plan or Spec
- `docs/plans/2026-07-13-pr-scope-direct-probe-disjoint.md`
- Registered probe: `pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json` (already includes focused test, coverage, and probe commands for this path).

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_selection_reuses_full_path_set_when_no_context_only_paths services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_large_changed_set_preserves_exact_selection_semantics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered pr-scoped-performance-scope-matcher focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo . --output /tmp/pr-scope-direct-probe-disjoint-result.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `2 passed in 1.17s`.
- Registered coverage selection: `25 passed in 50.36s`; changed-scope coverage `TOTAL 4 0 100%`.
- Registered probe (`pr-scoped-performance-scope-matcher`, local Linux):
  - `build_scope_report_ms_mean`: base `3.705073 ms`, head `1.285725 ms`, delta `-2.419348 ms`, speedup `2.8817x` (`65.30%` lower).
  - `selected_probe_count_mean`: base `7.0`, head `7.0`.
  - `force_all_selected_mean`: base `0.0`, head `0.0`.

## Known Gaps
- This is a Python-only slice and was locally validated on Linux. CI remains the authoritative validation for the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused test passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe passed locally with improved `build_scope_report_ms_mean` and unchanged selection semantics.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
