### PR TITLE
perf: avoid lstrip for diagnostic private markers

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -247,6 +247,13 @@ target-relative resolution, file read, and source-line extension behavior, but
 avoids repeated protobuf attribute lookups for rows that enter the diagnostic
 source collection path.
 
+A follow-up 2026-07-15 private-line marker direct-text slice keeps the redaction
+contract unchanged while avoiding `lstrip()` on the common unindented runtime-log
+line path. `_has_private_text_line_marker()` now inspects the first character
+directly when it is already non-whitespace, and only falls back to the existing
+left-strip behavior for indented or blank lines. Prompt/response labels,
+case-insensitive branches, and private-preview redaction semantics stay the same.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -190,7 +190,9 @@ def test_export_target_diagnostics_identity_marker_fast_path_matches_markers(
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("plain runtime status", False),
+        ("ordinary runtime status", False),
+        ("", False),
+        ("   ", False),
         ("p", False),
         ("R", False),
         ("  prompt: private customer prompt", True),

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -716,10 +716,16 @@ def _has_secret_redaction_marker(text: str) -> bool:
 
 
 def _has_private_text_line_marker(text: str) -> bool:
-    stripped = text.lstrip()
-    if not stripped:
+    if not text:
         return False
-    first = stripped[0]
+    first = text[0]
+    if first > " ":
+        stripped = text
+    else:
+        stripped = text.lstrip()
+        if not stripped:
+            return False
+        first = stripped[0]
     if first == "p" or first == "P":
         if len(stripped) < 2:
             return False


### PR DESCRIPTION
## Summary
- Avoid `lstrip()` in `_has_private_text_line_marker()` for the common unindented runtime-log path.
- Preserve indented/blank/private-preview marker behavior with focused regression coverage.
- Update the runtime export diagnostic parser plan with the 2026-07-15 slice notes.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md`.
- Registered PR-scoped probe already covers this path: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`, with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=10 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id runtime-export-diagnostic-parser --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/runtime_export_diagnostic_private_marker_probe.json`

## Coverage and Metrics
- Focused pytest: `84 passed in 0.65s`.
- Changed-scope coverage: `TOTAL 8 0 100%`.
- Registered local default probe comparison:
  - base `elapsed_ms_mean=2607.867 ms`, head `elapsed_ms_mean=2577.443 ms`, delta `-30.424 ms` (`~1.17%` faster).
  - base `path_redaction_elapsed_ms_mean=20.170 ms`, head `20.286 ms` (noise-level `+0.116 ms`).
  - parser coverage stayed `1.0`; parsed/unknown/redaction counts unchanged.
- Local registered runner smoke with shorter env completed successfully and stayed under warning thresholds; CI PR-scoped performance remains the merge gate.

## Known Gaps
- Linux local validation covers the Python worker path only.
- The optimization is intentionally small; the aggregate probe improvement is modest and CI is required for final registered probe validation.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at or above 95%.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
