### PR TITLE
perf: reduce dev-up dist-info metadata path joins

### DIFF
--- a/docs/plans/2026-07-14-dev-up-dist-info-entry-path.md
+++ b/docs/plans/2026-07-14-dev-up-dist-info-entry-path.md
@@ -1,0 +1,36 @@
+# Dev-up MLX Metal dist-info entry-path slice
+
+## Scope
+
+This performance slice keeps `scripts/dev_up.py` behavior unchanged while reducing
+path-construction overhead in `read_mlx_metal_dist_info_version`. The scan still
+walks ancestors of `mlx.metallib`, accepts `mlx_metal-*.dist-info` directories,
+reads `METADATA` when present, falls back to the dist-info directory version, and
+continues past unreadable directories or metadata files.
+
+## Registered PR-scoped probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dev-up-mlx-metal-dist-info-scandir` in `infra/perf/pr_scoped_probes.json`. The
+entry includes focused `test_command`, `coverage_command`, and `probe_command`
+fields for `scripts/dev_up.py` and the associated regression tests.
+
+## Implementation plan
+
+- Preserve the existing `os.scandir` directory iteration and fallback semantics.
+- Build the `METADATA` path from `DirEntry.path` so matching entries avoid an
+  extra `ancestor / entry_name` path join before appending `METADATA`.
+- Do not change candidate ordering, version parsing, or error handling.
+
+## Verification plan
+
+Run locally on Linux before PR:
+
+1. Focused dist-info regression tests from the registered probe.
+2. Changed-scope coverage using the registered `coverage_command`.
+3. Registered probe locally against `origin/main` and this branch with
+   `scripts/pr_scoped_performance_run.py`.
+4. `git diff --check`.
+
+GitHub Actions PR-scoped performance remains the merge gate for base-vs-head
+validation before merge.

--- a/scripts/dev_up.py
+++ b/scripts/dev_up.py
@@ -508,7 +508,7 @@ def read_mlx_metal_dist_info_version(metallib_path: Path) -> str | None:
                     ):
                         continue
 
-                    metadata_path = ancestor / entry_name / "METADATA"
+                    metadata_path = Path(entry.path) / "METADATA"
                     try:
                         version = _read_dist_info_metadata_version(metadata_path)
                     except OSError:


### PR DESCRIPTION
## Summary
- Reduce `read_mlx_metal_dist_info_version` path-construction overhead by building `METADATA` paths from the matching `DirEntry.path`.
- Preserve existing scandir traversal, metadata parsing, fallback version extraction, and error handling.

## Plan or Spec
- `docs/plans/2026-07-14-dev-up-dist-info-entry-path.md`
- Registered PR-scoped probe: `dev-up-mlx-metal-dist-info-scandir`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_ignores_empty_dist_info_version services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 6 passed in 0.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_uses_scandir_without_path_glob services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_falls_back_to_dist_info_directory_name services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_ignores_empty_dist_info_version services/mlx-worker-python/tests/test_dev_up_script.py::test_read_mlx_metal_dist_info_version_skips_scandir_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dev_up_mlx_metal_dist_info_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/dev_up.py services/mlx-worker-python/tests/test_dev_up_script.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 6 passed in 0.56s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dev-up-mlx-metal-dist-info-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/pr-scoped/dev-up-dist-info-entry-path-rerun.json
# passed; base elapsed_ms_mean=0.980791, head elapsed_ms_mean=0.966731; base elapsed_ms_min=0.909367, head elapsed_ms_min=0.928462

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`scripts/dev_up.py` changed line 511 covered).
- Local registered probe rerun: `old_mean=0.980791ms`, `new_mean=0.966731ms`, `speedup≈1.43%`, `delta=-0.014060ms`.
- `elapsed_ms_min` moved from `0.909367ms` to `0.928462ms` in the local rerun, below the probe's 5% warning threshold.
- GitHub Actions PR-scoped performance is required as the merge gate for final base-vs-head validation.

## Known Gaps
- Local Linux probe timings are sub-millisecond and noisy; CI PR-scoped performance report is the authoritative registered-probe gate before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: PR-scoped performance evidence; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
