### PR TITLE
perf: streamline PR scope changed path normalization

### DIFF
--- a/docs/plans/2026-07-14-pr-scoped-scope-normalization-set-discard.md
+++ b/docs/plans/2026-07-14-pr-scoped-scope-normalization-set-discard.md
@@ -1,0 +1,28 @@
+# PR-scoped scope normalization set-discard slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.pr_scoped_performance.build_scope_report()`.
+The affected path is covered by the registered
+`pr-scoped-performance-scope-matcher` probe in
+`infra/perf/pr_scoped_probes.json`, which includes focused `test_command`,
+`coverage_command`, and `probe_command` entries.
+
+## Plan
+
+`build_scope_report()` normalizes changed file inputs on every PR-scoped
+performance scope build. The previous normalization used a set comprehension
+that filtered empty paths during construction. This slice keeps the same
+observable semantics—deduplicate paths, remove the empty sentinel, and sort the
+result—but builds the set directly from the input list and removes the empty
+sentinel with `discard("")` once. This avoids one Python-level conditional per
+changed-file entry in large PR scopes while preserving the existing sorted scope
+payload.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and the local
+registered `pr-scoped-performance-scope-matcher` probe on Linux before opening
+the PR. GitHub Actions PR-scoped performance remains the merge gate for the
+registered probe report.

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -256,7 +256,8 @@ def build_scope_report(
     changed_files: list[str],
 ) -> dict[str, object]:
     probes = load_probe_registry_for_scope(registry_path)
-    changed_path_set = {path for path in changed_files if path}
+    changed_path_set = set(changed_files)
+    changed_path_set.discard("")
     changed_paths = tuple(sorted(changed_path_set))
     force_all, matched_probe_ids, selected_probes = _scope_selection(
         probes=probes,


### PR DESCRIPTION
## Summary
- Streamline PR-scoped performance scope changed-path normalization by building the set directly from `changed_files` and discarding the empty sentinel once.
- Keep existing behavior: deduplicated, sorted changed files and unchanged probe selection semantics.

## Plan or Spec
- Added `docs/plans/2026-07-14-pr-scoped-scope-normalization-set-discard.md` for this Python-only performance slice.
- Affected path is covered by the registered `pr-scoped-performance-scope-matcher` probe with focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered `pr-scoped-performance-scope-matcher` focused tests)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/pr-scope-local/scope-matcher-result.json`

## Coverage and Metrics
- Focused tests: 25 passed.
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Local registered probe result (`pr-scoped-performance-scope-matcher`):
  - `build_scope_report_ms_mean`: base `2.463578` ms, head `1.181849` ms, delta `-1.281729` ms, speedup `2.0845x`.
  - `selected_probe_count_mean`: base `7.0`, head `7.0`.
  - `force_all_selected_mean`: base `0.0`, head `0.0`.
- GitHub Actions PR-scoped performance report is required for final registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only; no Swift runtime path is changed in this slice.
- The registered CI PR-scoped performance workflow remains the merge gate.

## Evidence Checklist
- [x] Scope is one small performance optimization slice.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage met the 95% requirement.
- [x] Local registered probe showed improvement with unchanged selection counters.
- [ ] GitHub Actions PR-scoped performance completed successfully.
