### PR TITLE
perf: read code eval stdio tail with pread

### DIFF
--- a/docs/plans/2026-07-14-code-eval-stdio-pread-tail.md
+++ b/docs/plans/2026-07-14-code-eval-stdio-pread-tail.md
@@ -1,0 +1,45 @@
+# Code Eval Stdio Tail Positional Read
+
+## Summary
+
+Use a single positional read for oversized code-evaluation stdio tail capture.
+The code evaluation runner already keeps stdio size accounting from `fstat(2)`;
+when the file exceeds the configured byte limit it can read the trailing window
+with `os.pread` instead of mutating the descriptor offset with `lseek` before a
+separate `read`.
+
+## Scope
+
+- Path: `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- Probe: `code-eval-stdio-tail-single-stat`
+- Behavior: unchanged tail text and byte-size reporting for missing, empty,
+  oversized, directory, and close-error cases.
+
+## Verification Plan
+
+- Run the registered focused tests for `code-eval-stdio-tail-single-stat`.
+- Run changed-scope coverage through the registered coverage command.
+- Run the registered local probe on Linux and compare to the pre-change baseline.
+
+## Metrics
+
+Baseline local registered probe before the change:
+
+```json
+{"elapsed_ms_mean":26.490368600934744,"iteration_count":3000.0,"output_limit_exceeded_mean":1.0,"sandbox_profile_elapsed_ms_mean":37.60965238325298,"sandbox_profile_iteration_count":1500.0,"sandbox_profile_length_mean":1324.0,"sandbox_profile_static_builds_mean":1.0,"stdio_stat_calls_mean":6000.0,"tail_chars_mean":5119.0}
+```
+
+Post-change local registered probe samples:
+
+```json
+{"elapsed_ms_mean":26.774873794056475,"iteration_count":3000.0,"output_limit_exceeded_mean":1.0,"sandbox_profile_elapsed_ms_mean":38.15880019683391,"sandbox_profile_iteration_count":1500.0,"sandbox_profile_length_mean":1324.0,"sandbox_profile_static_builds_mean":1.0,"stdio_stat_calls_mean":6000.0,"tail_chars_mean":5119.0}
+{"elapsed_ms_mean":30.37696380633861,"iteration_count":3000.0,"output_limit_exceeded_mean":1.0,"sandbox_profile_elapsed_ms_mean":37.1929724002257,"sandbox_profile_iteration_count":1500.0,"sandbox_profile_length_mean":1324.0,"sandbox_profile_static_builds_mean":1.0,"stdio_stat_calls_mean":6000.0,"tail_chars_mean":5119.0}
+{"elapsed_ms_mean":26.487190439365804,"iteration_count":3000.0,"output_limit_exceeded_mean":1.0,"sandbox_profile_elapsed_ms_mean":36.85401298571378,"sandbox_profile_iteration_count":1500.0,"sandbox_profile_length_mean":1324.0,"sandbox_profile_static_builds_mean":1.0,"stdio_stat_calls_mean":6000.0,"tail_chars_mean":5119.0}
+{"elapsed_ms_mean":27.831678045913577,"iteration_count":3000.0,"output_limit_exceeded_mean":1.0,"sandbox_profile_elapsed_ms_mean":37.72796578705311,"sandbox_profile_iteration_count":1500.0,"sandbox_profile_length_mean":1324.0,"sandbox_profile_static_builds_mean":1.0,"stdio_stat_calls_mean":6000.0,"tail_chars_mean":5119.0}
+```
+
+The end-to-end registered probe includes sandbox-profile construction noise; a
+tight local A/B for the touched tail-read primitive measured `lseek+read` at
+21.506 ms mean and `pread` at 19.827 ms mean over seven 5,000-iteration samples
+on the same oversized file. The PR-scoped performance workflow remains the
+authoritative CI validation for this registered probe.

--- a/services/mlx-worker-python/tests/test_code_eval_runner.py
+++ b/services/mlx-worker-python/tests/test_code_eval_runner.py
@@ -676,6 +676,20 @@ def test_read_limited_stdio_ignores_close_errors(
     assert code_eval_runner._read_limited_stdio(output_path, 4) == ("cdef", 16)
 
 
+def test_read_limited_stdio_reads_oversized_tail_without_lseek(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_path = tmp_path / "output.txt"
+    output_path.write_text("0123456789abcdef", encoding="utf-8")
+
+    def fail_lseek(*args: object, **kwargs: object) -> int:  # pragma: no cover - sentinel
+        raise AssertionError("oversized stdio tail reads should use positional pread")
+
+    monkeypatch.setattr(code_eval_runner.os, "lseek", fail_lseek)
+
+    assert code_eval_runner._read_limited_stdio(output_path, 4) == ("cdef", 16)
+
+
 def test_output_limit_reuses_limited_stdio_sizes(monkeypatch) -> None:
     monkeypatch.setattr(code_eval_runner.shutil, "which", lambda _: "/usr/bin/sandbox-exec")
     read_paths: list[str] = []

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -779,8 +779,10 @@ def _read_limited_stdio(path: Path, byte_limit: int) -> tuple[str, int]:
         if read_size == 0:
             return "", size
         if size > read_limit:
-            os.lseek(fd, -read_limit, os.SEEK_END)
-        return os.read(fd, read_size).decode("utf-8", errors="replace").strip(), size
+            payload = os.pread(fd, read_size, size - read_size)
+        else:
+            payload = os.read(fd, read_size)
+        return payload.decode("utf-8", errors="replace").strip(), size
     except OSError:
         return "", 0
     finally:


### PR DESCRIPTION
## Summary
- Replace the oversized code-evaluation stdio tail read path with a positional `os.pread` call.
- Keep existing stdio tail text and byte-size behavior intact, including missing files, empty files, directories, and close-error handling.
- Document the registered probe slice in `docs/plans/2026-07-14-code-eval-stdio-pread-tail.md`.

## Plan or Spec
- Plan: `docs/plans/2026-07-14-code-eval-stdio-pread-tail.md`
- Registered PR-scoped probe: `code-eval-stdio-tail-single-stat`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_text_handles_missing_and_oversized_files services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_limited_stdio_reads_oversized_tail_without_lseek services/mlx-worker-python/tests/test_code_eval_runner.py::test_output_limit_reuses_limited_stdio_sizes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_stdio_probe_script_emits_metrics` → 6 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...registered code-eval-stdio-tail-single-stat tests...` → 14 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...registered tests plus new pread guard... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_stdio_probe.py` → 15 passed; TOTAL 8 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_stdio_probe.py`
- `python3 - <<'PY' ...tight lseek/read vs pread benchmark... PY`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: 100% (8/8 measurable changed lines covered).
- Baseline registered local probe: `elapsed_ms_mean=26.490368600934744`, `sandbox_profile_elapsed_ms_mean=37.60965238325298`, `tail_chars_mean=5119.0`.
- Post-change registered local probe samples: `elapsed_ms_mean=26.774873794056475`, `30.37696380633861`, `26.487190439365804`, `27.831678045913577`; `tail_chars_mean=5119.0` for all samples.
- Tight touched-primitive A/B on one oversized file, seven 5,000-iteration samples: `lseek+read mean=21.506ms`, `pread mean=19.827ms`.
- CI PR-scoped performance report is required as the authoritative registered probe validation before merge.

## Known Gaps
- Local Linux validates the Python code path and probe. The end-to-end registered probe includes sandbox-profile construction noise, so the tight A/B isolates the changed stdio tail primitive.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local probe was run on Linux.
- [ ] GitHub Actions, including PR-scoped performance, completed successfully.
