### PR TITLE
perf: fast path CLI JSON metric placeholder

### DIFF
--- a/Sources/MelixCLICore/MelixCLIJSON.swift
+++ b/Sources/MelixCLICore/MelixCLIJSON.swift
@@ -10,6 +10,8 @@ func elapsedMilliseconds(since start: DispatchTime) -> Double {
 enum MelixCLIJSONMetricPatch {
     private static let metricLiteralLocale = Locale(identifier: "en_US_POSIX")
     private static let metricNameAlphanumerics = CharacterSet.alphanumerics
+    private static let jsonEncodeMetricName = "melix.cli.json_encode_ms"
+    private static let jsonEncodeMetricTokenPrefix = "__MELIX_METRIC_melix_cli_json_encode_ms_"
 
     private static func asciiMetricNameScalarOrUnderscore(_ scalar: Unicode.Scalar) -> Unicode.Scalar? {
         guard scalar.isASCII else {
@@ -36,6 +38,9 @@ enum MelixCLIJSONMetricPatch {
     }
 
     static func makePlaceholder(metricName: String) -> Placeholder {
+        if metricName == jsonEncodeMetricName {
+            return Placeholder(token: "\(jsonEncodeMetricTokenPrefix)\(UUID().uuidString)__")
+        }
         var safeMetricName = String()
         safeMetricName.reserveCapacity(metricName.count)
         for scalar in metricName.unicodeScalars {

--- a/docs/plans/2026-05-26-swift-cli-placeholder-scalar-build.md
+++ b/docs/plans/2026-05-26-swift-cli-placeholder-scalar-build.md
@@ -20,6 +20,8 @@ The registry defines focused `test_command`, `coverage_command`, and `probe_comm
 
 `MelixCLIJSONMetricPatch.makePlaceholder(metricName:)` previously used `String.map` over `Character` values, creating an intermediate array before rebuilding the sanitized metric-name string. This slice builds the sanitized name directly from Unicode scalars into a reserved `String` and reuses a static alphanumeric character set, preserving the same token shape while avoiding the intermediate mapped array.
 
+The 2026-07-14 follow-up keeps the same Swift-only boundary and registered `swift-cli-json-envelope-encoding` probe. The hot CLI envelope metric name is always `melix.cli.json_encode_ms`, so `makePlaceholder(metricName:)` now recognizes that exact metric and builds the already-sanitized token from a cached prefix plus a fresh UUID. Non-default metric names still use the existing scalar sanitizer, preserving Unicode and punctuation behavior.
+
 ## Behavior
 
 The placeholder still:

--- a/tests/MelixCLITests/MelixCLIRunnerTests.swift
+++ b/tests/MelixCLITests/MelixCLIRunnerTests.swift
@@ -771,12 +771,17 @@ struct MelixCLIRunnerTests {
     @Test("json metric placeholders sanitize scalar names without changing token shape")
     func jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape() {
         let placeholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.json_encode-ms")
+        let jsonEncodePlaceholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.json_encode_ms")
         let unicodePlaceholder = MelixCLIJSONMetricPatch.makePlaceholder(metricName: "melix.cli.測試-ms")
 
         #expect(placeholder.token.hasPrefix("__MELIX_METRIC_melix_cli_json_encode_ms_"))
         #expect(placeholder.token.hasSuffix("__"))
         #expect(placeholder.jsonLiteral == "\"\(placeholder.token)\"")
         #expect(placeholder.jsonLiteralData == Data(placeholder.jsonLiteral.utf8))
+        #expect(jsonEncodePlaceholder.token.hasPrefix("__MELIX_METRIC_melix_cli_json_encode_ms_"))
+        #expect(jsonEncodePlaceholder.token.hasSuffix("__"))
+        #expect(jsonEncodePlaceholder.jsonLiteral == "\"\(jsonEncodePlaceholder.token)\"")
+        #expect(jsonEncodePlaceholder.jsonLiteralData == Data(jsonEncodePlaceholder.jsonLiteral.utf8))
         #expect(unicodePlaceholder.token.hasPrefix("__MELIX_METRIC_melix_cli_測試_ms_"))
     }
 


### PR DESCRIPTION
## Summary
- Add an exact-name fast path for the hot `melix.cli.json_encode_ms` CLI JSON metric placeholder.
- Keep non-default metric names on the existing scalar sanitizer path.
- Extend the focused Swift CLI JSON placeholder test and update the governing Swift performance plan.

## Plan or Spec
- `docs/plans/2026-05-26-swift-cli-placeholder-scalar-build.md`
- Registered probe: `swift-cli-json-envelope-encoding` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# baseline / setup
git status --short && git branch --show-current
git fetch origin && git reset --hard origin/main
git worktree add -b perf/swift-cli-json-metric-name-fastpath-20260714 /root/.hermes/profiles/coder/workspace/worktrees/melix-swift-cli-json-metric-name-fastpath-20260714 origin/main

# registry coverage confirmation
python3 - <<'PY'
import json
from pathlib import Path
p=Path('infra/perf/pr_scoped_probes.json')
e=next(e for e in json.loads(p.read_text()) if e['id']=='swift-cli-json-envelope-encoding')
required=('test_command','coverage_command','probe_command')
missing=[k for k in required if not e.get(k)]
print({'id': e['id'], 'runner': e['runner'], 'missing': missing, 'watch_globs': e['watch_globs']})
PY
# output: {'id': 'swift-cli-json-envelope-encoding', 'runner': 'macos-15', 'missing': [], 'watch_globs': ['Sources/MelixCLICore/MelixCLIJSON.swift', 'tests/MelixCLITests/MelixCLIRunnerTests.swift']}

git diff --check
# exit 0

# local Swift focused test attempt
swift test --filter 'MelixCLIRunnerTests/(jsonV1WrapsCommandResultsInAStableEnvelope|jsonV1ErrorEnvelopesAreMachineReadable|jsonMetricPlaceholdersSanitizeScalarNamesWithoutChangingTokenShape|jsonMetricPatchingRejectsMissingPlaceholders|jsonMetricPatchingPreservesUserArtifactStringsThatLookLikeTheOldSentinel)'
# exit 127: /usr/bin/bash: line 3: swift: command not found
```

## Coverage and Metrics
- Local Linux changed-scope Swift coverage: N/A, `swift` is not installed in this scheduled Linux environment.
- Local Linux registered probe: N/A for the same reason.
- Registered PR-scoped probe required before merge: `swift-cli-json-envelope-encoding` on `macos-15`, with metric `elapsed_ms_mean` (`lower_is_better`, `warn_pct=5.0`).
- Expected effect: default CLI JSON envelopes avoid the scalar sanitizer loop for the fixed `melix.cli.json_encode_ms` metric name; non-default placeholder behavior is unchanged.

## Known Gaps
- Swift runtime/performance validation must come from macOS GitHub Actions for this Swift-only slice; do not merge until the registered probe and PR checks are green.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run. Local attempt recorded; authoritative Swift tests must run in macOS CI because local Linux lacks `swift`.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change; existing registered performance probe covers overhead.
- [x] Deferred work and known gaps are stated explicitly.
