### PR TITLE
perf: stream export smoke terminal status

### DIFF
--- a/docs/plans/2026-07-14-runtime-export-smoke-terminal-status.md
+++ b/docs/plans/2026-07-14-runtime-export-smoke-terminal-status.md
@@ -1,0 +1,15 @@
+# Runtime export smoke terminal-status performance slice
+
+This Python-only performance slice is limited to the runtime export smoke policy terminal status reducer in `services/mlx-worker-python/worker/productization/export_target_smoke.py`.
+
+## Scope
+
+- Replace the small status-set materialization in `_terminal_status(...)` with a single-pass reducer.
+- Preserve terminal-state precedence: `failed` > `blocked` > `waived` > `passed`.
+- Keep the existing registered `runtime-export-smoke-policy` PR-scoped performance probe as the validation source.
+
+## Verification
+
+- Focused behavior tests in `services/mlx-worker-python/tests/test_export_target_smoke_policy.py` cover precedence and failure short-circuiting.
+- Changed-scope coverage uses the registered probe entry's `coverage_command`.
+- Performance is measured with `scripts/runtime_export_smoke_policy_probe.py` locally on Linux and by the PR-scoped performance workflow in CI.

--- a/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
+++ b/services/mlx-worker-python/tests/test_export_target_smoke_policy.py
@@ -312,6 +312,51 @@ def test_export_target_smoke_metrics_aggregation_is_single_pass() -> None:
     }
 
 
+def test_export_target_smoke_terminal_status_short_circuits_failed() -> None:
+    yielded_statuses: list[str] = []
+
+    def checks():
+        for status in (
+            export_target_smoke.CHECK_STATUS_PASSED,
+            export_target_smoke.CHECK_STATUS_FAILED,
+            export_target_smoke.CHECK_STATUS_BLOCKED,
+        ):
+            yielded_statuses.append(status)
+            yield _check_result(status)
+
+    assert export_target_smoke._terminal_status(checks()) == "failed"
+    assert yielded_statuses == ["passed", "failed"]
+
+
+@pytest.mark.parametrize(
+    ("statuses", "expected"),
+    [
+        ((export_target_smoke.CHECK_STATUS_PASSED,), "passed"),
+        (
+            (
+                export_target_smoke.CHECK_STATUS_PASSED,
+                export_target_smoke.CHECK_STATUS_WAIVED,
+            ),
+            "waived",
+        ),
+        (
+            (
+                export_target_smoke.CHECK_STATUS_WAIVED,
+                export_target_smoke.CHECK_STATUS_BLOCKED,
+            ),
+            "blocked",
+        ),
+    ],
+)
+def test_export_target_smoke_terminal_status_preserves_precedence(
+    statuses: tuple[str, ...],
+    expected: str,
+) -> None:
+    assert export_target_smoke._terminal_status(
+        _check_result(status) for status in statuses
+    ) == expected
+
+
 def test_export_target_smoke_manifest_file_rows_streams_generated_then_required(
     tmp_path: Path,
 ) -> None:
@@ -525,6 +570,20 @@ def _load_runtime_export_smoke_policy_probe():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _check_result(status: str) -> export_target_smoke._CheckResult:
+    return export_target_smoke._CheckResult(
+        status=status,
+        started_at="1970-01-01T00:00:00Z",
+        ended_at="1970-01-01T00:00:00Z",
+        duration_ms=0.0,
+        timeout_ms=1,
+        failure_code="",
+        failure_message="",
+        evidence_path="",
+        diagnostics_receipt_path="",
+    )
 
 
 def _materialized_manifest(

--- a/services/mlx-worker-python/worker/productization/export_target_smoke.py
+++ b/services/mlx-worker-python/worker/productization/export_target_smoke.py
@@ -503,12 +503,19 @@ def _output_preview_payload(
 
 
 def _terminal_status(checks: Iterable[_CheckResult]) -> str:
-    statuses = {check.status for check in checks}
-    if CHECK_STATUS_FAILED in statuses:
-        return CHECK_STATUS_FAILED
-    if CHECK_STATUS_BLOCKED in statuses:
+    saw_blocked = False
+    saw_waived = False
+    for check in checks:
+        status = check.status
+        if status == CHECK_STATUS_FAILED:
+            return CHECK_STATUS_FAILED
+        if status == CHECK_STATUS_BLOCKED:
+            saw_blocked = True
+        elif status == CHECK_STATUS_WAIVED:
+            saw_waived = True
+    if saw_blocked:
         return CHECK_STATUS_BLOCKED
-    if CHECK_STATUS_WAIVED in statuses:
+    if saw_waived:
         return CHECK_STATUS_WAIVED
     return CHECK_STATUS_PASSED
 


### PR DESCRIPTION
## Summary
- Stream `_terminal_status(...)` for runtime export smoke receipts instead of materializing a status set.
- Preserve terminal-state precedence while short-circuiting immediately on `failed`.
- Add focused tests for failure short-circuiting and precedence.

## Plan or Spec
- `docs/plans/2026-07-14-runtime-export-smoke-terminal-status.md`
- Registered probe: `runtime-export-smoke-policy` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 20 passed in 0.59s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_smoke_policy_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_smoke_policy_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_smoke_policy_probe.py
# 20 passed; changed-line coverage TOTAL 25 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_smoke_policy_probe.py
# {"elapsed_ms_mean": 3015.3567244065925, "generation_smoke_latency_ms": 0.5148261552676558, "iteration_count": 30.0, "load_smoke_latency_ms": 0.03024714533239603, "metadata_check_latency_ms": 7.197768893092871, "output_preview_byte_count": 384.0, "peak_bytes_mean": 1200816.4, "sample_count": 5.0, "target_count": 4.0, "timeout_count": 0.0, "waiver_count": 0.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-line coverage: 100% (`TOTAL 25 0 100%`).
- Local registered probe baseline before change: `elapsed_ms_mean=3067.5566191785038`, `peak_bytes_mean=1202643.4`.
- Local registered probe after change: `elapsed_ms_mean=3015.3567244065925`, `peak_bytes_mean=1200816.4`.
- Delta: `-52.199895 ms`, speedup `1.017311x` (`1.7017%` improvement).
- CI PR-scoped performance workflow is required as the registered base-vs-head validation source before merge.

## Known Gaps
- Full repository gates were not run locally; this slice used the registered focused tests, coverage command, and probe on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability added.
- [x] Deferred work and known gaps are stated explicitly.
