### PR TITLE
perf: cache stream annotation token sum

### DIFF
--- a/docs/plans/2026-07-15-stream-assembler-token-count-sum-cache.md
+++ b/docs/plans/2026-07-15-stream-assembler-token-count-sum-cache.md
@@ -1,0 +1,36 @@
+# Stream Assembler Token Count Sum Cache
+
+## Goal
+
+Reduce repeated list summation in the Python request stream assembler token-count annotation hot path while preserving the existing token distribution semantics for content, reasoning, and tool-call deltas.
+
+## Scope
+
+- `services/mlx-worker-python/worker/runtime/stream_assembler.py`
+- `services/mlx-worker-python/tests/test_stream_assembler.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/stream_assembler_token_bytes_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Registered Probe
+
+The affected runtime path is covered by the registered PR-scoped probe `stream-assembler-token-byte-fast-decode` in `infra/perf/pr_scoped_probes.json`. This slice extends that probe script with a focused `token_count_annotation_ms_mean` local metric so the same PR-scoped probe workload exercises the `_annotate_token_counts(...)` multi-delta path directly, in addition to the existing token-byte and large ASCII token-count helper metrics.
+
+The probe entry already keeps focused `test_command`, `coverage_command`, and `probe_command` fields and runs on `ubuntu-latest`, so Linux local verification and CI can both validate this Python-only slice without broadening registry scope.
+
+## Implementation Plan
+
+1. Preserve behavior with the existing focused stream assembler token annotation tests.
+2. Extend `scripts/stream_assembler_token_bytes_probe.py` to time repeated multi-delta token-count annotation and emit a local `token_count_annotation_ms_mean` evidence metric.
+3. Cache `sum(weights)` once inside `_annotate_token_counts(...)` and reuse it for branch selection and extra-token calculation.
+4. Run focused tests, changed-scope coverage, and the registered probe locally on Linux.
+5. Use the PR-scoped performance workflow report as the merge gate.
+
+## Metrics
+
+Primary registered metrics for this slice:
+
+- `stream-assembler-token-byte-fast-decode.token_count_annotation_ms_mean` (lower is better)
+- Existing context metrics: `elapsed_ms_mean`, `delta_token_count_new_ms_mean`, and `peak_bytes_mean`
+
+Success requires behavior tests passing, changed-scope coverage at or above 95%, and no PR-scoped performance regression.

--- a/scripts/stream_assembler_token_bytes_probe.py
+++ b/scripts/stream_assembler_token_bytes_probe.py
@@ -13,6 +13,8 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "services/mlx-worker-python"))
 
 from worker.runtime.stream_assembler import (
+    AssembledToolCall,
+    AssemblyDelta,
     RequestStreamAssembler,
     StreamFragment,
     _whitespace_token_count,
@@ -49,6 +51,44 @@ def _measure_delta_token_count(sample_count: int) -> dict[str, float]:
         "delta_token_count_speedup": old_mean / new_mean if new_mean else 0.0,
         "delta_token_count_text_count": float(len(token_texts)),
         "delta_token_count_checksum": float(checksum),
+    }
+
+
+def _measure_token_count_annotation(sample_count: int) -> dict[str, float]:
+    deltas = [
+        AssemblyDelta(content_text=" ".join(f"visible{index}-{offset}" for offset in range(24)))
+        if index % 3 == 0
+        else AssemblyDelta(reasoning_text=" ".join(f"hidden{index}-{offset}" for offset in range(24)))
+        if index % 3 == 1
+        else AssemblyDelta(
+            tool_call=AssembledToolCall(
+                f"call-{index}",
+                "search",
+                "{}",
+                index,
+                "qwen",
+            )
+        )
+        for index in range(192)
+    ]
+    iterations = int(os.environ.get("MELIX_STREAM_ASSEMBLER_TOKEN_ANNOTATION_ITERATIONS", "5000"))
+    expected_count = 4096
+    elapsed: list[float] = []
+    checksum = 0
+
+    for _ in range(sample_count):
+        assembler = RequestStreamAssembler("token-count-annotation-probe", True, "", "qwen")
+        started = time.perf_counter()
+        for _index in range(iterations):
+            annotated = assembler._annotate_token_counts(deltas, expected_count)
+            checksum += annotated[-1].token_count
+        elapsed.append((time.perf_counter() - started) * 1000.0)
+
+    return {
+        "token_count_annotation_ms_mean": statistics.fmean(elapsed),
+        "token_count_annotation_iterations": float(iterations),
+        "token_count_annotation_delta_count": float(len(deltas)),
+        "token_count_annotation_checksum": float(checksum),
     }
 
 
@@ -100,6 +140,7 @@ def _measure(sample_count: int | None = None, token_event_count: int | None = No
         "sample_count": float(sample_count),
     }
     metrics.update(_measure_delta_token_count(sample_count))
+    metrics.update(_measure_token_count_annotation(sample_count))
     return metrics
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3936,6 +3936,7 @@ def test_stream_assembler_token_bytes_probe_script_emits_metrics(
 ) -> None:
     monkeypatch.setenv("MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_EVENTS", "8")
     monkeypatch.setenv("MELIX_STREAM_ASSEMBLER_TOKEN_BYTES_SAMPLES", "1")
+    monkeypatch.setenv("MELIX_STREAM_ASSEMBLER_TOKEN_ANNOTATION_ITERATIONS", "2")
 
     runpy.run_path(
         str(REPO_ROOT / "scripts/stream_assembler_token_bytes_probe.py"),
@@ -3954,6 +3955,10 @@ def test_stream_assembler_token_bytes_probe_script_emits_metrics(
     assert metrics["delta_token_count_speedup"] > 0
     assert metrics["delta_token_count_text_count"] == 4096.0
     assert metrics["delta_token_count_checksum"] > 0
+    assert metrics["token_count_annotation_ms_mean"] >= 0
+    assert metrics["token_count_annotation_iterations"] == 2.0
+    assert metrics["token_count_annotation_delta_count"] == 192.0
+    assert metrics["token_count_annotation_checksum"] > 0
 
 
 def test_runtime_utils_kwarg_cache_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1142,10 +1142,11 @@ class RequestStreamAssembler:
             return [self._with_token_count(deltas[0], token_count)]
 
         weights = [self._estimated_delta_token_count(delta) for delta in deltas]
-        if sum(weights) > token_count:
+        total_weight = sum(weights)
+        if total_weight > token_count:
             weights = self._compress_delta_token_counts(weights, token_count)
-        elif sum(weights) < token_count:
-            weights = self._distribute_extra_delta_tokens(deltas, weights, token_count - sum(weights))
+        elif total_weight < token_count:
+            weights = self._distribute_extra_delta_tokens(deltas, weights, token_count - total_weight)
 
         return [self._with_token_count(delta, count) for delta, count in zip(deltas, weights)]
 


### PR DESCRIPTION
## Summary
- Cache `_annotate_token_counts(...)` total token weight so the multi-delta path does not sum the same list twice.
- Extend the existing stream assembler token-byte probe script with `token_count_annotation_ms_mean` local evidence for this helper path without changing registry selection scope.
- Add the governing performance-slice plan for the stream assembler token-count annotation update.

## Plan or Spec
- `docs/plans/2026-07-15-stream-assembler-token-count-sum-cache.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_delta_token_annotation_uses_ascii_count_fast_path services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_only_gates_current_path_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_still_gates_large_count_helper_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
# 4 passed in 1.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_metric_gate_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_only_gates_current_path_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_still_gates_large_count_helper_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
# 100 passed in 0.39s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_structural_prefix_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_standard_pipe_parser services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_covers_metric_gate_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_only_gates_current_path_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_still_gates_large_count_helper_regression services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_token_bytes_probe.py
# 100 passed in 0.96s; changed-scope coverage 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_token_bytes_probe.py
# {"elapsed_ms_mean": 633.4448519628495, "token_count_annotation_ms_mean": 2885.885792807676, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY'
# local old-vs-new helper comparison for _annotate_token_counts sum reuse
PY
# {"old_mean_ms": 2920.648191985674, "new_mean_ms": 2890.800587157719, "delta_ms": -29.847604827955365, "speedup": 1.0103250307062177}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_byte_probe_only_gates_current_path_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_token_bytes_probe_script_emits_metrics
# 2 passed in 1.30s

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (27/27 measurable changed lines before the final metadata-only amend; executable changed lines remain covered).
- Local registered probe script: `stream_assembler_token_bytes_probe.py` passed with `token_count_annotation_ms_mean=2885.885792807676`, `elapsed_ms_mean=633.4448519628495`, `sample_count=5`, `token_event_count=80000`.
- Local old-vs-new helper comparison: `old_mean_ms=2920.648191985674`, `new_mean_ms=2890.800587157719`, `delta_ms=-29.847604827955365`, `speedup=1.0103250307062177`.
- CI PR-scoped performance report is required as the merge gate for base-vs-head registered probe validation.

## Known Gaps
- None. This is a Python-only Linux-verified slice; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe script; overhead is CI/local probe-only and not runtime instrumentation.
- [x] Deferred work and known gaps are stated explicitly.
