### PR TITLE
perf: streamline PR scoped registry metric parsing

### DIFF
--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -5392,6 +5392,27 @@ def test_load_probe_registry_rejects_invalid_payloads(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="non-empty list"):
         load_probe_registry(invalid_metrics)
 
+    mixed_metrics = tmp_path / "mixed-metrics.json"
+    mixed_metrics.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "demo",
+                    "name": "Demo",
+                    "probe_impl": "command_json",
+                    "probe_command": "python3 -c \"import json; print(json.dumps({'elapsed_ms_mean': 1.0}))\"",
+                    "metrics": [
+                        "ignored",
+                        {"key": "elapsed_ms_mean", "unit": "ms", "direction": "lower_is_better"},
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    probes = load_probe_registry(mixed_metrics)
+    assert [metric.key for metric in probes[0].metrics] == ["elapsed_ms_mean"]
+
 
 def test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged(
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -164,32 +164,37 @@ def _parse_probe_registry_payload(payload: object) -> tuple[ProbeDefinition, ...
     for raw_probe in payload:
         if not isinstance(raw_probe, dict):
             raise ValueError("probe registry entries must be JSON objects")
-        raw_metrics = raw_probe.get("metrics", [])
+        raw_probe_get = raw_probe.get
+        raw_metrics = raw_probe_get("metrics", [])
         if not isinstance(raw_metrics, list) or not raw_metrics:
             raise ValueError("probe registry metrics must be a non-empty list")
-        metrics = tuple(
-            metric_definition(
-                key=str_value(raw_metric["key"]),
-                unit=str_value(raw_metric.get("unit", "value")),
-                direction=str_value(raw_metric["direction"]),
-                warn_pct=float_value(raw_metric.get("warn_pct", 5.0)),
-                warn_abs=float_value(raw_metric.get("warn_abs", 0.0)),
+        parsed_metrics: list[MetricDefinition] = []
+        append_metric = parsed_metrics.append
+        for raw_metric in raw_metrics:
+            if not isinstance(raw_metric, dict):
+                continue
+            raw_metric_get = raw_metric.get
+            append_metric(
+                metric_definition(
+                    key=str_value(raw_metric["key"]),
+                    unit=str_value(raw_metric_get("unit", "value")),
+                    direction=str_value(raw_metric["direction"]),
+                    warn_pct=float_value(raw_metric_get("warn_pct", 5.0)),
+                    warn_abs=float_value(raw_metric_get("warn_abs", 0.0)),
+                )
             )
-            for raw_metric in raw_metrics
-            if isinstance(raw_metric, dict)
-        )
         append_probe(
             probe_definition(
                 probe_id=str_value(raw_probe["id"]),
                 name=str_value(raw_probe["name"]),
-                runner=str_value(raw_probe.get("runner", "ubuntu-latest")),
-                watch_globs=tuple(str_value(glob) for glob in raw_probe.get("watch_globs", [])),
-                test_command=str_value(raw_probe.get("test_command", "")).strip(),
-                coverage_command=str_value(raw_probe.get("coverage_command", "")).strip(),
+                runner=str_value(raw_probe_get("runner", "ubuntu-latest")),
+                watch_globs=tuple(str_value(glob) for glob in raw_probe_get("watch_globs", [])),
+                test_command=str_value(raw_probe_get("test_command", "")).strip(),
+                coverage_command=str_value(raw_probe_get("coverage_command", "")).strip(),
                 probe_impl=str_value(raw_probe["probe_impl"]),
-                probe_command=str_value(raw_probe.get("probe_command", "")).strip(),
-                metrics=metrics,
-                coverage_replays_tests=bool_value(raw_probe.get("coverage_replays_tests", False)),
+                probe_command=str_value(raw_probe_get("probe_command", "")).strip(),
+                metrics=tuple(parsed_metrics),
+                coverage_replays_tests=bool_value(raw_probe_get("coverage_replays_tests", False)),
             )
         )
     return tuple(probes)


### PR DESCRIPTION
## Summary
- Streamlines PR-scoped performance registry metric parsing by replacing the generator-filter tuple construction with an explicit append loop and bound `dict.get` lookups.
- Adds regression coverage for mixed metric payloads so non-object metric entries continue to be skipped while valid metrics are preserved.

## Plan or Spec
- Governed by `AGENTS.md` and `docs/engineering-standards.md` for small, registered performance slices.
- Registered probe: `pr-scoped-performance-registry-cache` in `infra/perf/pr_scoped_probes.json` already covers `services/mlx-worker-python/worker/productization/pr_scoped_performance.py` with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_uses_absolute_cache_key_without_resolving services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_rejects_invalid_payloads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_reuses_cached_payload_when_file_is_unchanged services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_build_scope_report_reuses_scope_cached_registry_without_double_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_load_probe_registry_refreshes_cache_when_file_changes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dispatch_probe_impl_supports_registry_cache_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_command_json_probe_rejects_missing_command_and_non_numeric_metrics` — 9 passed.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py` — changed-line coverage 100%.
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 .runtime/probe_registry_cache.py` — local registered-probe helper output captured below.
- `git diff --check` — passed.

## Coverage and Metrics
- Changed-line coverage: `TOTAL 13 0 100%`.
- Baseline local probe before accepted implementation: `load_probe_registry_ms_mean=1.047244`, `cold_load_probe_registry_ms_mean=298.779107`, `build_scope_report_ms_mean=1.965603`.
- Head local probe after implementation: `load_probe_registry_ms_mean=0.893802`, `cold_load_probe_registry_ms_mean=286.586941`, `build_scope_report_ms_mean=1.93301`.
- Delta: load registry `-0.153442 ms` (~14.65% faster), cold load `-12.192166 ms` (~4.08% faster), scope report `-0.032593 ms` (~1.66% faster).
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation ran on Linux only; this slice is Python-only and does not claim Swift/macOS runtime effects.
- An earlier local attempt to optimize code-eval assert scanning was rejected because the registered probe regressed (`assert_elapsed_ms_mean` 3.562410 -> 3.584457 ms; `elapsed_ms_mean` 1.833584 -> 1.958879 ms), and it was reverted before this PR.

## Evidence Checklist
- [x] Registered probe exists for the affected path and includes focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux and showed improvement.
- [ ] GitHub Actions PR-scoped performance workflow has completed successfully.
