### PR TITLE
perf: shortcut trajectory manifest fast extraction

### DIFF
--- a/docs/plans/2026-07-14-trajectory-manifest-direct-fast-extract.md
+++ b/docs/plans/2026-07-14-trajectory-manifest-direct-fast-extract.md
@@ -1,0 +1,22 @@
+# Trajectory Manifest Direct Fast Extract
+
+This Python-only performance slice is limited to `worker.trajectory_provenance.load_trajectory_provenance_from_snapshot_manifest()` for normalized agentic trajectory snapshot manifests loaded from JSON bytes.
+
+## Registered Probe
+
+The affected path is covered by the existing registered PR-scoped performance probe `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_trajectory_provenance.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/trajectory_manifest_json_load_probe.py`
+
+## Slice
+
+Normalized manifest loads currently parse JSON bytes into an exact `dict`, then enter `_trajectory_provenance_from_snapshot_manifest()`, whose first branch immediately calls the clean-manifest fast extractor. This keeps behavior correct, but it spends an extra Python function frame and fallback setup on the hot path that already has the exact loaded `dict` and snapshot path text.
+
+This slice keeps the clean-manifest extraction branch directly in `load_trajectory_provenance_from_snapshot_manifest()` when the decoded payload is an exact `dict`. If the inline fast branch rejects the manifest, the existing fallback extractor is still used, preserving whitespace cleanup, dict-subclass handling, non-trajectory behavior, and nested-copy semantics.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and `trajectory-manifest-json-load` probe locally before pushing. Compare the probe output before and after the change; accept the slice only if the registered probe remains directionally improved or neutral with behavior tests passing.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -414,6 +414,48 @@ def test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_defaulted_
     }
 
 
