### PR TITLE
perf: bind report evidence role append

### DIFF
--- a/docs/plans/2026-07-14-report-evidence-roles-append.md
+++ b/docs/plans/2026-07-14-report-evidence-roles-append.md
@@ -1,0 +1,25 @@
+# Report evidence matrix-role append binding
+
+## Slice
+
+This slice keeps report evidence role detection behavior unchanged while reusing the already-bound `roles_append` local in the generic `_report_matrix_roles` match branch.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes:
+
+- `test_command` for report evidence gate behavior and probe registry coverage.
+- `coverage_command` for changed-scope coverage on `report_evidence_gate.py`, tests, and the probe script.
+- `probe_command` via `scripts/report_evidence_gate_run_kind_probe.py`, which measures run-kind, metric-prefix, target-field, release-matrix, matrix-role, probe-phase, and dict-list hot paths.
+
+## Implementation
+
+`_report_matrix_roles` already binds `roles.append` to `roles_append` before scanning matrix rules. The run-kind-only branch used that local, but the generic rule branch still performed an attribute lookup. This slice changes only that append site.
+
+## Success criteria
+
+- Existing report evidence gate tests pass.
+- Changed-scope coverage remains at or above the repository threshold.
+- The registered probe reports comparable or lower matrix-role elapsed time without semantic drift.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -329,7 +329,7 @@ def _report_matrix_roles(
             metrics=metrics,
             probe_phases=probe_phases if probe_phases is not None else _EMPTY_PROBE_PHASES,
         ):
-            roles.append(role)
+            roles_append(role)
     return roles
 
 


### PR DESCRIPTION
## Summary
- Bind the generic report-evidence matrix-role append branch to the existing `roles_append` local.
- Keep report evidence gate behavior unchanged while shaving an attribute lookup in the registered hot path.

## Plan or Spec
- `docs/plans/2026-07-14-report-evidence-roles-append.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# 31 passed in 0.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# 31 passed in 0.47s; changed_line_coverage=100.00%; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/report_evidence_gate_run_kind_probe.py"; for CANDIDATE in "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT" "$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2'
# passed; see Coverage and Metrics

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 1 0 100%`).
- Registered probe: `report-evidence-gate-run-kind-set-membership`.
- Baseline local probe on `origin/main`: `elapsed_ms_mean=982.950267`, `matrix_roles_elapsed_ms_mean=3.316213`, `release_matrix_elapsed_ms_mean=28.533397`.
- Candidate local probe on this branch: `elapsed_ms_mean=969.858453`, `matrix_roles_elapsed_ms_mean=3.306583`, `release_matrix_elapsed_ms_mean=27.752792`.
- Delta: overall mean `-13.091814 ms` (~`1.33%` faster); matrix roles `-0.009630 ms` (~`0.29%` faster).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is touched.
- This is a micro-optimization; expected gain is small and should be interpreted through the registered CI probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing PR-scoped evidence probe used.
- [x] Deferred work and known gaps are stated explicitly.
