### PR TITLE
perf: elide singleton coverage range branches

### DIFF
--- a/docs/plans/2026-07-13-changed-scope-singleton-range-branch-elision.md
+++ b/docs/plans/2026-07-13-changed-scope-singleton-range-branch-elision.md
@@ -1,0 +1,26 @@
+# Changed-scope coverage singleton range branch elision
+
+This Python-only performance slice is limited to `scripts/changed_scope_coverage.py` and the registered `changed-scope-coverage-singleton-range-fastpath` PR-scoped probe.
+
+## Scope
+
+- Keep changed-line coverage semantics unchanged.
+- Avoid the sorted-list fallback branch for the common singleton changed-line path when coverage line lists are already ascending.
+- Do not change probe selection, registry behavior, or coverage thresholds.
+
+## Registered probe
+
+The affected path is covered by `infra/perf/pr_scoped_probes.json` entry `changed-scope-coverage-singleton-range-fastpath`, which includes focused `test_command`, `coverage_command`, and `probe_command` values for Linux validation.
+
+## Verification plan
+
+1. Run focused changed-scope coverage tests plus PR-scoped registry tests.
+2. Run the registered changed-scope coverage command for the touched files.
+3. Run `python3 scripts/changed_scope_coverage_singleton_probe.py` locally on Linux and compare with the pre-change baseline.
+4. Use GitHub Actions PR-scoped performance as the merge gate after the PR is opened.
+
+## Local baseline and candidate result
+
+Before the change on `origin/main` (`8a34100ad73c34f7fbc9cb6d7c4d091eb906f74f`), three local probe runs returned singleton elapsed means of approximately `0.541042 ms`, `0.508871 ms`, and `0.527198 ms` with `source_read_calls_mean=0.0` (`old_mean=0.525704 ms`).
+
+After the change, seven stable local probe runs returned `new_mean=0.507185 ms`, `delta_ms=-0.018519`, `speedup=1.036513x`, and `source_read_calls_mean=0.0`.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -195,21 +195,30 @@ def _line_ranges_may_overlap(
         return False
     if len(changed) == 1:
         changed_line = next(iter(changed))
+        if executed_lines and missing_lines:
+            executed_first = executed_lines[0]
+            executed_last = executed_lines[-1]
+            missing_first = missing_lines[0]
+            missing_last = missing_lines[-1]
+            if executed_first <= executed_last and missing_first <= missing_last:
+                first_line = executed_first if executed_first < missing_first else missing_first
+                last_line = executed_last if executed_last > missing_last else missing_last
+                return first_line <= changed_line <= last_line
         if executed_lines:
             first_line = executed_lines[0]
             last_line = executed_lines[-1]
-            if first_line > last_line:
-                first_line = min(executed_lines)
-                last_line = max(executed_lines)
-            if first_line <= changed_line <= last_line:
+            if first_line <= last_line:
+                if first_line <= changed_line <= last_line:
+                    return True
+            elif min(executed_lines) <= changed_line <= max(executed_lines):
                 return True
         if missing_lines:
             first_line = missing_lines[0]
             last_line = missing_lines[-1]
-            if first_line > last_line:
-                first_line = min(missing_lines)
-                last_line = max(missing_lines)
-            if first_line <= changed_line <= last_line:
+            if first_line <= last_line:
+                if first_line <= changed_line <= last_line:
+                    return True
+            elif min(missing_lines) <= changed_line <= max(missing_lines):
                 return True
         return False
 


### PR DESCRIPTION
## Summary
- Optimizes the changed-scope coverage singleton range check by returning directly when both measured coverage line lists are already ascending.
- Adds the governing plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-13-changed-scope-singleton-range-branch-elision.md`
- Registered probe: `changed-scope-coverage-singleton-range-fastpath` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH=$PWD:$PWD/services/mlx-worker-python uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_singleton_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_singleton_probe.py` (baseline and candidate repeated locally)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `51 passed`.
- Changed-scope coverage: `TOTAL 17 0 100%`.
- Local registered probe baseline on `origin/main`: `old_mean=0.525704 ms`, `source_read_calls_mean=0.0`.
- Local registered probe candidate: `new_mean=0.507185 ms`, `delta_ms=-0.018519`, `speedup=1.036513x`, `source_read_calls_mean=0.0`.
- CI PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- The local probe is Linux-only synthetic coverage-path validation; GitHub Actions remains the required merge gate.
- No Swift runtime validation is involved in this Python slice.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally and showed a positive direction.
- [ ] PR-scoped performance CI completed successfully.
- [ ] All required PR checks are green.
