### PR TITLE
perf: bind startup log tail open

### DIFF
--- a/docs/plans/2026-05-09-startup-signals-tail-window.md
+++ b/docs/plans/2026-05-09-startup-signals-tail-window.md
@@ -63,3 +63,16 @@ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-
   --head-repo "$PWD" \
   --output /tmp/startup-signals-tail-window-probe.json
 ```
+
+## Follow-up Slice: Direct Open Tail Reader
+
+The 2026-07-15 follow-up keeps the same registered probe and narrows to
+`_read_last_nonempty_line()`, which is called for each startup log inspected by
+`_log_excerpt()`. The tail reader now uses a module-local builtins `open` binding
+instead of `Path.open()`, preserving `Path` inputs, missing-file fallback, chunked
+backward scanning, and decode semantics while avoiding a bound-method lookup in
+the repeated log-tail hot path.
+
+Success is accepted only if focused tests, changed-scope coverage, and the local
+registered Linux probe pass with lower tail/classification elapsed metrics, and
+if the PR-scoped CI probe completes successfully before merge.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import socket
+from builtins import open as _OPEN
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -592,7 +593,7 @@ def _log_excerpt(*paths: object) -> str:
 
 
 def _read_last_nonempty_line(path: Path, *, chunk_size: int = 8192) -> str:
-    with path.open("rb") as handle:
+    with _OPEN(path, "rb") as handle:
         handle.seek(0, 2)
         line_start, payload_end = _seek_last_nonempty_line_bounds(handle, chunk_size=chunk_size)
         if payload_end == 0:


### PR DESCRIPTION
## Summary
- Bind builtins `open` once in the startup log tail reader to avoid the `Path.open()` bound-method lookup on every inspected startup log.
- Keep startup failure classification, missing-log fallback, chunked tail scanning, and decode semantics unchanged.

## Plan or Spec
- `docs/plans/2026-05-09-startup-signals-tail-window.md` — added the Direct Open Tail Reader follow-up slice.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# 57 passed in 3.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# 57 passed in 2.97s; changed-scope TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# baseline before change: tail_scan_elapsed_ms_mean=163.786715; after local head probe: tail_scan_elapsed_ms_mean=160.783206

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id startup-signals-lazy-worker-log-excerpts --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/startup-open-binding-pr-probe-2.json
# head verification passed; base/head deltas below

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Registered probe: `startup-signals-lazy-worker-log-excerpts`.
- Local direct probe before/after: `tail_scan_elapsed_ms_mean` 163.786715 ms -> 160.783206 ms (delta -3.003509 ms).
- Local PR-scoped base/head probe (`/tmp/startup-open-binding-pr-probe-2.json`):
  - `control_crash_elapsed_ms_mean`: 10.195264 ms -> 10.154114 ms (delta -0.041150 ms)
  - `tail_scan_elapsed_ms_mean`: 162.311173 ms -> 159.034278 ms (delta -3.276895 ms)
  - `worker_crash_elapsed_ms_mean`: 9.923025 ms -> 9.624183 ms (delta -0.298842 ms)
  - `report_to_dict_elapsed_ms_mean`: 99.770462 ms -> 98.134684 ms (delta -1.635778 ms; incidental unchanged path)
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local validation only; no Swift runtime effect is claimed for this Python worker slice.
- First local PR-scoped probe comparison was noisy and showed a slower head; rerunning the same registered probe produced lower target log-tail/classification elapsed metrics. CI is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
