### PR TITLE
perf: inline dataset record source URI

### DIFF
--- a/docs/plans/2026-07-13-dataset-record-source-uri-inline.md
+++ b/docs/plans/2026-07-13-dataset-record-source-uri-inline.md
@@ -1,0 +1,29 @@
+# Dataset Record Source URI Inline Access
+
+## Scope
+
+This Python-only performance slice is limited to dataset ingest record assembly in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+The hot `_record()` helper now writes `path.name` directly into the emitted
+record instead of first storing the source URI in a short-lived local variable.
+The source-id, source URI, metadata-copying, normalized-text, digest, and byte
+accounting contracts remain unchanged.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The entry
+includes focused `test_command`, `coverage_command`, and `probe_command` values
+for the dataset preparation ingest tests and `scripts/dataset_source_records_probe.py`.
+
+The probe reports record assembly timing through `record_elapsed_ms_mean`,
+`record_elapsed_ms_min`, and `record_elapsed_ms_p95`, alongside traversal and
+source-kind classification metrics.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, `git diff --check`,
+and the registered `dataset-source-records-scandir` probe locally on Linux before
+opening the PR. GitHub Actions PR-scoped performance remains the merge gate for
+the registered probe report.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1518,11 +1518,10 @@ def _record(
     content_sha256, byte_size = _record_content_digest_and_size(normalized_text)
     record_metadata = dict(metadata) if metadata else {}
     sha256 = _SHA256
-    path_name = path.name
     path_key = str(path).encode("utf-8")
     return {
         "source_id": sha256(path_key).hexdigest()[:16],
-        "source_uri": path_name,
+        "source_uri": path.name,
         "source_kind": source_kind,
         "content_sha256": content_sha256,
         "byte_size": byte_size,


### PR DESCRIPTION
## Summary
- Inline dataset ingest record `source_uri` access in `_record()` to avoid a short-lived local variable in the per-record hot path.
- Preserve the existing source-id, source URI, digest, byte-size, metadata-copying, and normalized-text behavior.

## Plan or Spec
- `docs/plans/2026-07-13-dataset-record-source-uri-inline.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 47 passed in 0.56s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 47 passed in 1.21s; TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# {"record_elapsed_ms_mean": 16.970320520075884, "record_elapsed_ms_min": 16.405096044763923, "record_elapsed_ms_p95": 17.953547998331487, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered probe: `dataset-source-records-scandir` is present with focused `test_command`, `coverage_command`, and `probe_command`.
- Local Linux probe comparison from repeated runs:
  - `origin/main` record mean average: `18.315778 ms`
  - branch record mean average: `17.483584 ms`
  - delta: `-0.832193 ms` (`1.0476x`, `4.54%` improvement)
- CI PR-scoped performance report is the merge gate for registered probe validation.

## Known Gaps
- None for local Python verification. CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime overhead.
- [x] Deferred work and known gaps are stated explicitly.
