### PR TITLE
perf: speed changed-scope diff header parsing

### DIFF
--- a/docs/plans/2026-07-13-changed-scope-diff-header-prefix.md
+++ b/docs/plans/2026-07-13-changed-scope-diff-header-prefix.md
@@ -1,0 +1,26 @@
+# Changed Scope Diff Header Prefix Slice
+
+## Scope
+
+This Python performance slice is limited to `scripts/changed_scope_coverage.py` diff-header detection inside `_parse_changed_lines()`.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped `changed-scope-coverage-diff-parser` probe in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for the parser and synthetic diff workload.
+
+## Plan
+
+1. Keep diff parsing semantics unchanged for git diff headers, hunk lines, additions, deletions, and context lines.
+2. Replace the byte-prefix helper call on candidate `diff --git` lines with a direct fixed-length bytes slice comparison.
+3. Run the registered focused tests, changed-scope coverage command, and the registered parser probe locally on Linux.
+4. Use GitHub Actions and the registered PR-scoped performance report as the merge gate.
+
+## Metrics
+
+Primary metric: `elapsed_ms_mean` from `scripts/changed_scope_coverage_parse_probe.py`; lower is better.
+
+Secondary metrics: `elapsed_ms_min`, `line_count`, `file_count`, and `changed_line_count` ensure the synthetic parser workload and output cardinality remain stable.
+
+## Boundary
+
+This slice changes Python tooling only and is fully locally verifiable on Linux. Swift runtime effects are not in scope.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -105,7 +105,7 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
                 new_line += 1
             continue
         first_char = line[0]
-        if first_char == ascii_lower_d and line.startswith(header_prefix):
+        if first_char == ascii_lower_d and line[:header_prefix_len] == header_prefix:
             separator_index = line.find(header_separator, header_prefix_len)
             add_changed_line = None
             if separator_index >= 0:


### PR DESCRIPTION
## Summary
- Speeds up changed-scope coverage diff header detection by replacing the candidate `bytes.startswith()` helper call with a fixed-length bytes slice comparison.
- Keeps changed line parsing semantics unchanged for git diff headers, hunks, additions, deletions, and context lines.

## Plan or Spec
- `docs/plans/2026-07-13-changed-scope-diff-header-prefix.md`
- Registered PR-scoped probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 51 passed in 1.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 51 passed in 0.73s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 1 0 100%

python3 scripts/changed_scope_coverage_parse_probe.py
# {"changed_line_count": 7680.0, "elapsed_ms_mean": 2.9616714261161783, "elapsed_ms_min": 2.7495879912748933, "file_count": 240.0, "line_count": 16080.0}

python3 - <<'PY'
# repeated base/head parser probe comparison
PY
# base mean_of_means=3.0740328462949646 ms; head mean_of_means=2.8787806300291168 ms; delta=-0.19525221626584788 ms; speedup=1.0678246248530139x

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for the touched parser line.
- Registered local probe (`changed-scope-coverage-diff-parser`): single head run `elapsed_ms_mean=2.9616714261161783`, `elapsed_ms_min=2.7495879912748933`, `file_count=240`, `changed_line_count=7680`.
- Repeated local base/head comparison over five probe executions: `base_mean=3.0740328462949646 ms`, `head_mean=2.8787806300291168 ms`, `delta=-0.19525221626584788 ms`, `speedup=1.0678246248530139x`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python tooling path. Swift runtime validation is not applicable to this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
