### PR TITLE
perf: bind dataset suffix map for preview scans

### DIFF
--- a/docs/plans/2026-07-15-dataset-registry-supported-suffix-binding-performance.md
+++ b/docs/plans/2026-07-15-dataset-registry-supported-suffix-binding-performance.md
@@ -1,0 +1,39 @@
+# Dataset Registry Supported Suffix Binding Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.dataset_registry.catalog._is_supported_dataset_file_name()`, the suffix
+predicate used by dataset registry discovery and limited preview scans.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-registry-preview-limit-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The entry includes focused `test_command`,
+`coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_preview_limit_probe.py`
+
+## Slice
+
+Bind the supported suffix mapping as a default argument for the hot suffix
+predicate. This preserves suffix handling, lowercase fast paths, and mixed-case
+fallback behavior while avoiding repeated global mapping lookups in scan-heavy
+preview paths.
+
+## Success Metrics
+
+Use the registered probe metrics:
+
+- `elapsed_ms_mean` lower is better for limit-one preview scans,
+- `multi_limit_elapsed_ms_mean` lower is better for multi-file limited previews,
+- `peak_bytes_mean` and `multi_limit_peak_bytes_mean` lower is better or neutral,
+- returned row/file counts must remain unchanged.
+
+The change is accepted only if focused tests pass, changed-scope coverage is at
+least 95%, and the registered probe improves or remains non-regressive locally
+on Linux and in PR-scoped CI.

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -46,16 +46,19 @@ _DEFAULT_CONFIG_FIRST_PARTS = frozenset(
 _JSON_LIMITED_PREVIEW_CHUNK_CHARS = 16 * 1024
 
 
-def _is_supported_dataset_file_name(name: str) -> bool:
+def _is_supported_dataset_file_name(
+    name: str,
+    supported_suffixes: Mapping[str, str] = _SUPPORTED_DATASET_SUFFIXES,
+) -> bool:
     dot_index = name.rfind(".")
     if dot_index <= 0 or dot_index == len(name) - 1:
         return False
     suffix = name[dot_index:]
-    if suffix in _SUPPORTED_DATASET_SUFFIXES:
+    if suffix in supported_suffixes:
         return True
     if suffix.islower():
         return False
-    return suffix.lower() in _SUPPORTED_DATASET_SUFFIXES
+    return suffix.lower() in supported_suffixes
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary
- Bind the dataset registry supported-suffix mapping as a default argument for the hot file-name predicate used by preview scans.
- Keep suffix semantics unchanged while reducing repeated global mapping lookups in scan-heavy limited previews.

## Plan or Spec
- `docs/plans/2026-07-15-dataset-registry-supported-suffix-binding-performance.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_returns_first_file_rows_directly ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
# 30 passed in 0.35s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_returns_first_file_rows_directly ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py
# TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_registry_preview_limit_probe.py
# baseline before change: elapsed_ms_mean=98.459072, multi_limit_elapsed_ms_mean=141.739257, peak_bytes_mean=14364.286, multi_limit_peak_bytes_mean=20635.714
# after change samples: elapsed_ms_mean=97.156089 and 97.80939; multi_limit_elapsed_ms_mean=141.612786 and 141.488841; rows_returned=1.0; multi_limit_dataset_files_yielded_mean=5.0

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `services/mlx-worker-python/worker/dataset_registry/catalog.py` and the registered probe/test scope.
- Registered local Linux probe: `dataset_registry_preview_limit_probe.py`.
  - Baseline before change: `elapsed_ms_mean=98.459072`, `multi_limit_elapsed_ms_mean=141.739257`, `peak_bytes_mean=14364.286`, `multi_limit_peak_bytes_mean=20635.714`.
  - After change: representative accepted samples `elapsed_ms_mean=97.156089` / `97.80939`, `multi_limit_elapsed_ms_mean=141.612786` / `141.488841`, row/file counts unchanged.
- CI PR-scoped performance report is required for final registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only; PR-scoped CI must complete and publish the registered probe report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
