### PR TITLE
perf: bind dataset source record helpers

### DIFF
--- a/docs/plans/2026-07-15-dataset-source-record-helper-bindings.md
+++ b/docs/plans/2026-07-15-dataset-source-record-helper-bindings.md
@@ -1,0 +1,43 @@
+# Dataset Source Record Helper Bindings Performance Slice
+
+## Context
+
+The registered PR-scoped probe `dataset-source-records-scandir` covers
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`,
+including dataset ingest source-file traversal, source-kind classification, and
+record assembly. The source-record loop calls the same module-level helpers for
+every candidate file while building records from already enumerated source paths.
+
+## Slice
+
+Bind the source-record loop helpers (`_source_kind`, `_read_source_text`,
+`_structured_records`, `_normalize_line_endings`, `_metadata_for_path`, `_record`)
+and `operator_failures.append` once before iterating. This keeps the same source
+path order, unsupported/empty-source failure payloads, structured-data handling,
+line-ending normalization, metadata, and record schema while avoiding repeated
+global or attribute lookups inside the per-file loop.
+
+This slice does not change directory traversal, privacy detection, segmentation,
+deduplication, upload caps, or dataset versioning behavior.
+
+## Probe
+
+Registered probe: `dataset-source-records-scandir`
+
+The registry entry in `infra/perf/pr_scoped_probes.json` includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for the affected
+path and `scripts/dataset_source_records_probe.py`.
+
+## Verification Plan
+
+1. Run the registered focused test command for `dataset-source-records-scandir`.
+2. Run the registered changed-scope coverage command for the same probe.
+3. Run the registered probe locally on Linux.
+4. Use GitHub Actions PR-scoped performance as the final merge gate for the
+   registered probe report.
+
+## Expected Impact
+
+The primary expected metric is lower or stable `record_elapsed_ms_mean` in the
+registered dataset source-record workload. Overall `elapsed_ms_*` may be stable
+because the workload still includes filesystem traversal and file reads.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1185,10 +1185,17 @@ def _iter_source_records(
         upload_cap_bytes=upload_cap_bytes,
         source_cap_bytes=source_cap_bytes,
     )
+    operator_failures_append = operator_failures.append
+    source_kind_for_path = _source_kind
+    read_source_text = _read_source_text
+    structured_records = _structured_records
+    normalize_line_endings = _normalize_line_endings
+    metadata_for_path = _metadata_for_path
+    record = _record
     for path in paths:
-        source_kind = _source_kind(path)
+        source_kind = source_kind_for_path(path)
         if source_kind is None:
-            operator_failures.append(
+            operator_failures_append(
                 {
                     "id": _failure_id("unsupported-source", path.name),
                     "code": "DATASET_INGEST_UNSUPPORTED_SOURCE",
@@ -1198,9 +1205,9 @@ def _iter_source_records(
                 }
             )
             continue
-        text = _read_source_text(path, cap_bytes=read_cap_bytes)
+        text = read_source_text(path, cap_bytes=read_cap_bytes)
         if not text or text.isspace():
-            operator_failures.append(
+            operator_failures_append(
                 {
                     "id": _failure_id("empty-source", path.name),
                     "code": "DATASET_INGEST_EMPTY_SOURCE",
@@ -1211,14 +1218,14 @@ def _iter_source_records(
             )
             continue
         if source_kind == "structured_data":
-            yield from _structured_records(path, text, operator_failures)
+            yield from structured_records(path, text, operator_failures)
         else:
-            normalized_text = _normalize_line_endings(text)
-            yield _record(
+            normalized_text = normalize_line_endings(text)
+            yield record(
                 path=path,
                 source_kind=source_kind,
                 text=normalized_text,
-                metadata=_metadata_for_path(path, source_kind),
+                metadata=metadata_for_path(path, source_kind),
                 normalized=True,
             )
 


### PR DESCRIPTION
## Summary
- Bind dataset source-record loop helpers once before iterating candidate source paths.
- Preserve source path order, unsupported/empty-source failures, structured-data handling, normalization, metadata, and record schema.

## Plan or Spec
- `docs/plans/2026-07-15-dataset-source-record-helper-bindings.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# 47 passed in 1.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# 47 passed in 1.19s; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# {"elapsed_ms_mean": 11.568030543540688, "record_elapsed_ms_mean": 17.62143082239411, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-base-dataset-source-record-helper-bindings-20260715 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-dataset-source-path-map-20260715 --output .runtime/dataset-source-record-helper-bindings-probe.json
# head verification ok; base/head probe ok

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local registered probe comparison (`dataset-source-records-scandir`):
  - `elapsed_ms_mean`: base `12.183338636532426` ms, head `11.220032571476292` ms, delta `-0.963306065056134` ms.
  - `record_elapsed_ms_mean`: base `17.572678011757407` ms, head `17.22754835447466` ms, delta `-0.3451296572827466` ms.
  - `source_kind_elapsed_ms_mean`: base `18.76160817813467` ms, head `18.168945436958563` ms, delta `-0.5926627411761065` ms.
- GitHub Actions PR-scoped performance is still required as the registered CI probe gate before merge.

## Known Gaps
- Local Linux validation only; no Swift runtime behavior is changed.
- Overall dataset ingest remains filesystem/read dominated, so CI probe noise may affect wall-clock metrics.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
