### PR TITLE
perf: tighten response boundary no-limit aggregation

### DIFF
--- a/docs/plans/2026-05-21-response-boundary-no-limit-minmax.md
+++ b/docs/plans/2026-05-21-response-boundary-no-limit-minmax.md
@@ -15,6 +15,15 @@ When there is no truncation limit, trainable response-token bounds and totals ar
 - Compute only response-token bounds/totals in the hot loop.
 - After the loop, mirror those values into the trainable response-token aggregate fields.
 
+## 2026-07-14 follow-up: no-limit single-loop fast path
+
+The original seed-from-first-entry no-limit branch removed the per-row empty check,
+but local Linux probe runs showed the extra `iter(...)`/`next(...)` setup and split
+first-row path were slower for the registered tuple workload than a single tight
+loop with one predictable `sample_count == 0` branch. This follow-up keeps the
+truncation-limit branch unchanged and restores one no-limit aggregation loop that
+mirrors response-token bounds into trainable response-token fields after the pass.
+
 ## Validation
 
 The registered PR-scoped probe `response-only-boundary-slotted-records` covers this path and includes focused tests, changed-scope coverage, and `scripts/response_only_boundary_slots_probe.py` metrics.

--- a/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
+++ b/services/mlx-worker-python/worker/model_ops/response_only_boundary.py
@@ -239,35 +239,26 @@ def aggregate_response_only_boundaries(
                 fully_truncated_response_sample_count += 1
             sample_count += 1
     else:
-        iterator = iter(boundaries)
-        first_entry = next(iterator, None)
-        if first_entry is not None:
-            offset = first_entry.assistant_offset
-            total_tokens = first_entry.total_tokens
-            response_tokens = total_tokens - offset
-            if response_tokens < 0:
-                response_tokens = 0
-            sample_count = 1
-            boundary_min = offset
-            boundary_max = offset
-            response_tokens_min = response_tokens
-            response_tokens_max = response_tokens
-            total_offset = offset
-            total_response_tokens = response_tokens
-        for entry in iterator:
+        for entry in boundaries:
             offset = entry.assistant_offset
             total_tokens = entry.total_tokens
             response_tokens = total_tokens - offset
             if response_tokens < 0:
                 response_tokens = 0
-            if offset < boundary_min:
+            if sample_count == 0:
                 boundary_min = offset
-            if offset > boundary_max:
                 boundary_max = offset
-            if response_tokens < response_tokens_min:
                 response_tokens_min = response_tokens
-            if response_tokens > response_tokens_max:
                 response_tokens_max = response_tokens
+            else:
+                if offset < boundary_min:
+                    boundary_min = offset
+                if offset > boundary_max:
+                    boundary_max = offset
+                if response_tokens < response_tokens_min:
+                    response_tokens_min = response_tokens
+                if response_tokens > response_tokens_max:
+                    response_tokens_max = response_tokens
             total_offset += offset
             total_response_tokens += response_tokens
             sample_count += 1


### PR DESCRIPTION
## Summary
- Tighten the response-only boundary no-limit aggregation path by using one hot loop instead of priming the iterator and splitting the first row.
- Keep the truncation-limit aggregation branch unchanged and continue mirroring no-limit response-token totals into trainable response-token fields after the pass.
- Update the governing performance plan with the measured follow-up rationale.

## Plan or Spec
- `docs/plans/2026-05-21-response-boundary-no-limit-minmax.md`

## Commands Run
```text
# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_summarizes_train_set_without_rereading_disk services/mlx-worker-python/tests/test_response_only_boundary.py::test_probe_returns_empty_when_response_only_is_disabled services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_response_only_boundary_records_are_slotted services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_consumes_single_pass_iterator services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_response_only_boundary_slots_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_response_only_boundary_slots_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# result: 10 passed, 1 skipped in 5.22s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...same focused test set...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/response_only_boundary.py services/mlx-worker-python/tests/test_response_only_boundary.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/response_only_boundary_slots_probe.py
# result: TOTAL 10 0 100%

# registered local probe, final head run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
# result: {"aggregation_elapsed_ms_mean": 251.97360964957625, "aggregation_no_limit_elapsed_ms_mean": 239.1787985805422, "boundary_count": 50000.0, "checksum": 21964595.0, "construction_elapsed_ms_mean": 118.18555616773665, "instance_dict_count_mean": 0.0, "peak_bytes_mean": 3422112.0, "sample_count": 5.0}

git diff --check
# result: passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 10 0 100%`).
- Registered probe: `response-only-boundary-slotted-records`.
- Local Linux base/head 3-run means:
  - `aggregation_no_limit_elapsed_ms_mean`: base `263.48803899406147` ms, head `244.21946604270488` ms, delta `-19.26857295135659` ms (`-7.312883357028155%`).
  - `aggregation_elapsed_ms_mean`: base `248.97759985954812` ms, head `251.39943140093237` ms, delta `+2.4218315413842504` ms (`+0.9727106144289399%`, below the 5% warning threshold).
  - `peak_bytes_mean`: unchanged at `3422112.0` bytes.
- CI PR-scoped performance is required before merge for the registered probe report.

## Known Gaps
- Local validation is Linux-only; this Python slice does not require Swift runtime validation.
- Full repository gates were deferred to GitHub Actions; the focused registered test, coverage command, and registered probe were run locally.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing evidence-mode registered probe used.
- [x] Deferred work and known gaps are stated explicitly.
