### PR TITLE
perf: sort PR performance result entries by name

### DIFF
--- a/docs/plans/2026-07-15-pr-scoped-performance-report-results-path-comprehension.md
+++ b/docs/plans/2026-07-15-pr-scoped-performance-report-results-path-comprehension.md
@@ -16,11 +16,16 @@ probe `pr-scoped-performance-report-results-scandir` in
 
 ## Optimization
 
-Keep the existing `os.scandir()` traversal and binary `json.loads()` parsing,
-but collect sorted JSON result paths directly from a list comprehension passed to
-`sorted(...)`. This removes the explicit temporary append binding and post-build
-in-place sort while preserving deterministic path order, ignored non-JSON files,
-missing-directory behavior, and dictionary-only payload loading.
+Keep the existing `os.scandir()` traversal and binary `json.loads()` parsing.
+The first slice collected sorted JSON result paths directly from a list
+comprehension passed to `sorted(...)`, removing the explicit temporary append
+binding and post-build in-place sort.
+
+This follow-up slice sorts the filtered `DirEntry` objects by `entry.name` and
+opens each entry through `entry.path`. That avoids building a separate list of
+full path strings before sorting while preserving deterministic result-name
+order, ignored non-JSON files, missing-directory behavior, and dictionary-only
+payload loading.
 
 ## Verification
 

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -26,14 +26,17 @@ def _load_results(results_dir: Path) -> list[dict[str, object]]:
     results: list[dict[str, object]] = []
     try:
         with os.scandir(results_dir) as entries:
-            result_paths = sorted([entry.path for entry in entries if entry.name.endswith(".json")])
+            result_entries = sorted(
+                (entry for entry in entries if entry.name.endswith(".json")),
+                key=lambda entry: entry.name,
+            )
     except OSError:
         return []
     results_append = results.append
     json_loads = json.loads
     open_file = _OPEN
-    for path in result_paths:
-        with open_file(path, "rb") as result_file:
+    for entry in result_entries:
+        with open_file(entry.path, "rb") as result_file:
             payload = json_loads(result_file.read())
         if type(payload) is dict:
             results_append(payload)


### PR DESCRIPTION
## Summary
- Sort PR-scoped performance report result `DirEntry` objects by name and open them via `entry.path`.
- Avoid building a separate list of full path strings before sorting while preserving deterministic JSON result order and existing missing-directory/non-dict behavior.

## Plan or Spec
- `docs/plans/2026-07-15-pr-scoped-performance-report-results-path-comprehension.md`
- Registered probe: `pr-scoped-performance-report-results-scandir` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke
# 6 passed in 7.57s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_report.py scripts/pr_scoped_performance_report_results_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 6 passed in 42.08s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 - <<'PY' ... registered probe body ... PY
# {"elapsed_ms_mean": 24.704924, "elapsed_ms_min": 23.48854, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}

python3 - <<'PY' ... base-vs-head comparison harness ... PY
# old_mean=20.470758, new_mean=19.488012, delta_ms=-0.982746, speedup=1.051896 across 3 runs

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `scripts/pr_scoped_performance_report.py`, `scripts/pr_scoped_performance_report_results_probe.py`, and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Local registered probe (Linux): `elapsed_ms_mean=24.704924`, `elapsed_ms_min=23.48854`, `file_count=2000`, `result_count=2000`, `sample_count=5`.
- Local base-vs-head comparison across 3 runs: `old_mean=20.470758 ms`, `new_mean=19.488012 ms`, `delta_ms=-0.982746 ms`, `speedup=1.051896`.
- CI PR-scoped performance workflow is required for registered probe validation before merge.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not part of this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
