### PR TITLE
perf: slice local job JSON suffix filter

### DIFF
--- a/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
+++ b/docs/plans/2026-06-15-local-job-followup-loop-bindings.md
@@ -51,6 +51,12 @@ This Python-only follow-up keeps the same registered `local-job-followup-scan-sc
 
 The existing scalar/container regression guards cover mutation isolation for the exact list/dict shape and subclass preservation. No record schema, reconciliation, claim, prompt-context admission, scan ordering, or receipt payload fields change.
 
+## 2026-07-13 follow-up: JSON suffix slice filter
+
+This Python-only follow-up keeps the same registered `local-job-followup-scan-scandir` probe and narrows the flat-store filename filter in `scan_followup_candidates(...)`. The scan now uses a length guard plus direct suffix slicing for `.json` detection instead of calling `str.endswith(...)` for every directory entry. JSON-named files, JSON-named directories, short filenames, non-record suffixes, no-follow file checks, record ordering, and receipt semantics remain unchanged.
+
+The registered scan probe remains the local and CI metric source for this slice. No record schema, reconciliation, claim, prompt-context admission, scan ordering, or receipt payload fields change.
+
 ## Linux validation boundary
 
 This is a Python-only slice and is locally verifiable on Linux. No Swift runtime behavior changes are included.

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -366,7 +366,10 @@ class LocalJobContinuationStore:
             json_suffix_length = len(json_suffix)
             for entry in os.scandir(root_fspath):
                 name = entry.name
-                if not name.endswith(json_suffix):
+                if (
+                    len(name) < json_suffix_length
+                    or name[-json_suffix_length:] != json_suffix
+                ):
                     continue
                 if entry.is_file(follow_symlinks=False):
                     # The scan has already filtered this to a .json file name.


### PR DESCRIPTION
## Summary
- Optimize `LocalJobContinuationStore.scan_followup_candidates(...)` by replacing per-entry `str.endswith(".json")` with a length guard plus direct suffix slicing.
- Preserve JSON file filtering, JSON-named directory skipping, no-follow file checks, scan ordering, and receipt semantics.
- Document the Python-only follow-up in the existing local-job performance plan.

## Plan or Spec
- Updated `docs/plans/2026-06-15-local-job-followup-loop-bindings.md` with the 2026-07-13 JSON suffix slice filter follow-up.
- Registered probe coverage already exists via `local-job-followup-scan-scandir` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` (baseline on `origin/main` before edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_filters_suffix_before_file_stat services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_filters_suffix_before_file_stat services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py` (after edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `git diff --check`

## Coverage and Metrics
- Focused local tests: `6 passed in 2.76s`.
- Broader local-job suite: `107 passed in 1.80s`.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Registered local probe baseline: `elapsed_ms_mean=18.781811`, `candidate_count_mean=500.0`, `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`.
- Registered local probe after edit: `elapsed_ms_mean=18.176363`, `candidate_count_mean=500.0`, `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`.
- Local scan delta: `-0.605448 ms` (`3.22%` lower elapsed mean). CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- Python-only slice validated locally on Linux. No Swift runtime behavior changes are included.
- Local probe timings are synthetic and small; the registered PR-scoped performance workflow is required before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed affected path is covered by registered `local-job-followup-scan-scandir` probe with focused commands.
- [x] Kept implementation to one optimization slice.
- [x] Updated the governing plan under `docs/plans/`.
- [x] Ran focused tests, changed-scope coverage, registered local probe, and `git diff --check`.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
