### PR TITLE
perf: map dataset source paths after scan

### DIFF
--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1270,7 +1270,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return [path_cls(path) for path in file_paths]
+    return list(map(path_cls, file_paths))
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Convert sorted dataset ingest source path strings to `Path` objects with `list(map(Path, ...))` after the existing scandir traversal.
- Preserve deterministic ordering, error handling, and no-follow directory symlink behavior while trimming Python-level projection overhead.

## Plan or Spec
- `docs/plans/2026-06-14-dataset-source-path-map-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 47 passed in 0.77s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test set>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 47 passed in 1.11s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# head/base baseline on origin/main: elapsed_ms_mean=11.398359455845572, record_elapsed_ms_mean=17.48801291581582, source_kind_elapsed_ms_mean=18.124615254981276
# branch: elapsed_ms_mean=11.24507570850917, record_elapsed_ms_mean=16.985054455951534, source_kind_elapsed_ms_mean=18.126942989924416

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 1 0 100%`).
- Registered probe: `dataset-source-records-scandir` covers this path and has focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Local Linux probe delta:
  - `elapsed_ms_mean`: 11.398359455845572 -> 11.24507570850917 ms (`-0.153283747336402`, ~1.34% lower)
  - `record_elapsed_ms_mean`: 17.48801291581582 -> 16.985054455951534 ms (`-0.5029584598642859`, ~2.88% lower)
  - `source_kind_elapsed_ms_mean`: 18.124615254981276 -> 18.126942989924416 ms (effectively neutral)
- CI PR-scoped performance workflow is still required as the merge gate for the registered probe report.

## Known Gaps
- None for the Python/Linux slice. This PR does not change Swift runtime behavior.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability behavior change; existing evidence-mode PR-scoped probe remains the validation path.
- [x] Deferred work and known gaps are stated explicitly.
