### PR TITLE
perf: bind dataset version manifest iterator locals

### DIFF
--- a/docs/plans/2026-05-24-dataset-version-listing-scandir.md
+++ b/docs/plans/2026-05-24-dataset-version-listing-scandir.md
@@ -1,6 +1,6 @@
 # Dataset version listing scandir slice
 
-This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. A follow-up changed shared JSON manifest loading from text decoding to byte loading. The current slice keeps the same registered listing probe and removes per-manifest `Path` construction from the listing hot path by carrying `os.scandir()` string paths into a direct binary JSON load.
+This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. A follow-up changed shared JSON manifest loading from text decoding to byte loading. This slice keeps the same registered listing probe and trims the manifest iterator hot path by binding `os.scandir`, converting the versions root with `os.fspath(...)` once, and appending a local manifest suffix string instead of formatting each yielded path.
 
 ## Scope
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1161,13 +1161,14 @@ _DATASET_VERSION_LIST_STRING_SORT_KEY = itemgetter("created_at", "version_id")
 
 
 def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:
+    scandir = os.scandir
+    manifest_suffix = "/dataset-version.json"
     try:
-        with os.scandir(versions_root) as entries:
+        with scandir(os.fspath(versions_root)) as entries:
             for entry in entries:
                 if not entry.is_dir(follow_symlinks=False):
                     continue
-                manifest_path = f"{entry.path}/dataset-version.json"
-                yield manifest_path
+                yield entry.path + manifest_suffix
     except OSError:
         return
 


### PR DESCRIPTION
## Summary
- Bind the dataset-version manifest iterator's `os.scandir` lookup and manifest suffix locally.
- Convert the versions root with `os.fspath(...)` once before scanning.
- Update the dataset-version listing performance plan for this narrow Python slice.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-version-listing-scandir.md`
- Registered probe: `dataset-version-listing-scandir` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `git status --short && git branch --show-current && git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-version-listing-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/dataset_version_listing_compare.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 60 passed in 2.14s.
- Changed-scope coverage: 100.00% (4/4 changed measurable lines covered).
- Local registered probe (head-only): `elapsed_ms_mean=36.903096`, `elapsed_ms_min=33.190527`, `elapsed_ms_p95=39.538315`, `version_count=2500`.
- Local registered comparison: base `elapsed_ms_mean=37.382668`, head `elapsed_ms_mean=35.063136`, delta `-2.319532 ms` (`~6.21%` faster); base `elapsed_ms_p95=40.641596`, head `elapsed_ms_p95=35.175742`, delta `-5.465854 ms`.

## Known Gaps
- This is a Python-only slice validated locally on Linux; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance must still run the registered `dataset-version-listing-scandir` probe before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally with base/head comparison.
- [ ] GitHub Actions registered probe completed successfully.
