### PR TITLE
perf: bind local job JSON copy type checks

### DIFF
--- a/docs/plans/2026-07-07-local-job-json-tuple3-copy-fastpath.md
+++ b/docs/plans/2026-07-07-local-job-json-tuple3-copy-fastpath.md
@@ -36,9 +36,13 @@ and adds this plan to the probe watch list. No Swift runtime behavior is changed
 4. Use GitHub Actions PR-scoped performance as the final registered CI probe
    validation before merge.
 
-## Expected outcome
+## 2026-07-15 follow-up: JSON scalar-copy type binding
 
-The scalar-copy metric should improve because exact three-item tuples no longer
-pay tuple-generator overhead. Scan-only filesystem metrics are expected to stay
-within normal noise because this slice does not change candidate discovery,
-record loading, reconciliation, or follow-up claim semantics.
+This Python-only follow-up remains limited to `_copy_json_like_value(...)` in the
+local-job follow-up projection path. The copier now reuses a function-local
+`type` binding across the exact dict/list scalar scans instead of resolving the
+builtin for every nested item. The change preserves scalar reuse, recursive copy
+isolation for nested mutables, tuple fast paths, and container-subclass fallback
+behavior. The registered `local-job-followup-scan-scandir` probe remains the
+Linux and CI validation gate, with `scalar_copy_optimized_elapsed_ms_mean`,
+`scalar_copy_delta_ms`, and `scalar_copy_speedup` as the primary metrics.

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -1007,7 +1007,8 @@ def _copy_untrusted_context_receipts(
 
 
 def _copy_json_like_value(value: Any) -> Any:
-    value_type = type(value)
+    value_type_of = type
+    value_type = value_type_of(value)
     if (
         value_type is str
         or value_type is int
@@ -1019,7 +1020,7 @@ def _copy_json_like_value(value: Any) -> Any:
     if value_type is dict:
         copied: dict[Any, Any] = {}
         for key, nested in value.items():
-            nested_type = type(nested)
+            nested_type = value_type_of(nested)
             if (
                 nested_type is str
                 or nested_type is int
@@ -1035,7 +1036,7 @@ def _copy_json_like_value(value: Any) -> Any:
         copied_list: list[Any] = []
         append = copied_list.append
         for item in value:
-            item_type = type(item)
+            item_type = value_type_of(item)
             if (
                 item_type is str
                 or item_type is int
@@ -1047,7 +1048,7 @@ def _copy_json_like_value(value: Any) -> Any:
             elif item_type is dict:
                 copied_item: dict[Any, Any] = {}
                 for key, nested in item.items():
-                    nested_type = type(nested)
+                    nested_type = value_type_of(nested)
                     if (
                         nested_type is str
                         or nested_type is int


### PR DESCRIPTION
## Summary
- Bind `type` once inside the local-job JSON-like copy helper so dict/list scalar scans reuse the local binding.
- Keep scalar reuse, nested mutable copy isolation, tuple fast paths, and container-subclass fallback behavior unchanged.
- Update the local-job JSON tuple copy plan with this follow-up slice and validation metrics.

## Plan or Spec
- `docs/plans/2026-07-07-local-job-json-tuple3-copy-fastpath.md`

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_reads_json_bytes services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_uses_direct_binary_open services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_avoids_path_join_wrapper services/mlx-worker-python/tests/test_local_job_continuation.py::test_load_record_tolerates_record_deleted_between_path_resolution_and_read services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_live_evidence_lookup_when_absent services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_claim_local_job_followup_uses_direct_record_copy_for_claim services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_uses_narrow_receipt_copies services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_copy_preserves_json_scalars_by_value services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_copy_preserves_container_subclasses services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
20 passed in 1.89s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py
20 passed in 4.28s
TOTAL 5 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" MELIX_LOCAL_JOB_SCAN_RECORDS=1 MELIX_LOCAL_JOB_PROJECTION_RECORDS=1 MELIX_LOCAL_JOB_SCALAR_COPY_ITERATIONS=1000000 MELIX_LOCAL_JOB_CLAIM_COPY_ITERATIONS=1 uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
exit 0

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe (default): `scalar_copy_baseline_elapsed_ms_mean=2635.529481`, `scalar_copy_optimized_elapsed_ms_mean=1584.944807`, `scalar_copy_delta_ms=-1050.584674`, `scalar_copy_speedup=1.662853`, `elapsed_ms_mean=17.803845`, `path_glob_calls_mean=0.0`, `scandir_calls_mean=1.0`.
- Focused scalar-copy probe (1,000,000 iterations): `scalar_copy_baseline_elapsed_ms_mean=13216.111244`, `scalar_copy_optimized_elapsed_ms_mean=7891.797929`, `scalar_copy_delta_ms=-5324.313315`, `scalar_copy_speedup=1.674664`.
- Registered CI PR-scoped performance workflow is required before merge.

## Known Gaps
- Local validation is Linux-only Python validation; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance report is pending at PR creation time.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
