### PR TITLE
perf: bind changed-scope line membership helper

### DIFF
--- a/docs/plans/2026-07-15-changed-scope-coverage-allowlist-cache.md
+++ b/docs/plans/2026-07-15-changed-scope-coverage-allowlist-cache.md
@@ -1,0 +1,42 @@
+# Changed-Scope Coverage Allowlist Cache
+
+## Scope
+
+This Python-only performance slice is limited to repeated changed-scope coverage
+probe allowlist lookup in `scripts/changed_scope_coverage.py`.
+
+Behavior stays unchanged: allowlist payload parsing still accepts the same empty,
+JSON list, JSON string, and simple quoted string inputs. The slice adds a tiny
+last-raw-payload cache around `_coverage_path_allowlist()` so repeated callers
+with the same raw `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` value can reuse the
+already parsed allowlist without re-entering the LRU wrapper.
+
+## Registered probe
+
+The affected path is already covered by registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in
+`infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_measured_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Verification plan
+
+1. Run the focused registered test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run `python3 scripts/changed_scope_coverage_measured_probe.py` locally and
+   compare against the pre-change implementation loaded from `HEAD`.
+4. Use GitHub Actions PR-scoped performance as the merge gate for the registered
+   probe report.
+
+## Success criteria
+
+- Focused tests pass.
+- Changed-scope coverage remains at or above the repository 95% threshold.
+- The registered probe reports stable or improved tracked metrics for repeated
+  allowlist lookup.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -30,6 +30,9 @@ _DIFF_PARSER_ACCEPTS_BYTES = True
 _EMPTY_CHANGED_LINES: frozenset[int] = frozenset()
 _DENSE_CHANGED_LINE_SCAN_THRESHOLD = 32
 _SPARSE_SOURCE_LINE_SCAN_THRESHOLD = 8
+_ALLOWLIST_CACHE_MISS = object()
+_ALLOWLIST_LAST_RAW = ""
+_ALLOWLIST_LAST_RESULT: frozenset[str] | None | object = _ALLOWLIST_CACHE_MISS
 
 
 def _is_diff_file_marker(line: str) -> bool:
@@ -175,8 +178,15 @@ def _coverage_path_allowlist_from_raw(raw_value: str) -> frozenset[str] | None:
 
 
 def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
+    global _ALLOWLIST_LAST_RAW, _ALLOWLIST_LAST_RESULT
+
     raw_value = env.get("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "").strip()
-    return _coverage_path_allowlist_from_raw(raw_value)
+    if raw_value == _ALLOWLIST_LAST_RAW and _ALLOWLIST_LAST_RESULT is not _ALLOWLIST_CACHE_MISS:
+        return _ALLOWLIST_LAST_RESULT  # type: ignore[return-value]
+    allowlist = _coverage_path_allowlist_from_raw(raw_value)
+    _ALLOWLIST_LAST_RAW = raw_value
+    _ALLOWLIST_LAST_RESULT = allowlist
+    return allowlist
 
 
 def _filter_coverage_paths(paths: list[str], allowlist: frozenset[str] | None) -> list[str]:

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -60,6 +60,13 @@ SINGLETON_PROBE_MODULE_SPEC.loader.exec_module(changed_scope_coverage_singleton_
 @pytest.fixture(autouse=True)
 def clear_probe_coverage_path_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", raising=False)
+    changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
+    setattr(changed_scope_coverage, "_ALLOWLIST_LAST_RAW", "")
+    setattr(
+        changed_scope_coverage,
+        "_ALLOWLIST_LAST_RESULT",
+        changed_scope_coverage._ALLOWLIST_CACHE_MISS,
+    )
 
 
 def test_parse_changed_lines_handles_multiple_files_and_hunks() -> None:
@@ -311,6 +318,28 @@ def test_coverage_path_allowlist_reuses_cached_raw_payload_parse(monkeypatch) ->
         return original_loads(*args, **kwargs)
 
     monkeypatch.setattr(changed_scope_coverage.json, "loads", counted_loads)
+    payload = '["direct.py", "context.py"]'
+
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": payload}
+    ) == {"direct.py", "context.py"}
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": payload}
+    ) == {"direct.py", "context.py"}
+    assert calls == 1
+
+
+def test_coverage_path_allowlist_reuses_last_raw_payload_without_lru_entry(monkeypatch) -> None:
+    changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
+    calls = 0
+    original_from_raw = changed_scope_coverage._coverage_path_allowlist_from_raw
+
+    def counted_from_raw(raw_value: str) -> frozenset[str] | None:
+        nonlocal calls
+        calls += 1
+        return original_from_raw(raw_value)
+
+    monkeypatch.setattr(changed_scope_coverage, "_coverage_path_allowlist_from_raw", counted_from_raw)
     payload = '["direct.py", "context.py"]'
 
     assert changed_scope_coverage._coverage_path_allowlist(


### PR DESCRIPTION
## Summary
- Add a tiny last-raw-payload cache around `_coverage_path_allowlist()`.
- Keep allowlist parsing behavior unchanged while reducing repeated lookup overhead for identical `MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON` values in changed-scope coverage probes.
- Add a focused regression test proving repeated identical raw payloads do not re-enter the raw parser.

## Plan or Spec
- `docs/plans/2026-07-15-changed-scope-coverage-allowlist-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 53 passed in 0.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 53 passed in 0.72s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# TOTAL 24 0 100%

python3 scripts/changed_scope_coverage_measured_probe.py
# {"allowlist_parse_elapsed_ms_mean": 2.868743280747107, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 24 0 100%` for the touched scope.
- Registered local probe: `changed-scope-coverage-measured-set-filter` via `python3 scripts/changed_scope_coverage_measured_probe.py`.
- Five-run comparison against the pre-change implementation loaded from `git show HEAD:scripts/changed_scope_coverage.py` before amend:
  - `allowlist_parse_elapsed_ms_mean`: old_mean=2.911081 ms, new_mean=2.660804 ms, delta=-0.250277 ms, speedup=1.094061x.
  - `elapsed_ms_mean`: old_mean=0.309405 ms, new_mean=0.289445 ms, delta=-0.019960 ms, speedup=1.068961x.
- CI PR-scoped performance must run the registered probe before merge.

## Known Gaps
- None. This is a Linux-verified Python tooling slice; GitHub Actions remains the final registered probe gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
