### PR TITLE
perf: simplify hub catalog MLX predicates

### DIFF
--- a/docs/plans/2026-07-15-hub-catalog-tag-atom-predicate-fastpath.md
+++ b/docs/plans/2026-07-15-hub-catalog-tag-atom-predicate-fastpath.md
@@ -1,0 +1,34 @@
+# Hub catalog MLX compatibility predicate fast path
+
+## Scope
+
+This Python-only performance slice is limited to the Hub catalog MLX compatibility
+predicates in `services/mlx-worker-python/worker/model_ops/hub_catalog.py`.
+
+The slice preserves MLX tag and repo-id matching behavior while simplifying two
+hot predicates used during Hub summary construction:
+
+- `_tag_payload_contains_mlx()` removes redundant exact `"MLX"` / `"mlx"`
+  comparisons from each list item because `_is_mlx_atom()` already accepts those
+  exact forms and mixed-case three-character variants.
+- `_repo_id_contains_mlx()` uses one lowercase containment check instead of
+  multiple case-probe scans plus a conditional lowercase fallback.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`hub-catalog-tag-normalization-single-pass` in `infra/perf/pr_scoped_probes.json`.
+The probe watches the Hub catalog module, focused Hub catalog tests, PR-scoped
+performance tests, and `scripts/hub_catalog_tag_normalization_probe.py`; it has
+focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+## Verification plan
+
+Run on Linux before opening the PR:
+
+1. Focused Hub catalog regression tests and PR-scoped probe smoke tests.
+2. Changed-scope coverage through the registered probe coverage command.
+3. Local registered probe comparison for `hub-catalog-tag-normalization-single-pass`.
+
+GitHub Actions PR-scoped performance remains the final merge gate for the
+registered probe report.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -190,12 +190,12 @@ def test_payload_mlx_tag_detection_fast_paths_exact_membership(monkeypatch: pyte
     assert hub_catalog._payload_is_mlx_compatible(
         {"id": "plain/model", "tags": ["Text-Generation", "MLX", object()]}
     ) is True
-    assert calls == 0
+    assert calls == 1
 
     assert hub_catalog._payload_is_mlx_compatible(
         {"id": "plain/model", "tags": ["Text-Generation", "mLx", object()]}
     ) is True
-    assert calls == 1
+    assert calls == 2
 
 
 class FakeHTTPResponse:
@@ -1669,14 +1669,21 @@ def test_search_models_counts_fp32_parameters_as_four_bytes_for_local_fit() -> N
     assert model.estimated_resident_bytes > int(64 * 1024 * 1024 * 1024 * 0.60)
 
 
-def test_tag_payload_contains_exact_mlx_without_atom_helper(
+def test_tag_payload_contains_exact_mlx_uses_atom_helper_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    atom_helper = Mock(side_effect=AssertionError("exact MLX list membership should short-circuit"))
-    monkeypatch.setattr(hub_catalog_module, "_is_mlx_atom", atom_helper)
+    calls = 0
+    original = hub_catalog_module._is_mlx_atom
+
+    def counted_is_mlx_atom(value: str) -> bool:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(hub_catalog_module, "_is_mlx_atom", counted_is_mlx_atom)
 
     assert hub_catalog_module._tag_payload_contains_mlx(["Text-Generation", "MLX", object()]) is True
-    atom_helper.assert_not_called()
+    assert calls == 1
 
 
 def test_tag_lowering_fallbacks_preserve_direct_helper_compatibility() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -496,16 +496,12 @@ def _is_mlx_atom(value: str) -> bool:
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if type(value) is list:
         for item in value:
-            if type(item) is str and (
-                item == "MLX" or item == "mlx" or (len(item) == 3 and _is_mlx_atom(item))
-            ):
+            if type(item) is str and len(item) == 3 and _is_mlx_atom(item):
                 return True
         return False
     if isinstance(value, list):
         for item in value:
-            if isinstance(item, str) and (
-                item == "MLX" or item == "mlx" or (len(item) == 3 and _is_mlx_atom(item))
-            ):
+            if isinstance(item, str) and len(item) == 3 and _is_mlx_atom(item):
                 return True
         return False
     if isinstance(value, str):
@@ -563,9 +559,7 @@ def _base_models(value: Any) -> list[str]:
 
 
 def _repo_id_contains_mlx(repo_id: str) -> bool:
-    return "mlx" in repo_id or (
-        ("M" in repo_id or "L" in repo_id or "X" in repo_id) and "mlx" in repo_id.lower()
-    )
+    return "mlx" in repo_id.lower()
 
 
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- Simplifies Hub catalog MLX tag and repo-id compatibility predicates used during summary construction.
- Preserves mixed-case three-character MLX matching while removing redundant exact string comparisons in tag scans.
- Adds focused regression coverage and a governing performance-slice plan.

## Plan or Spec
- `docs/plans/2026-07-15-hub-catalog-tag-atom-predicate-fastpath.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_mlx_repo_id_detection_preserves_case_insensitive_matches services/mlx-worker-python/tests/test_hub_catalog.py::test_payload_mlx_tag_detection_preserves_exact_list_and_subclass_semantics services/mlx-worker-python/tests/test_hub_catalog.py::test_payload_mlx_tag_detection_fast_paths_exact_membership services/mlx-worker-python/tests/test_hub_catalog.py::test_tag_payload_contains_exact_mlx_uses_atom_helper_once services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics` — 7 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_tag_normalization_probe_script_emits_metrics` — 96 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_tag_normalization_probe.py` — 100% changed-line coverage
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_tag_normalization_probe.py` on base/head — base `elapsed_ms_mean=197.527867`, head `elapsed_ms_mean=194.154550`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_TAG_PROBE_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-tag-normalization-single-pass --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-hub-catalog-tag-payload-20260715 --head-repo "$PWD" --output /tmp/hub_catalog_compat_predicate_probe.json` — coverage ok, base `elapsed_ms_mean=206.761981`, head `elapsed_ms_mean=204.102165`
- `git diff --check` — passed

## Coverage and Metrics
- Changed-line coverage: 100% (13/13 changed measurable lines covered).
- Registered local probe: `hub-catalog-tag-normalization-single-pass`.
- Local registered probe delta: `elapsed_ms_mean` 206.761981 ms → 204.102165 ms (`delta_ms=-2.659816`, `delta_pct=-1.2864%`).
- Direct script probe delta with 7 samples: 197.527867 ms → 194.154550 ms (`delta_ms=-3.373318`, `delta_pct=-1.7089%`).
- GitHub Actions PR-scoped performance report is required before merge.

## Known Gaps
- Linux local verification covers the Python Hub catalog path only.
- CI remains the source of truth for the registered PR-scoped performance workflow and final merge gate.

## Evidence Checklist
- [x] Governing plan/spec updated.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage measured locally and is at least 95%.
- [x] Registered probe ran locally with base/head metrics.
- [ ] GitHub Actions and PR-scoped performance report are green.
