### PR TITLE
perf: skip event JSON suffix scan at string end

### DIFF
--- a/docs/plans/2026-07-13-event-json-end-fastpath.md
+++ b/docs/plans/2026-07-13-event-json-end-fastpath.md
@@ -1,0 +1,34 @@
+# Event extraction JSON end fast path
+
+## Scope
+
+This Python performance slice is limited to the event-extraction response JSON parser helpers in `worker.productization.event_extraction`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_response_json_probe.py`
+
+## Optimization plan
+
+The parser already decodes direct JSON objects and fenced JSON responses with `JSONDecoder.raw_decode` and then validates that the remaining suffix is either empty, whitespace, or an optional closing fence.
+
+This slice adds a constant-time end-of-string fast path to the trailing validation helpers so the common exact-end decode path avoids entering the generic whitespace/fence scanner.
+
+## Verification
+
+Local Linux validation must run:
+
+1. The registered focused tests for `event-extraction-response-json-fence-trim`.
+2. The registered changed-scope coverage command.
+3. The registered local probe command.
+
+GitHub Actions PR-scoped performance remains the final registered probe merge gate.
+
+## Expected metrics
+
+The primary expected direction is lower `elapsed_ms_mean` and `direct_elapsed_ms_mean` on the registered event-extraction response JSON probe. Peak memory should remain stable because this slice changes only branch flow and does not allocate new parser data structures.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2942,6 +2942,8 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
 
 
 def _has_only_optional_closing_fence(response_text: str, start: int, response_length: int) -> bool:
+    if start == response_length:
+        return True
     if response_text.startswith(_CLOSING_FENCE_WITH_LEADING_NEWLINE, start):
         start += _CLOSING_FENCE_WITH_LEADING_NEWLINE_LENGTH
         return _skip_json_whitespace(response_text, start, response_length) == response_length
@@ -2955,6 +2957,8 @@ def _has_only_optional_closing_fence(response_text: str, start: int, response_le
 
 
 def _has_only_trailing_whitespace(response_text: str, start: int, response_length: int) -> bool:
+    if start == response_length:
+        return True
     return _skip_json_whitespace(response_text, start, response_length) == response_length
 
 


### PR DESCRIPTION
## Summary
- Add exact-end fast paths to event-extraction JSON suffix validators so raw-decoded direct/fenced JSON responses skip the generic trailing whitespace/fence scanner when the decode ends at the string boundary.
- Keep the registered `event-extraction-response-json-fence-trim` probe as the validation gate.

## Plan or Spec
- `docs/plans/2026-07-13-event-json-end-fastpath.md`

## Commands Run
```text
# Baseline probe on origin/main (melix-base)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py
# exit 0; elapsed_ms_mean=1235.7045457931235; direct_elapsed_ms_mean=1262.0899664005265; peak_bytes_mean=2999220.0; direct_peak_bytes_mean=2999224.8

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_inline_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_object_skips_fence_prefix_checks services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_direct_object_subclass_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_object_subclass_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_object_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_rejects_non_object_payload services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_direct_object_fast_path services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_object_fast_paths_skip_json_loads services/mlx-worker-python/tests/test_event_extraction.py::test_skip_json_whitespace_preserves_ascii_control_boundary services/mlx-worker-python/tests/test_event_extraction.py::test_skip_json_whitespace_keeps_unicode_whitespace_fallback services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_unfenced_closing_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics
# exit 0; 21 passed in 1.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
# exit 0; 21 passed in 0.57s; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py
# exit 0; elapsed_ms_mean=1225.6043331697583; direct_elapsed_ms_mean=1200.4084670217708; peak_bytes_mean=2999220.0; direct_peak_bytes_mean=2999224.8

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%` for `event_extraction.py` changed lines.
- Registered local probe (`event-extraction-response-json-fence-trim`):
  - `elapsed_ms_mean`: 1235.7045457931235 -> 1225.6043331697583 (delta -10.100212623365121 ms, ~0.82% faster)
  - `direct_elapsed_ms_mean`: 1262.0899664005265 -> 1200.4084670217708 (delta -61.681499379354694 ms, ~4.89% faster)
  - `peak_bytes_mean`: 2999220.0 -> 2999220.0 (stable)
  - `direct_peak_bytes_mean`: 2999224.8 -> 2999224.8 (stable)
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this small Python parser slice.
- Local validation is Linux-only; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new probe overhead.
- [x] Deferred work and known gaps are stated explicitly.