+def test_load_trajectory_provenance_from_snapshot_manifest_short_circuits_clean_dict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes(
+        json.dumps(
+            {
+                "format": "agentic_tool_trace",
+                "source_dataset_id": "agentic-snapshot",
+                "version": "2026-05-25",
+                "trajectory_trace_digest": "abc123",
+            }
+        ).encode("utf-8")
+    )
+
+    def fail_fallback_extract(
+        _manifest: Mapping[str, object],
+        *,
+        snapshot_manifest_path: Path | str | None = None,
+        copy_nested: bool,
+    ) -> dict[str, object]:
+        raise AssertionError(
+            "clean dict manifest loads should return from the direct fast path"
+        )
+
+    monkeypatch.setattr(
+        trajectory_provenance_module,
+        "_trajectory_provenance_from_snapshot_manifest",
+        fail_fallback_extract,
+    )
+
+    assert load_trajectory_provenance_from_snapshot_manifest(manifest_path) == {
+        "trajectory_dataset_id": "agentic-snapshot",
+        "trajectory_dataset_version": "2026-05-25",
+        "trajectory_schema_version": "melix.agentic_tool_trace.v1",
+        "trajectory_snapshot_manifest_path": str(manifest_path),
+        "trajectory_split": "train",
+        "trajectory_trace_digest": "abc123",
+    }
+
+
 @pytest.mark.parametrize(
     ("field", "fallback_key", "fallback_value"),
     [

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -358,6 +358,76 @@ def load_trajectory_provenance_from_snapshot_manifest(
     with open_file(manifest_path_text, "rb") as manifest_file:
         payload = loads(manifest_file.read())
     if type(payload) is dict:
+        manifest_get = payload.get
+        if manifest_get("format") == "agentic_tool_trace":
+            dataset_id = manifest_get("source_dataset_id")
+            dataset_version = manifest_get("version")
+            trace_digest = manifest_get("trajectory_trace_digest")
+            if (
+                type(dataset_id) is str
+                and dataset_id != ""
+                and not dataset_id[0].isspace()
+                and not dataset_id[-1].isspace()
+                and type(dataset_version) is str
+                and dataset_version != ""
+                and not dataset_version[0].isspace()
+                and not dataset_version[-1].isspace()
+                and type(trace_digest) is str
+                and trace_digest != ""
+                and not trace_digest[0].isspace()
+                and not trace_digest[-1].isspace()
+            ):
+                schema_version = manifest_get("trajectory_schema_version")
+                if schema_version is None:
+                    schema_version = "melix.agentic_tool_trace.v1"
+                elif (
+                    type(schema_version) is not str
+                    or schema_version == ""
+                    or schema_version[0].isspace()
+                    or schema_version[-1].isspace()
+                ):
+                    schema_version = None
+                split = manifest_get("trajectory_split")
+                if split is None:
+                    split = "train"
+                elif (
+                    type(split) is not str
+                    or split == ""
+                    or split[0].isspace()
+                    or split[-1].isspace()
+                ):
+                    split = None
+                if schema_version is not None and split is not None:
+                    provenance: dict[str, Any] = {
+                        "trajectory_dataset_id": dataset_id,
+                        "trajectory_dataset_version": dataset_version,
+                        "trajectory_schema_version": schema_version,
+                        "trajectory_snapshot_manifest_path": manifest_path_text,
+                        "trajectory_split": split,
+                        "trajectory_trace_digest": trace_digest,
+                    }
+                    trajectory_toolset_version = manifest_get("trajectory_toolset_version")
+                    if trajectory_toolset_version is not None and trajectory_toolset_version != "":
+                        provenance["trajectory_toolset_version"] = trajectory_toolset_version
+                    trajectory_registry_schema_version = manifest_get("trajectory_registry_schema_version")
+                    if trajectory_registry_schema_version is not None and trajectory_registry_schema_version != "":
+                        provenance["trajectory_registry_schema_version"] = trajectory_registry_schema_version
+                    trajectory_reward_policy_id = manifest_get("trajectory_reward_policy_id")
+                    if trajectory_reward_policy_id is not None and trajectory_reward_policy_id != "":
+                        provenance["trajectory_reward_policy_id"] = trajectory_reward_policy_id
+                    trajectory_leakage_policy_id = manifest_get("trajectory_leakage_policy_id")
+                    if trajectory_leakage_policy_id is not None and trajectory_leakage_policy_id != "":
+                        provenance["trajectory_leakage_policy_id"] = trajectory_leakage_policy_id
+                    source_package_path = manifest_get("source_package_path")
+                    if source_package_path is not None and source_package_path != "":
+                        provenance["trajectory_package_path"] = source_package_path
+                    trajectory_quality_metrics = manifest_get("trajectory_quality_metrics")
+                    if trajectory_quality_metrics is not None and trajectory_quality_metrics != "":
+                        provenance["trajectory_quality_metrics"] = trajectory_quality_metrics
+                    agentic_sft_token_metrics = manifest_get("agentic_sft_token_metrics")
+                    if agentic_sft_token_metrics is not None and agentic_sft_token_metrics != "":
+                        provenance["agentic_sft_token_metrics"] = agentic_sft_token_metrics
+                    return provenance
         return extract_provenance(
             payload,
             snapshot_manifest_path=manifest_path_text,


### PR DESCRIPTION
## Summary
- Inline the clean trajectory snapshot manifest extraction branch immediately after JSON bytes decode for exact `dict` payloads.
- Preserve the fallback extractor for rejected clean-fast-path payloads, dict subclasses, non-trajectory manifests, and whitespace-cleanup cases.
- Add a focused regression test proving normalized exact-dict manifest loads no longer enter the fallback extraction frame.

## Plan or Spec
- `docs/plans/2026-07-14-trajectory-manifest-direct-fast-extract.md`
- Registered PR-scoped probe: `trajectory-manifest-json-load` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reads_bytes services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_string_path_uses_direct_open services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_path_uses_direct_open services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_keeps_pathlike_support services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_clean_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_paths_defaulted_schema_and_split services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_short_circuits_clean_dict services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_fast_path_falls_back_for_defaulted_required_fields services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_reuses_path_text services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_accepts_dict_subclass services/mlx-worker-python/tests/test_trajectory_provenance.py::test_trajectory_provenance_helpers_ignore_empty_or_unrelated_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_manifest_json_load_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 20 passed in 0.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q <same focused tests>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# changed_line_coverage=97.50%; TOTAL 40 1 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_TRAJECTORY_MANIFEST_JSON_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/trajectory_manifest_json_load_probe.py
# {"elapsed_ms_mean": 707.0600756211206, "new_mean_ms": 707.0600756211206, "old_mean_ms": 1545.7474634051323, "delta_ms": -838.6873877840117, "speedup": 2.1861614263077467, "peak_bytes_mean": 53944.0, "sample_count": 5.0, "iteration_count": 2000.0, "component_count": 64.0}
```

## Coverage and Metrics
- Changed-scope coverage: `97.50%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines (`TOTAL 40 1 98%`).
- Registered local probe: `trajectory-manifest-json-load`.
- Pre-change local probe sample on `origin/main`: `new_mean_ms=733.2163068233058`, `old_mean_ms=1571.9631388084963`, `speedup=2.1439282298822575`, `peak_bytes_mean=53944.0`.
- Post-change local probe sample: `new_mean_ms=707.0600756211206`, `old_mean_ms=1545.7474634051323`, `speedup=2.1861614263077467`, `peak_bytes_mean=53944.0`.
- Local observed delta vs pre-change optimized mean: `-26.156231202185154 ms` (`~3.57%` lower elapsed mean). CI PR-scoped performance report remains the merge validation source.

## Known Gaps
- None for the Python slice. CI must complete the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime probe overhead change.
- [x] Deferred work and known gaps are stated explicitly.
