### PR TITLE
perf: reuse retrieval lookup records type check

### DIFF
--- a/docs/plans/2026-07-14-retrieval-lookup-record-type-fastpath.md
+++ b/docs/plans/2026-07-14-retrieval-lookup-record-type-fastpath.md
@@ -1,0 +1,44 @@
+# Retrieval Lookup Record Type Fastpath Performance Slice
+
+## Context
+
+The registered PR-scoped probe `retrieval-context-projection-fastpath` covers
+`services/mlx-worker-python/worker/runtime/retrieval_context.py`, including
+lookup-result projection and copy behavior. Earlier retrieval slices already
+hoisted retrieval context-kind membership checks, specialized common copy
+shapes, and kept tuple-backed lookup records valid when wrapper metadata is
+present.
+
+## Slice
+
+This Python-only slice is limited to the lookup-result metadata fallback branch
+inside `project_retrieval_lookup_result`. The function already computes
+`records_type = type(lookup_records)` before validating the records container;
+the fallback check now reuses that exact type value instead of calling
+`isinstance(lookup_records, list)` again.
+
+Behavior is unchanged:
+
+- list-backed lookup records keep the existing projection path;
+- tuple-backed lookup records remain accepted and preserve valid metadata;
+- malformed or missing records still return metadata-scoped refusal receipts.
+
+## Probe
+
+Registered probe: `retrieval-context-projection-fastpath`
+
+Required local Linux validation:
+
+- Focused retrieval lookup/result tests, including tuple-record metadata
+  preservation.
+- Changed-scope coverage for retrieval context, the probe selector tests, and
+  the projection probe script.
+- `scripts/retrieval_context_projection_probe.py` through the registered probe
+  command path.
+
+## Expected Impact
+
+The lookup-result hot path avoids one redundant `isinstance` dispatch after an
+exact type lookup has already been performed. Expected gains are very small and
+should be read from the registered probe's lookup-record and lookup-copy
+sub-metrics, with overall projection metrics remaining neutral-to-improved.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -613,7 +613,7 @@ def project_retrieval_lookup_result(
         has_lookup_metadata
         and (
             not has_records
-            or not isinstance(lookup_records, list)
+            or records_type is not list
         )
         and len(refusal_receipts) == 1
         and not prompt_user_payload


### PR DESCRIPTION
## Summary
- Reuse the already-computed exact `records_type` in `project_retrieval_lookup_result` instead of dispatching a second `isinstance(..., list)` check in the metadata fallback branch.
- Add the plan note for this retrieval lookup record-type fastpath slice.

## Plan or Spec
- `docs/plans/2026-07-14-retrieval-lookup-record-type-fastpath.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/runtime/retrieval_context.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...retrieval-context focused tests... ...test_pr_scoped_performance probe tests...` → 36 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py` → TOTAL 0 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py` → run locally before and after the slice
- `git diff --check`

## Coverage and Metrics
- Focused tests: 36 passed in 1.34s; coverage run: 36 passed in 0.39s.
- Changed-scope coverage: `TOTAL 0 0 100%` (the changed production line is not separately measurable by the coverage diff, but the focused retrieval lookup tests cover the branch behavior).
- Local Linux probe comparison against pre-change `origin/main` worktree sample:
  - `optimized_elapsed_ms_mean`: 0.114870 ms → after mean 0.104189 ms (`-0.010681 ms`, `-9.30%`).
  - `lookup_copy_optimized_elapsed_ms_mean`: 2.634012 ms → after mean 2.616534 ms (`-0.017478 ms`, `-0.66%`).
  - `lookup_records_optimized_elapsed_ms_mean`: 0.004255 ms → after mean 0.004365 ms (`+0.000109 ms`, `+2.57%`, noise-scale regression on a sub-micro path).
- CI PR-scoped performance must validate the registered probe report before merge.

## Known Gaps
- Linux local validation cannot replace the registered PR-scoped CI gate; this PR should only merge after GitHub Actions and the registered `retrieval-context-projection-fastpath` report complete successfully.
- The directly targeted fallback branch is extremely small, so sub-metric movement can be noisy.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed the affected path has a registered PR-scoped performance probe with focused commands.
- [x] Implemented exactly one Python performance slice.
- [x] Ran focused local tests on Linux.
- [x] Ran changed-scope coverage on Linux.
- [x] Ran the registered local probe on Linux before and after the change.
- [ ] GitHub Actions / PR-scoped performance completed successfully.
