### PR TITLE
perf: bind embedding single-cycle vector copy

### DIFF
--- a/docs/plans/2026-07-15-embedding-single-cycle-copy-bind.md
+++ b/docs/plans/2026-07-15-embedding-single-cycle-copy-bind.md
@@ -1,0 +1,37 @@
+# Deterministic Embedding Single-Cycle Copy Binding
+
+## Slice
+
+This Python-only performance slice keeps the deterministic embedding repeated
+single-input cycle behavior unchanged while reducing per-replayed-vector method
+lookup overhead. The affected production path is
+`services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`.
+
+## Registered probe
+
+The path is already covered by the registered PR-scoped performance probe
+`deterministic-embedding-duplicate-input-cache` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` fields and reports the
+single-cycle metrics:
+
+- `single_cycle_elapsed_ms_mean`
+- `single_cycle_peak_bytes_mean`
+- `single_cycle_embed_text_calls_mean`
+
+## Implementation plan
+
+1. Bind `vector.copy` once in the `cycle_length == 1` replay branch before the
+   generator extends the vector list.
+2. Preserve unique list objects for replayed vectors so callers cannot mutate a
+   shared vector accidentally.
+3. Run the registered focused tests, changed-scope coverage, and registered
+   probe locally on Linux before pushing. GitHub Actions PR-scoped performance
+   remains the merge gate.
+
+## Verification plan
+
+- Focused pytest for deterministic embedding and PR-scoped registry coverage.
+- Changed-scope coverage for the deterministic embedding runtime, focused tests,
+  registry tests, and probe script.
+- Local registered probe comparison against the pre-change baseline.

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -74,8 +74,9 @@ class DeterministicEmbeddingRuntime:
         if cycle_length:
             if cycle_length == 1:
                 vector = embed_text(backend, inputs[0], dimensions)
+                copy_vector = vector.copy
                 vectors = [vector]
-                vectors.extend(vector.copy() for _ in range(input_count - 1))
+                vectors.extend(copy_vector() for _ in range(input_count - 1))
                 return vectors
             for text in inputs[:cycle_length]:
                 vector = embed_text(backend, text, dimensions)


### PR DESCRIPTION
## Summary
- Bind the single-cycle embedding replay vector copy method once before extending replayed vectors.
- Preserve per-result vector isolation for repeated single-input embedding batches.
- Document the slice and registered probe coverage under `docs/plans/`.

## Plan or Spec
- `docs/plans/2026-07-15-embedding-single-cycle-copy-bind.md`
- Registered probe: `deterministic-embedding-duplicate-input-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py` (baseline on `origin/main`, 3 runs; head branch, 3 runs)
- `git diff --check`

## Coverage and Metrics
- Focused tests: `20 passed in 2.66s`.
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered local probe, `single_cycle_elapsed_ms_mean` over 3 runs:
  - baseline mean: `17.912077 ms`
  - head mean: `16.645489 ms`
  - delta: `-1.266589 ms` (`-7.071%`, `1.076092x`)
- `single_cycle_embed_text_calls_mean` stayed `1.0`.
- `single_cycle_peak_bytes_mean` changed from `2620458.4` to `2620530.4` bytes in the local probe; this is a ~72 byte measurement difference and the primary target is elapsed replay overhead.

## Known Gaps
- Local validation is Linux-only. This slice is Python-only, so local focused tests, changed-scope coverage, and the registered probe were run locally; GitHub Actions remains the final registered PR-scoped performance gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% for touched measurable lines.
- [x] Registered probe ran locally with a positive elapsed-time delta for the targeted metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
