### PR TITLE
perf: unlink prefix cold orphan metadata by string

### DIFF
--- a/docs/plans/2026-07-13-prefix-cold-index-orphan-string-unlink.md
+++ b/docs/plans/2026-07-13-prefix-cold-index-orphan-string-unlink.md
@@ -1,0 +1,25 @@
+# Prefix cold index orphan string unlink
+
+## Scope
+
+This Python-only performance slice is limited to `ColdPrefixStore._ensure_loaded_locked()` cold-index reloads in `services/mlx-worker-python/worker/runtime/prefix_block_store.py`. The registered probe models a cold directory with valid snapshot sidecars plus orphaned metadata files.
+
+The current reload path already uses one `os.scandir()` pass and reuses `entry.name` for the filename-based orphan precheck. This follow-up keeps the orphan precheck in that fast path by unlinking prechecked orphan metadata sidecars directly from the `entry.path` string instead of first constructing a `Path` object only to call `unlink()`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `prefix-cold-index-scandir` in `infra/perf/pr_scoped_probes.json`. The entry has focused `test_command`, `coverage_command`, and `probe_command` entries and reports `elapsed_ms_mean`, `elapsed_ms_min`, `elapsed_ms_p95`, `json_load_calls_mean`, `path_glob_calls_mean`, and `scandir_calls_mean`.
+
+## Optimization plan
+
+1. Keep collecting metadata rows and snapshot names from one `os.scandir()` pass.
+2. For filename-prechecked orphan metadata sidecars, call an `os.unlink()` string-path helper rather than materializing `Path(meta_path_string)`.
+3. Preserve valid metadata parsing, malformed metadata cleanup, no-`Path.glob()` behavior, and scandir-only cold index reload behavior.
+4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux before opening the PR.
+5. Use GitHub Actions PR-scoped performance as the registered probe merge gate.
+
+## Verification
+
+- Focused cold-prefix tests pass.
+- Changed-scope coverage for touched Python/test/plan files remains at or above 95%.
+- Local registered probe should keep `json_load_calls_mean=600`, `path_glob_calls_mean=0`, `scandir_calls_mean=1`, and improve or stay stable on elapsed metrics; CI remains the merge-gate source of truth for the registered probe report.

