### PR TITLE
perf: parse changed-scope diffs from bytes

### DIFF
--- a/docs/plans/2026-07-14-changed-scope-diff-bytes-fastpath.md
+++ b/docs/plans/2026-07-14-changed-scope-diff-bytes-fastpath.md
@@ -1,0 +1,24 @@
+# Changed-Scope Coverage Diff Bytes Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to `scripts/changed_scope_coverage.py` diff parsing. The changed-scope coverage command already asks Git for a zero-context diff and then parses added line numbers. Before this slice, the subprocess path decoded Git output to text and the parser immediately encoded it back to bytes for byte-prefix dispatch.
+
+## Optimization
+
+The slice keeps existing diff semantics while capturing Git diff stdout as bytes and allowing `_parse_changed_lines()` to accept either `str` or `bytes`. Existing string callers remain supported, while the command hot path avoids one decode/encode round trip.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`. The entry already provides focused `test_command`, `coverage_command`, and `probe_command` values covering:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_parse_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+This slice updates the probe script to feed bytes when the target module advertises byte-parser support, while remaining compatible with the previous string-only implementation for base comparisons.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and registered local probe on Linux before opening the PR. GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -26,6 +26,7 @@ _ASCII_PLUS = ord("+")
 _ASCII_MINUS = ord("-")
 _ASCII_AT = ord("@")
 _ASCII_LOWER_D = ord("d")
+_DIFF_PARSER_ACCEPTS_BYTES = True
 _EMPTY_CHANGED_LINES: frozenset[int] = frozenset()
 _DENSE_CHANGED_LINE_SCAN_THRESHOLD = 32
 _SPARSE_SOURCE_LINE_SCAN_THRESHOLD = 8
@@ -84,7 +85,7 @@ def _parse_hunk_new_start(line: str) -> int | None:
     return _parse_hunk_new_start_from_digit(line, new_range_index + 2)
 
 
-def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
+def _parse_changed_lines(diff_text: str | bytes) -> dict[str, set[int]]:
     changed_by_path: dict[str, set[int]] = {}
     changed_by_path_setdefault = changed_by_path.setdefault
     header_prefix = _DIFF_HEADER_PREFIX_BYTES
@@ -99,7 +100,8 @@ def _parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     ascii_lower_d = _ASCII_LOWER_D
     add_changed_line = None
     new_line: int | None = None
-    for line in diff_text.encode().splitlines():
+    diff_bytes = diff_text if isinstance(diff_text, bytes) else diff_text.encode()
+    for line in diff_bytes.split(b"\n"):
         if not line:
             if add_changed_line is not None and new_line is not None:
                 new_line += 1
@@ -140,7 +142,6 @@ def _changed_lines_by_path(repo_root: Path, rel_paths: list[str]) -> dict[str, s
     proc = subprocess.run(
         ["git", "diff", "--unified=0", "--", *rel_paths],
         cwd=repo_root,
-        text=True,
         capture_output=True,
         check=True,
     )

--- a/scripts/changed_scope_coverage_parse_probe.py
+++ b/scripts/changed_scope_coverage_parse_probe.py
@@ -43,13 +43,18 @@ def _build_synthetic_diff(file_count: int = 240, hunks_per_file: int = 8, additi
 def run_probe(repo_root: Path) -> dict[str, float]:
     module = _load_changed_scope_module(repo_root)
     diff_text = _build_synthetic_diff()
+    diff_payload = (
+        diff_text.encode()
+        if getattr(module, "_DIFF_PARSER_ACCEPTS_BYTES", False)
+        else diff_text
+    )
     expected_changed = 240 * 8 * 4
     samples: list[float] = []
     observed_changed = 0
     observed_files = 0
     for _ in range(12):
         start = time.perf_counter()
-        parsed = module._parse_changed_lines(diff_text)
+        parsed = module._parse_changed_lines(diff_payload)
         samples.append((time.perf_counter() - start) * 1000.0)
         observed_files = len(parsed)
         observed_changed = sum(len(lines) for lines in parsed.values())

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -93,6 +93,20 @@ def test_parse_changed_lines_handles_multiple_files_and_hunks() -> None:
     assert changed_scope_coverage._parse_changed_lines(diff_text + "\n") == changed
 
 
+def test_parse_changed_lines_accepts_git_diff_bytes() -> None:
+    diff_text = "\n".join(
+        [
+            "diff --git a/foo.py b/foo.py",
+            "--- a/foo.py",
+            "+++ b/foo.py",
+            "@@ -0,0 +2 @@",
+            "+alpha",
+        ]
+    )
+
+    assert changed_scope_coverage._parse_changed_lines(diff_text.encode()) == {"foo.py": {2}}
+
+
 def test_parse_hunk_new_start_uses_delimiters_for_counted_and_single_line_ranges() -> None:
     assert changed_scope_coverage._parse_hunk_new_start("@@ -0,0 +3,2 @@") == 3
     assert changed_scope_coverage._parse_hunk_new_start("@@ -10 +12 @@") == 12
@@ -132,9 +146,10 @@ def test_changed_lines_by_path_uses_one_batched_git_diff(monkeypatch, tmp_path: 
         ]
     )
 
-    def fake_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    def fake_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[bytes]:
         observed_commands.append(command)
-        return subprocess.CompletedProcess(command, 0, stdout=diff_text, stderr="")
+        assert kwargs.get("text") is None
+        return subprocess.CompletedProcess(command, 0, stdout=diff_text.encode(), stderr=b"")
 
     monkeypatch.setattr(changed_scope_coverage.subprocess, "run", fake_run)
 


### PR DESCRIPTION
## Summary
- Parse changed-scope Git diffs directly from bytes on the command hot path.
- Keep `_parse_changed_lines()` compatible with existing string callers while avoiding the subprocess decode + parser re-encode round trip.
- Update the registered diff-parser probe to use bytes when the target module supports it, with fallback compatibility for the previous base implementation.

## Plan or Spec
- `docs/plans/2026-07-14-changed-scope-diff-bytes-fastpath.md`
- Registered PR-scoped probe: `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline before edits, 5 process samples:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 - <<'PY' ... scripts/changed_scope_coverage_parse_probe.py ... PY
baseline_mean_of_means=2.9053033387754112 ms

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
52 passed in 0.25s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
52 passed in 0.71s; TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage_parse_probe.py
{"changed_line_count": 7680.0, "elapsed_ms_mean": 3.159282496199012, "elapsed_ms_min": 2.712055924348533, "file_count": 240.0, "line_count": 16080.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered local probe (single run): `elapsed_ms_mean=3.159282496199012`, `elapsed_ms_min=2.712055924348533`, `changed_line_count=7680`, `file_count=240`.
- Controlled in-process old/new comparison on the same synthetic diff:
  - `base-str mean=3.2384829110621163 ms`
  - `head-bytes mean=2.7680669464947036 ms`
  - `delta_ms=-0.4704159645674127`, `speedup=1.17x`
- GitHub Actions PR-scoped performance is required for final registered probe validation before merge.

## Known Gaps
- Local Linux validates the Python path only. No Swift runtime effects are involved in this slice.
- The process-level local probe is noisy; merge decision should rely on the registered PR-scoped performance workflow plus green checks.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
