### PR TITLE
perf: return measured changed lines directly

### DIFF
--- a/docs/plans/2026-07-13-changed-scope-measurable-line-direct-list.md
+++ b/docs/plans/2026-07-13-changed-scope-measurable-line-direct-list.md
@@ -1,0 +1,45 @@
+# Changed Scope Coverage Measurable Line Direct List Slice
+
+## Goal
+
+Reduce per-file overhead in `scripts/changed_scope_coverage.py` when converting
+measured changed lines into non-comment measurable line numbers.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for
+`scripts/changed_scope_coverage.py`, its probe script, and focused tests.
+
+## Scope
+
+This slice only changes the source-line filtering helper used by
+`_measurable_changed_lines`:
+
+- return the measurable non-comment line-number list directly;
+- avoid building an intermediate `line_no -> stripped_source` dictionary;
+- preserve sparse streaming reads and dense full-file reads.
+
+No coverage threshold, diff parsing, allowlist parsing, or PR-scoped probe
+selection behavior changes are included.
+
+## Validation Plan
+
+Run the registered focused test set, changed-scope coverage command, and local
+registered probe on Linux:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+python3 scripts/changed_scope_coverage_measured_probe.py
+```
+
+## Metrics
+
+Primary probe metric: lower `dense_elapsed_ms_mean` and `sparse_elapsed_ms_mean`
+from `changed-scope-coverage-measured-set-filter`, with unchanged source read
+call counts and measured line counts.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -239,29 +239,33 @@ def _sorted_line_list_contains(lines: list[int], line_no: int) -> bool:
     return index < len(lines) and lines[index] == line_no
 
 
-def _stripped_source_lines_for_numbers(
+def _measurable_non_comment_lines(
     source_path: Path,
     line_numbers: list[int],
-) -> dict[int, str]:
+) -> list[int]:
+    measurable: list[int] = []
+    append_measurable = measurable.append
     if len(line_numbers) <= _SPARSE_SOURCE_LINE_SCAN_THRESHOLD:
         remaining = set(line_numbers)
-        stripped_by_line: dict[int, str] = {}
         with source_path.open("r", encoding="utf-8") as source_file:
             for index, line in enumerate(source_file, 1):
                 if index in remaining:
-                    stripped_by_line[index] = line.strip()
+                    stripped = line.strip()
+                    if stripped and not stripped.startswith("#"):
+                        append_measurable(index)
                     remaining.remove(index)
                     if not remaining:
                         break
-        return stripped_by_line
+        return measurable
 
     source_lines = source_path.read_text(encoding="utf-8").splitlines()
     source_line_count = len(source_lines)
-    return {
-        line_no: source_lines[line_no - 1].strip()
-        for line_no in line_numbers
-        if 1 <= line_no <= source_line_count
-    }
+    for line_no in line_numbers:
+        if 1 <= line_no <= source_line_count:
+            stripped = source_lines[line_no - 1].strip()
+            if stripped and not stripped.startswith("#"):
+                append_measurable(line_no)
+    return measurable
 
 
 def _measurable_changed_lines(
@@ -332,12 +336,9 @@ def _measurable_changed_lines(
         return [], [], []
 
     sorted_measured_changed = sorted(measured_changed)
-    stripped_source_lines = _stripped_source_lines_for_numbers(repo_root / rel_path, sorted_measured_changed)
-    measurable: list[int] = []
-    for line_no in sorted_measured_changed:
-        stripped = stripped_source_lines.get(line_no)
-        if stripped and not stripped.startswith("#"):
-            measurable.append(line_no)
+    measurable = _measurable_non_comment_lines(
+        repo_root / rel_path, sorted_measured_changed
+    )
     if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
         covered = [
             line_no


### PR DESCRIPTION
## Summary
- Return measurable non-comment changed line numbers directly in `scripts/changed_scope_coverage.py`.
- Remove the intermediate `line_no -> stripped_source` dictionary from the changed-scope coverage hot path.
- Add a small governing plan for the `changed-scope-coverage-measured-set-filter` performance slice.

## Plan or Spec
- `docs/plans/2026-07-13-changed-scope-measurable-line-direct-list.md`
- Registered probe: `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_measured_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-measured-set-filter --base-repo /root/.hermes/profiles/coder/workspace/melix-base --head-repo "$PWD" --output /tmp/changed_scope_measurable_direct_probe.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `51 passed`.
- Changed-scope coverage: `TOTAL 14 0 100%` for the changed files.
- Local registered probe comparison (`changed-scope-coverage-measured-set-filter`):
  - `elapsed_ms_mean`: base `0.29494588462901966` -> head `0.28827944437840153` (`-0.00666644025061813 ms`, ~`2.26%` faster)
  - `sparse_elapsed_ms_mean`: base `10.032657434099487` -> head `9.396047148454402` (`-0.6366102856450854 ms`, ~`6.35%` faster)
  - `dense_elapsed_ms_mean`: base `65.12431602459401` -> head `56.2377257073032` (`-8.88659031729081 ms`, ~`13.65%` faster; emitted by probe, currently informational/not a registry threshold metric)
  - `source_read_calls_mean`: base `0.0` -> head `0.0`
  - `sparse_source_read_calls_mean`: base `0.0` -> head `0.0`

## Known Gaps
- Linux-local Python validation is complete for this slice.
- CI is still required for the authoritative registered PR-scoped performance workflow report before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before starting the slice.
- [x] Confirmed affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Implemented exactly one Python performance slice.
- [x] Updated the governing plan under `docs/plans/`.
- [x] Ran focused tests, changed-scope coverage, and the registered probe locally.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
