### PR TITLE
perf: skip expanduser for plain startup log paths

### DIFF
--- a/docs/plans/2026-07-15-startup-log-plain-path-fastpath.md
+++ b/docs/plans/2026-07-15-startup-log-plain-path-fastpath.md
@@ -1,0 +1,31 @@
+# Startup Log Plain Path Fast Path Slice
+
+## Scope
+
+This Python-only performance slice is limited to startup failure log excerpt path handling in `worker.productization.startup_signals._log_excerpt()`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `startup-signals-lazy-worker-log-excerpts` in `infra/perf/pr_scoped_probes.json`.
+
+The probe already includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/startup_signals.py`
+- `services/mlx-worker-python/tests/test_startup_signals.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/startup_signals_log_probe.py`
+
+## Implementation plan
+
+1. Preserve startup failure classification and log excerpt behavior.
+2. Avoid `Path.expanduser()` for plain log paths that cannot contain a leading tilde.
+3. Keep tilde-prefixed paths on the existing expand-user behavior.
+4. Add a focused regression test that fails if plain absolute log paths call `Path.expanduser()`.
+5. Verify focused startup-signals tests, changed-scope coverage, and the registered probe locally on Linux.
+6. Use the GitHub Actions PR-scoped performance report as the final merge gate.
+
+## Success criteria
+
+- Focused startup-signals tests pass.
+- Changed-scope coverage for the touched Python/test/probe scope remains above the repository threshold.
+- The registered `startup-signals-lazy-worker-log-excerpts` probe reports stable or improved classification timings without changing log read/path-exists counters.

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -534,6 +534,33 @@ def test_classify_startup_failure_reports_host_port_conflict(tmp_path: Path) -> 
     assert "Address already in use" in report.log_excerpt
 
 
+def test_classify_startup_failure_plain_log_path_skips_expanduser(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    control_plane_stderr = tmp_path / "control-plane.stderr.log"
+    control_plane_stderr.write_text("fatal error: boot failed\n", encoding="utf-8")
+
+    def fail_expanduser(self: Path) -> Path:
+        raise AssertionError(  # pragma: no cover
+            f"plain startup log path should not expanduser: {self}"
+        )
+
+    monkeypatch.setattr(Path, "expanduser", fail_expanduser)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+            "control_plane_stderr_path": str(control_plane_stderr),
+        },
+        error_text="handshake failed",
+    )
+
+    assert report.classification == "control_plane_crash"
+    assert report.log_excerpt == "fatal error: boot failed"
+
+
 def test_startup_failure_report_uses_slots_without_changing_dict_payload(tmp_path: Path) -> None:
     control_plane_stderr = tmp_path / "control-plane.stderr.log"
     control_plane_stderr.write_text("fatal error: boot failed\n", encoding="utf-8")

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -576,7 +576,8 @@ def _log_excerpt(*paths: object) -> str:
     for path in paths:
         if not path:
             continue
-        resolved = Path(str(path)).expanduser()
+        path_text = str(path)
+        resolved = Path(path_text) if path_text[:1] != "~" else Path(path_text).expanduser()
         try:
             excerpt = _read_last_nonempty_line(resolved)
         except OSError:


### PR DESCRIPTION
## Summary
- Skip `Path.expanduser()` for startup failure log paths that do not begin with `~`.
- Add a regression test that guards the plain-path fast path.
- Document the slice and registered probe coverage under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-07-15-startup-log-plain-path-fastpath.md`
- Registered PR-scoped probe: `startup-signals-lazy-worker-log-excerpts`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_classify_startup_failure_plain_log_path_skips_expanduser`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output .runtime/startup-log-plain-path-pr-probe.json`

## Coverage and Metrics
- Focused tests: `57 passed in 2.95s`.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Registered local PR-scoped probe completed with base/head probe `ok=true`.
- Local base/head sample from `.runtime/startup-log-plain-path-pr-probe.json`:
  - `control_crash_elapsed_ms_mean`: 9.009312 -> 9.379439 ms (within 15% warn threshold).
  - `empty_hang_elapsed_ms_mean`: 0.892045 -> 0.865205 ms.
  - `tail_scan_elapsed_ms_mean`: 167.001628 -> 159.74266 ms.
  - Log-read and path-exists counters unchanged.
- GitHub Actions PR-scoped performance remains the merge gate for registered probe validation.

## Known Gaps
- Local validation is Linux-only; this slice touches Python startup diagnostics and has no Swift runtime effect to validate locally.
- Probe timing is noisy at sub-millisecond classification scale, so CI registered probe status is required before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused regression test added.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally.
- [ ] GitHub Actions PR-scoped performance completed successfully.
