### PR TITLE
perf: use tensor-name set for quantized scale checks

### DIFF
--- a/docs/plans/2026-07-13-quantized-scales-tensor-set-performance.md
+++ b/docs/plans/2026-07-13-quantized-scales-tensor-set-performance.md
@@ -1,0 +1,36 @@
+# Quantized scales tensor-name set performance slice
+
+## Scope
+
+This Python performance slice is limited to `worker.runtime.quantized_tensor_metadata` membership checks used by native multimodal quantization decisions.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py`
+- `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`
+- `services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/quantized_tensor_metadata_prepass_probe.py`
+
+## Optimization plan
+
+`QuantizedTensorMetadata` already materializes an immutable `_tensor_names` snapshot during construction. This slice routes hot tensor-presence checks through that cached frozenset instead of the mapping proxy. `quantized_scales_present()` also checks the cached set directly in this module-local hot path, avoiding an extra method dispatch before falling back to materialized weight lookup.
+
+Behavior remains unchanged: shard lookup still uses `tensor_to_shard`, public `tensor_names` remains stable, and empty weight mappings still skip unnecessary fallback membership checks.
+
+## Verification
+
+Local Linux validation must run:
+
+1. The registered focused tests for `quantized-tensor-metadata-prepass`.
+2. The registered changed-scope coverage command.
+3. The registered local probe command.
+
+GitHub Actions PR-scoped performance remains the final registered probe merge gate.
+
+## Expected metrics
+
+The primary expected direction is lower `metadata_decision_elapsed_ms_mean` in the registered probe. `high_precision_decision_elapsed_ms_mean` and `tensor_names_access_elapsed_ms_mean` should remain within the probe warning threshold because this slice changes only membership dispatch and does not alter parsing or tensor-name snapshot materialization.

--- a/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
+++ b/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py
@@ -2513,6 +2513,11 @@ class _CountingEmptyWeights(dict[str, object]):
         return super().__contains__(key)
 
 
+class _UnexpectedTensorMapping(dict[str, str]):
+    def __contains__(self, key: object) -> bool:  # pragma: no cover - regression guard
+        raise AssertionError("hot tensor membership should use the cached tensor-name set")
+
+
 class _StringifiedOnce:
     def __init__(self, value: str) -> None:
         self.value = value
@@ -2551,8 +2556,14 @@ def test_quantized_scales_present_skips_empty_weight_lookup() -> None:
     metadata = QuantizedTensorMetadata(
         {"language_model.layers.0.q_proj.scales": "model-00001.safetensors"}
     )
+    object.__setattr__(
+        metadata,
+        "tensor_to_shard",
+        _UnexpectedTensorMapping(metadata.tensor_to_shard),
+    )
     empty_weights = _CountingEmptyWeights()
 
+    assert metadata.has_tensor("language_model.layers.0.q_proj.scales") is True
     assert (
         quantized_scales_present(
             "language_model.layers.0.q_proj",

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -31,7 +31,7 @@ class QuantizedTensorMetadata:
         return self._tensor_names
 
     def has_tensor(self, tensor_name: str) -> bool:
-        return tensor_name in self.tensor_to_shard
+        return tensor_name in self._tensor_names
 
     def shard_for(self, tensor_name: str) -> str:
         return self.tensor_to_shard.get(tensor_name, "")
@@ -193,7 +193,7 @@ def quantized_scales_present(
     weights: Mapping[str, object],
 ) -> bool:
     scales_key = f"{prefix}.scales"
-    if metadata.has_tensor(scales_key):
+    if scales_key in metadata._tensor_names:
         return True
     if not weights:
         return False


### PR DESCRIPTION
## Summary
- Route `QuantizedTensorMetadata.has_tensor()` through the cached tensor-name frozenset.
- Use the same cached tensor-name set directly in the hot `quantized_scales_present()` scale-presence check before the materialized-weight fallback.
- Add a regression guard proving hot membership avoids the mapping proxy lookup while preserving the empty-weight short circuit.

## Plan or Spec
- `docs/plans/2026-07-13-quantized-scales-tensor-set-performance.md`
- Registered probe: `quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...quantized-tensor-metadata-prepass focused tests
# 31 passed in 2.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,*/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py,*/services/mlx-worker-python/worker/runtime/mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_mlx_vlm_runtime.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py,*/scripts/quantized_tensor_metadata_prepass_probe.py' -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py ...
# 31 passed in 0.78s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/quantized_tensor_metadata_prepass_probe.py
# head/default: metadata_decision_elapsed_ms_mean=30.074482411146164, high_precision_decision_elapsed_ms_mean=74.28000716026872

# Local base/head comparison with MELIX_QUANTIZED_METADATA_SAMPLES=9 MELIX_QUANTIZED_METADATA_PAIR_COUNT=3000 MELIX_QUANTIZED_METADATA_DECISION_ITERATIONS=30:
# base metadata_decision_elapsed_ms_mean=72.39082890252273
# head metadata_decision_elapsed_ms_mean=67.7623468865123
# delta=-4.628482016010423 ms (-6.393740873229767%)
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe (head/default): `metadata_decision_elapsed_ms_mean=30.074482411146164`; default-size local base comparison was effectively flat/slightly positive (`30.097105028107762 -> 30.074482411146164`, -0.075%).
- Larger repeated local comparison: `metadata_decision_elapsed_ms_mean` improved from `72.39082890252273` to `67.7623468865123` (-4.628 ms, -6.394%).
- Larger repeated local comparison also showed `high_precision_decision_elapsed_ms_mean` from `164.0926325409156` to `167.02944913413376` (+1.790%), within the registered 5% warning threshold.
- CI PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Linux local validation only; this slice is Python-only and does not claim Swift runtime validation.
- Local micro-probe timings show normal noise on unrelated informational metrics; CI registered probe report is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability/debug mode changes.
- [x] Deferred work and known gaps are stated explicitly.
