### PR TITLE
perf: compact benchmark matrix row writes

### DIFF
--- a/docs/plans/2026-05-02-benchmark-store-write-coalescing.md
+++ b/docs/plans/2026-05-02-benchmark-store-write-coalescing.md
@@ -67,3 +67,17 @@ git diff --check
 - Changed-scope automated coverage is at least 95%.
 - Local probe reports concrete metrics and shows the optimized path is not worse for the measured hot path.
 - Existing scoped CI probe `benchmark-store-matrix-streaming` can validate the same path in PR CI.
+
+## Follow-up Slice: Compact Inline Matrix Row Emission
+
+The 2026-07-13 follow-up keeps row ordering and artifact schema unchanged but
+narrows the benchmark-matrix JSONL/CSV hot loop. `_write_jsonl_and_csv()` now
+uses a compact JSON encoder for JSONL rows and emits CSV rows inline with a
+locally bound `writerow()` and field-name tuple. This avoids generator frame
+overhead and reduces JSONL bytes written for the large request-row artifact while
+preserving one `to_dict()` and one JSONL write per row.
+
+Success is accepted only if the focused benchmark-store tests, changed-scope
+coverage, and local registered probe pass with non-regressive or improved
+`elapsed_ms_mean` and peak memory, and if the PR-scoped CI probe completes
+successfully before merge.

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -621,16 +621,17 @@ class BenchmarkStore:
             csv_writer = csv.writer(csv_handle)
             csv_writer.writerow(fieldnames)
             write_jsonl = jsonl_handle.write
-            dump_json = json.dumps
+            dump_json = json.JSONEncoder(separators=(",", ":")).encode
             normalize_csv_value = _csv_value
-            def csv_rows() -> Iterable[list[str]]:
-                for row in rows:
-                    payload = row.to_dict()
-                    write_jsonl(dump_json(payload) + "\n")
-                    payload_get = payload.get
-                    yield [normalize_csv_value(payload_get(field, "")) for field in fieldnames]
-
-            csv_writer.writerows(csv_rows())
+            write_csv_row = csv_writer.writerow
+            fieldnames_tuple = tuple(fieldnames)
+            for row in rows:
+                payload = row.to_dict()
+                write_jsonl(dump_json(payload) + "\n")
+                payload_get = payload.get
+                write_csv_row(
+                    [normalize_csv_value(payload_get(field, "")) for field in fieldnames_tuple]
+                )
 
     @staticmethod
     def _attach_matrix_tool_turn_summary_fields(


### PR DESCRIPTION
## Summary
- Compact benchmark matrix JSONL row encoding and emit CSV rows inline in `BenchmarkStore._write_jsonl_and_csv()`.
- Update the benchmark-store write coalescing plan with the compact inline matrix row emission slice.
- Keep the existing registered PR-scoped probe coverage for `benchmark-store-matrix-streaming`.

## Plan or Spec
- `docs/plans/2026-05-02-benchmark-store-write-coalescing.md`

## Commands Run
```text
# Baseline probe before this accepted slice:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
# exit 0; elapsed_ms_mean=1879.561125, peak_bytes_mean=179520.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
# exit 0; 28 passed in 7.39s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
# exit 0; 28 passed in 36.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/benchmark_store_probe.py
# exit 0; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
# exit 0; elapsed_ms_mean=1799.65165, peak_bytes_mean=178726.3

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Local registered probe (`benchmark_store_probe.py`):
  - Baseline: `elapsed_ms_mean=1879.561125`, `peak_bytes_mean=179520.0`.
  - Optimized: `elapsed_ms_mean=1799.65165`, `peak_bytes_mean=178726.3`.
  - Delta: `elapsed_ms_mean` -79.909475 ms (~4.25% faster); `peak_bytes_mean` -793.7 bytes (~0.44% lower).
- Registered CI probe validation is required before merge: `benchmark-store-matrix-streaming`.

## Known Gaps
- Full repository gates were not run locally; this Python-only slice was verified with the focused registered test, coverage, and probe commands on Linux.
- CI is the source of truth for the PR-scoped performance workflow report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance evidence via existing registered probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
