### PR TITLE
perf: bind dataset quality message dict check

### DIFF
--- a/docs/plans/2026-07-15-dataset-quality-message-dict-bind.md
+++ b/docs/plans/2026-07-15-dataset-quality-message-dict-bind.md
@@ -1,0 +1,26 @@
+# Dataset Quality Message Dict Binding
+
+## Goal
+
+Reduce per-message global lookups in the dataset quality output-length scan while preserving the existing completion-row and message-row semantics.
+
+## Scope
+
+This Python-only slice is limited to `services/mlx-worker-python/worker/productization/dataset_preparation.py` in `_append_rows_output_lengths(...)`:
+
+- bind the `dict` type to a local before the inner message loop;
+- keep the existing completion-key presence fast path and message fallback behavior unchanged;
+- do not change dataset version payloads, quality metrics, partitioning, or file layout.
+
+## Performance Probe
+
+The affected path is already covered by the registered PR-scoped probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The registry entry has focused `test_command`, `coverage_command`, and `probe_command` entries covering `dataset_preparation.py`, the dataset preparation tests, and `scripts/dataset_quality_lengths_probe.py`.
+
+The probe reports quality-summary scan metrics including:
+
+- `elapsed_ms_mean`, `elapsed_ms_min`, and `elapsed_ms_p95` for `_quality_summary(...)` over prompt/completion and chat-message rows;
+- failed-partition timing metrics as context for the shared registered probe.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, and the registered local probe on Linux before opening the PR. CI remains the source of truth for the PR-scoped base-vs-head performance report.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1869,6 +1869,7 @@ def _append_rows_output_lengths(
     append = lengths.append
     len_ = len
     str_ = str
+    dict_ = dict
     output_length_total = 0
     for row in rows:
         if "completion" not in row:
@@ -1878,7 +1879,7 @@ def _append_rows_output_lengths(
                 continue
             total = 0
             for item in messages:
-                if type(item) is dict:
+                if type(item) is dict_:
                     content = item.get("content", "")
                 else:
                     try:


### PR DESCRIPTION
## Summary
- Binds the `dict` type to a local in the dataset quality message output-length loop.
- Keeps completion-row key-presence behavior and message fallback semantics unchanged.
- Adds the governing plan for this focused Python performance slice.

## Plan or Spec
- `docs/plans/2026-07-15-dataset-quality-message-dict-bind.md`
- Registered PR-scoped probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py` (baseline on `origin/main` before edit)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py` (after edit)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 60 passed in 2.03s.
- Changed-scope coverage: TOTAL 2 changed measurable lines, 0 missed, 100%.
- Local probe baseline (`origin/main`): `elapsed_ms_mean=2.673879`, `elapsed_ms_min=2.530234`, `elapsed_ms_p95=3.00747`, `failed_partition_elapsed_ms_mean=1.119286`.
- Local probe after edit: `elapsed_ms_mean=2.640474`, `elapsed_ms_min=2.537406`, `elapsed_ms_p95=2.754956`, `failed_partition_elapsed_ms_mean=1.052424`.
- Local quality-summary delta: `elapsed_ms_mean -0.033405 ms` (`~1.25%` faster), `elapsed_ms_p95 -0.252514 ms` (`~8.40%` faster).
- Registered PR-scoped performance CI is required for the base-vs-head report before merge.

## Known Gaps
- Linux local validation covers the Python dataset quality path only.
- The registered CI probe is the source of truth for PR-scoped base-vs-head performance gating.

## Evidence Checklist
- [x] Registered probe exists with focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95% for touched Python lines.
- [x] Local registered probe script was run before and after the edit.
- [x] Governing plan/spec updated under `docs/plans/`.
- [ ] PR-scoped performance workflow completed successfully.
