### PR TITLE
perf: streamline PR performance result path collection

### DIFF
--- a/docs/plans/2026-07-15-pr-scoped-performance-report-results-path-comprehension.md
+++ b/docs/plans/2026-07-15-pr-scoped-performance-report-results-path-comprehension.md
@@ -1,0 +1,29 @@
+# PR-scoped Performance Report Result Path Collection Slice
+
+## Scope
+
+This Python-only performance slice covers the result-file collection phase in
+`scripts/pr_scoped_performance_report.py`.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `pr-scoped-performance-report-results-scandir` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/pr_scoped_performance_report.py`
+- `scripts/pr_scoped_performance_report_results_probe.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Optimization
+
+Keep the existing `os.scandir()` traversal and binary `json.loads()` parsing,
+but collect sorted JSON result paths directly from a list comprehension passed to
+`sorted(...)`. This removes the explicit temporary append binding and post-build
+in-place sort while preserving deterministic path order, ignored non-JSON files,
+missing-directory behavior, and dictionary-only payload loading.
+
+## Verification
+
+Local Linux validation uses the registered focused tests, changed-scope coverage
+command, and registered PR-scoped performance probe. The GitHub Actions
+PR-scoped performance workflow remains the merge gate for CI validation.

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -24,16 +24,11 @@ from worker.productization.pr_scoped_performance import (  # noqa: E402
 
 def _load_results(results_dir: Path) -> list[dict[str, object]]:
     results: list[dict[str, object]] = []
-    result_paths: list[str] = []
-    result_paths_append = result_paths.append
     try:
         with os.scandir(results_dir) as entries:
-            for entry in entries:
-                if entry.name.endswith(".json"):
-                    result_paths_append(entry.path)
+            result_paths = sorted([entry.path for entry in entries if entry.name.endswith(".json")])
     except OSError:
         return []
-    result_paths.sort()
     results_append = results.append
     json_loads = json.loads
     open_file = _OPEN


### PR DESCRIPTION
## Summary
- Streamline PR-scoped performance report result path collection by building the sorted JSON path list directly from the `os.scandir()` iterator.
- Preserve binary `json.loads()` parsing, deterministic result ordering, non-JSON filtering, missing-directory handling, and dictionary-only payload loading.

## Plan or Spec
- `docs/plans/2026-07-15-pr-scoped-performance-report-results-path-comprehension.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke
# 6 passed in 6.24s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_report.py scripts/pr_scoped_performance_report_results_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 6 passed in 42.62s; TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report_results_probe.py
# {"elapsed_ms_mean": 24.163983, "elapsed_ms_min": 22.584772, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}
# {"elapsed_ms_mean": 22.762603, "elapsed_ms_min": 21.5667, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}
# {"elapsed_ms_mean": 24.484336, "elapsed_ms_min": 23.108954, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}

git diff --check
# passed

python3 custom old-vs-new comparison for _load_results over 30 samples
# {"old_mean_ms": 20.22798694282149, "new_mean_ms": 19.008714500038575, "delta_ms": -1.2192724427829162, "speedup_pct": 6.027650928534991, "old_min_ms": 18.172190058976412, "new_min_ms": 18.084706040099263}
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% for `scripts/pr_scoped_performance_report.py` changed line 29; aggregate `TOTAL 1 0 100%`.
- Registered local probe (`pr-scoped-performance-report-results-scandir`) samples: `elapsed_ms_mean` 24.163983 / 22.762603 / 24.484336 ms; `elapsed_ms_min` 22.584772 / 21.5667 / 23.108954 ms.
- Direct same-process old-vs-new comparison over 30 samples: old_mean=20.22798694282149 ms, new_mean=19.008714500038575 ms, delta=-1.2192724427829162 ms, speedup=6.027650928534991%.
- CI PR-scoped performance is required for registered base-vs-head validation before merge.

## Known Gaps
- Local validation is Linux-only. This Python slice does not require Swift runtime validation.
- The registered probe is filesystem-timing sensitive; CI PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