--- a/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
+++ b/services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import worker.runtime.prefix_block_store as prefix_block_store
 from worker.runtime.prefix_block_store import (
     ColdPrefixStore,
     PrefixBlockStore,
@@ -430,6 +431,58 @@ def test_cold_store_index_reload_skips_json_decode_for_filename_orphans(
     second = _make_cold(tmp_path)
     assert second.entry_count() == 0
     assert list((tmp_path / "cold").glob("*.meta.json")) == []
+
+
+def test_cold_store_index_reload_unlinks_filename_orphans_by_path_string(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    first = _make_cold(tmp_path)
+    first.store(
+        session_id="s1",
+        token_ids=[1, 2, 3, 4],
+        cache_snapshot=_make_snapshot("s1"),
+        cache_mode="CACHE_MODE_TIERED",
+        model_id="m1",
+        model_revision="r1",
+        block_size=4,
+        acceleration_mode="",
+    )
+    snapshot_files = list((tmp_path / "cold").glob("*.kv.safetensors"))
+    assert len(snapshot_files) == 1
+    snapshot_files[0].unlink()
+    removed_path_strings: list[str] = []
+
+    def counted_string_unlink(path: str) -> None:
+        assert type(path) is str
+        removed_path_strings.append(path)
+        os.unlink(path)
+
+    monkeypatch.setattr(
+        prefix_block_store,
+        "_remove_path_string_quietly",
+        counted_string_unlink,
+    )
+
+    second = _make_cold(tmp_path)
+    assert second.entry_count() == 0
+    assert len(removed_path_strings) == 1
+    assert removed_path_strings[0].endswith(".meta.json")
+    assert list((tmp_path / "cold").glob("*.meta.json")) == []
+
+
+def test_remove_path_string_quietly_tolerates_missing_and_denied_paths(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing.meta.json"
+    prefix_block_store._remove_path_string_quietly(str(missing))
+
+    def raise_os_error(path: str) -> None:
+        raise OSError(f"denied: {path}")
+
+    monkeypatch.setattr(prefix_block_store.os, "unlink", raise_os_error)
+    prefix_block_store._remove_path_string_quietly(str(tmp_path / "denied.meta.json"))
 
 
 def test_cold_store_index_load_uses_scandir_without_path_glob(

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -369,7 +369,7 @@ class ColdPrefixStore:
                     # write, or manual snapshot deletion) — drop it before parsing
                     # JSON so orphan-heavy cold dirs do not pay per-sidecar decode
                     # cost on every restart.
-                    _remove_quietly(Path(meta_path_string))
+                    _remove_path_string_quietly(meta_path_string)
                     continue
             meta_path = Path(meta_path_string)
             try:
@@ -476,6 +476,15 @@ def _session_digest(session_id: str) -> str:
 def _remove_quietly(path: Path) -> None:
     try:
         path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _remove_path_string_quietly(path: str) -> None:
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
     except OSError:
         pass
 


### PR DESCRIPTION
## Summary
- Optimize `ColdPrefixStore._ensure_loaded_locked()` orphan-sidecar cleanup by unlinking filename-prechecked orphan metadata sidecars directly from their `os.scandir()` path string.
- Add regression coverage for string-path orphan unlinking and tolerant missing/denied unlink behavior.

## Plan or Spec
- `docs/plans/2026-07-13-prefix-cold-index-orphan-string-unlink.md`
- Registered probe: `prefix-cold-index-scandir` in `infra/perf/pr_scoped_probes.json` covers the touched Python path and already has focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_unlinks_filename_orphans_by_path_string services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_skips_json_decode_for_filename_orphans
# 2 passed in 0.17s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_drops_orphaned_meta services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_skips_json_decode_for_filename_orphans services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_reload_unlinks_filename_orphans_by_path_string services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_remove_path_string_quietly_tolerates_missing_and_denied_paths services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_filters_relevant_suffixes_before_file_stat services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_reuses_scandir_snapshot_names services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_tolerates_scandir_failure services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_cold_store_index_load_skips_entries_with_metadata_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cold_index_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 12 passed in 0.59s under coverage; focused non-coverage run was 11 passed in 0.25s before adding the unlink-helper branch test.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 33 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_COLD_INDEX_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cold_index_scandir_probe.py
# baseline before change: {"elapsed_ms_mean": 39.886137570387554, "elapsed_ms_min": 38.56059908866882, "elapsed_ms_p95": 39.807203924283385, "entry_count": 600.0, "json_load_calls_mean": 600.0, "loaded_count_mean": 600.0, "orphan_count": 600.0, "path_glob_calls_mean": 0.0, "sample_count": 7.0, "scandir_calls_mean": 1.0}
# after change: {"elapsed_ms_mean": 33.31366755134825, "elapsed_ms_min": 30.079245916567743, "elapsed_ms_p95": 34.335391013883054, "entry_count": 600.0, "json_load_calls_mean": 600.0, "loaded_count_mean": 600.0, "orphan_count": 600.0, "path_glob_calls_mean": 0.0, "sample_count": 7.0, "scandir_calls_mean": 1.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 33 0 100%`.
- Local registered probe (`prefix-cold-index-scandir`) improved `elapsed_ms_mean` from `39.886137570387554` to `33.31366755134825` ms (`-6.572470019039306` ms, about `16.48%` faster).
- Guard metrics stayed stable: `json_load_calls_mean=600.0`, `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`.
- CI PR-scoped performance report is required as the merge-gate validation source.

## Known Gaps
- Linux local validation only; no Swift/runtime effect is claimed.
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally for this narrow Python slice; GitHub Actions remains the broad gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
