### PR TITLE
perf: unroll trajectory component labels

### DIFF
--- a/docs/plans/2026-06-25-trajectory-copy-list-literal.md
+++ b/docs/plans/2026-06-25-trajectory-copy-list-literal.md
@@ -88,3 +88,14 @@ with the same key order while safely reusing the immutable labels tuple; mutable
 labels or non-standard component shapes still fall back to the existing recursive
 copy path. The registered `trajectory-provenance-copy-elision` probe remains the
 local Linux and CI validation gate for this small Python-only slice.
+
+## 2026-07-15 follow-up: three-label component tuple fast path
+
+This follow-up remains limited to the component-dict fast path inside
+`worker.trajectory_provenance._copy_trajectory_provenance_value`. The registered
+probe fixture uses the common three-label component tuple shape, so this slice
+unrolls that exact scalar-label guard before falling back to the existing generic
+tuple scan for other scalar label counts. It preserves the same fresh-dict copy
+semantics, immutable-label tuple reuse, and mutable-label fallback behavior while
+reducing per-component iterator overhead in the registered
+`trajectory-provenance-copy-elision` probe.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -963,14 +963,22 @@ def test_copy_trajectory_provenance_value_uses_bound_type_dispatch(
     assert calls[0] is source
 
 
+@pytest.mark.parametrize(
+    "labels",
+    [
+        ("agentic", "trajectory", "1"),
+        ("agentic", "trajectory", "quality", "1"),
+    ],
+)
 def test_copy_trajectory_provenance_value_fast_paths_component_dicts(
+    labels: tuple[str, ...],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     source = {
         "name": "component-1",
         "score": 0.75,
         "passed": True,
-        "labels": ("agentic", "trajectory", "1"),
+        "labels": labels,
     }
 
     def fail_recursive_copy(value: object) -> object:  # pragma: no cover - regression guard

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -115,16 +115,30 @@ def _copy_trajectory_provenance_value(value: Any) -> Any:
                     and _TYPE(passed) in _JSON_IMMUTABLE_TYPE_SET
                     and _TYPE(labels) is tuple
                 ):
-                    for label in labels:
-                        if _TYPE(label) not in _JSON_IMMUTABLE_TYPE_SET:
-                            break
+                    if len(labels) == 3:
+                        label_0, label_1, label_2 = labels
+                        if (
+                            _TYPE(label_0) in _JSON_IMMUTABLE_TYPE_SET
+                            and _TYPE(label_1) in _JSON_IMMUTABLE_TYPE_SET
+                            and _TYPE(label_2) in _JSON_IMMUTABLE_TYPE_SET
+                        ):
+                            return {
+                                "name": name,
+                                "score": score,
+                                "passed": passed,
+                                "labels": labels,
+                            }
                     else:
-                        return {
-                            "name": name,
-                            "score": score,
-                            "passed": passed,
-                            "labels": labels,
-                        }
+                        for label in labels:
+                            if _TYPE(label) not in _JSON_IMMUTABLE_TYPE_SET:
+                                break
+                        else:
+                            return {
+                                "name": name,
+                                "score": score,
+                                "passed": passed,
+                                "labels": labels,
+                            }
         return {key: _copy_trajectory_provenance_value(item) for key, item in value.items()}
     if value_type is list:
         return _copy_json_list(value)


### PR DESCRIPTION
## Summary
- Unroll the common three-label trajectory component tuple guard in `_copy_trajectory_provenance_value`.
- Preserve the generic scalar-label fallback for non-three-label tuples and the mutable-label recursive copy path.
- Extend the component fast-path regression test to cover both three-label and non-three-label scalar tuples.

## Plan or Spec
- `docs/plans/2026-06-25-trajectory-copy-list-literal.md`
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_normalize_trajectory_provenance_copies_nested_json_containers services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_copies_short_scalar_lists_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_uses_literal_copy_for_scalar_lists services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_list_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_reuses_scalar_tuples_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_tuple_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_copies_flat_scalar_dicts_without_recursive_calls services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_uses_unpack_copy_for_flat_scalar_dicts services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_json_dict_still_copies_nested_mutable_items services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_uses_bound_type_dispatch services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_fast_paths_component_dicts services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_component_fast_path_keeps_mutable_labels_isolated services/mlx-worker-python/tests/test_trajectory_provenance.py::test_copy_trajectory_provenance_value_falls_back_for_custom_mutables services/mlx-worker-python/tests/test_trajectory_provenance.py::test_load_trajectory_provenance_from_snapshot_manifest_uses_stable_field_names services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_trajectory_provenance_copy_elision_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_trajectory_provenance_copy_elision_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 29 passed in 2.58s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q <registered trajectory-provenance-copy-elision coverage selection> && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
# 26 passed in 0.88s; changed_line_coverage=100.00%; TOTAL 8 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
# optimized_elapsed_ms_mean=147.78468601871282; speedup=13.505269295098051

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id trajectory-provenance-copy-elision --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/trajectory_copy_tuple_small_pr_probe.json
# head verification ok; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` for `services/mlx-worker-python/worker/trajectory_provenance.py` changed lines (`8/8`).
- Registered local PR-scoped probe (`trajectory-provenance-copy-elision`):
  - base `optimized_elapsed_ms_mean=180.66954298410565`
  - head `optimized_elapsed_ms_mean=109.39448580611497`
  - delta `-71.27505717799068 ms` (`39.45%` lower)
  - base `speedup=10.685163335906902`
  - head `speedup=17.966738243840226`
- Observability mode: evidence (registered PR-scoped command-json probe).
- Probe overhead: synthetic local probe only; no production runtime observability overhead added.
- CI is required to rerun the registered PR-scoped performance workflow before merge.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- Swift runtime effects are N/A; this slice only changes Python trajectory provenance copying.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts.
- [x] Dependency changes include updated lockfiles.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
