### PR TITLE
perf: flatten prefix snapshot byte branches

### DIFF
--- a/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
+++ b/docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md
@@ -101,3 +101,17 @@ tensor metadata that produces a non-`int` total.
 Success is accepted only if focused tests, changed-scope coverage, and the local
 registered Linux probe pass with lower elapsed time, and if the PR-scoped CI
 probe completes successfully before merge.
+
+## Follow-up Slice: State Branch Flattening
+
+The next 2026-07-14 follow-up keeps the same registered probe and narrows to the
+per-layer branch layout in `estimate_cache_snapshot_bytes()`. The estimator now
+binds `getattr` once and handles the `.state is None` keys/values path as the
+first branch, then handles state sequences and scalar state objects without the
+extra `continue` jumps. This preserves the existing `.state`, `.keys/.values`,
+`.nbytes`, and `size * itemsize` behavior while trimming interpreter dispatch in
+the repeated snapshot byte-estimation loop.
+
+Success is accepted only if focused tests, changed-scope coverage, and the local
+registered Linux probe pass with lower elapsed time, and if the PR-scoped CI
+probe completes successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/prefix_block_store.py
+++ b/services/mlx-worker-python/worker/runtime/prefix_block_store.py
@@ -447,25 +447,24 @@ def estimate_cache_snapshot_bytes(cache_snapshot: Any) -> int:
     total = 0
     tensor_nbytes = _tensor_nbytes
     sequence_types = _CACHE_STATE_SEQUENCE_TYPES
+    get_attr = getattr
     for layer_cache in cache_snapshot:
-        state = getattr(layer_cache, "state", None)
-        if state is not None:
-            if isinstance(state, sequence_types):
-                if len(state) == 2:
-                    total += tensor_nbytes(state[0]) + tensor_nbytes(state[1])
-                    continue
+        state = get_attr(layer_cache, "state", None)
+        if state is None:
+            keys = get_attr(layer_cache, "keys", None)
+            if keys is not None:
+                total += tensor_nbytes(keys)
+            values = get_attr(layer_cache, "values", None)
+            if values is not None:
+                total += tensor_nbytes(values)
+        elif isinstance(state, sequence_types):
+            if len(state) == 2:
+                total += tensor_nbytes(state[0]) + tensor_nbytes(state[1])
+            else:
                 for tensor in state:
                     total += tensor_nbytes(tensor)
-                continue
+        else:
             total += tensor_nbytes(state)
-            continue
-
-        keys = getattr(layer_cache, "keys", None)
-        if keys is not None:
-            total += tensor_nbytes(keys)
-        values = getattr(layer_cache, "values", None)
-        if values is not None:
-            total += tensor_nbytes(values)
     return total if type(total) is int else int(total)
 
 


### PR DESCRIPTION
## Summary
- Flatten `estimate_cache_snapshot_bytes()` per-layer branches for the prefix-cache snapshot byte estimator.
- Bind `getattr` once and handle the `.state is None` keys/values path without extra `continue` jumps.
- Preserve existing `.state`, `.keys/.values`, `.nbytes`, and `size * itemsize` behavior.

## Plan or Spec
- `docs/plans/2026-07-11-prefix-cache-snapshot-byte-streaming.md` — added the State Branch Flattening follow-up slice.

## Commands Run
```text
# Baseline registered probe before code change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
{"checksum": 62912640.0, "elapsed_ms_mean": 392.65085842926055, "elapsed_ms_min": 388.35980696603656, "elapsed_ms_p95": 394.75561503786594, "iteration_count": 80.0, "layer_count": 4096.0, "peak_bytes_mean": 216.0, "sample_count": 5.0}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_sums_state_and_key_value_layers services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py::test_estimate_cache_snapshot_bytes_coerces_non_int_totals services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_returns_zero_for_empty_and_none services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_sums_nbytes_from_layered_state services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_size_itemsize_fallback services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_handles_scalar_state_with_nbytes services/mlx-worker-python/tests/test_mlx_backend.py::test_estimate_cache_bytes_skips_layer_with_none_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_prefix_cold_index_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_prefix_cache_snapshot_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
11 passed in 1.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/prefix_block_store.py services/mlx-worker-python/tests/test_prefix_cache_cold_tier.py services/mlx-worker-python/tests/test_mlx_backend.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/prefix_cache_snapshot_bytes_probe.py
11 passed in 0.54s
TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_PREFIX_CACHE_SNAPSHOT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/prefix_cache_snapshot_bytes_probe.py
{"checksum": 62912640.0, "elapsed_ms_mean": 382.4045061832294, "elapsed_ms_min": 371.37961899861693, "elapsed_ms_p95": 384.5955409342423, "iteration_count": 80.0, "layer_count": 4096.0, "peak_bytes_mean": 216.0, "sample_count": 5.0}

git diff --check
pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered local probe: `prefix-cache-snapshot-byte-streaming`.
- Baseline `elapsed_ms_mean=392.650858`; candidate `elapsed_ms_mean=382.404506`; delta `-10.246352 ms`; improvement `2.61%` (`~2.68%` speedup by old/new).
- Baseline `elapsed_ms_p95=394.755615`; candidate `elapsed_ms_p95=384.595541`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Python-only slice used the focused registered probe/test/coverage commands on Linux.
- GitHub Actions is the source of truth for the PR-scoped performance workflow after push.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
