### PR TITLE
perf: bind dataset version manifest iterator locals

### DIFF
--- a/docs/plans/2026-05-24-dataset-version-listing-scandir.md
+++ b/docs/plans/2026-05-24-dataset-version-listing-scandir.md
@@ -1,6 +1,6 @@
 # Dataset version listing scandir slice
 
-This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. A follow-up changed shared JSON manifest loading from text decoding to byte loading. The current slice keeps the same registered listing probe and removes per-manifest `Path` construction from the listing hot path by carrying `os.scandir()` string paths into a direct binary JSON load.
+This Python-only performance track keeps dataset-version listing behavior unchanged while reducing overhead in small, registered slices. The first slice replaced the one-level `Path.glob("*/dataset-version.json")` scan with an explicit `os.scandir()` pass. A follow-up changed shared JSON manifest loading from text decoding to byte loading. This slice keeps the same registered listing probe and trims the manifest iterator hot path by binding `os.scandir`, converting the versions root with `os.fspath(...)` once, and appending a local manifest suffix string instead of formatting each yielded path.
 
 ## Scope
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1161,13 +1161,14 @@ _DATASET_VERSION_LIST_STRING_SORT_KEY = itemgetter("created_at", "version_id")
 
 
 def _iter_dataset_version_manifest_paths(versions_root: Path) -> Iterable[str]:
+    scandir = os.scandir
+    manifest_suffix = "/dataset-version.json"
     try:
-        with os.scandir(versions_root) as entries:
+        with scandir(os.fspath(versions_root)) as entries:
             for entry in entries:
                 if not entry.is_dir(follow_symlinks=False):
                     continue
-                manifest_path = f"{entry.path}/dataset-version.json"
-                yield manifest_path
+                yield entry.path + manifest_suffix
     except OSError:
         return
 


### PR DESCRIPTION
## Summary
- Bind `os.scandir` and convert the dataset versions root to an fspath once in the dataset-version manifest iterator.
- Reuse a local `/dataset-version.json` suffix string while yielding manifest paths.

## Plan or Spec
- `docs/plans/2026-05-24-dataset-version-listing-scandir.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics
# 60 passed in 1.86s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_version_listing_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_version_listing_probe.py
# 60 passed in 1.54s; TOTAL 0 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_version_listing_probe.py
# {"elapsed_ms_mean": 37.455639, "elapsed_ms_min": 35.345046, "elapsed_ms_p95": 37.298412, "sample_count": 7.0, "version_count": 2500.0}
# {"elapsed_ms_mean": 35.983904, "elapsed_ms_min": 33.613857, "elapsed_ms_p95": 37.440348, "sample_count": 7.0, "version_count": 2500.0}
# {"elapsed_ms_mean": 34.303927, "elapsed_ms_min": 32.848751, "elapsed_ms_p95": 34.65424, "sample_count": 7.0, "version_count": 2500.0}

BASE_WT=/root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-version-yield-stat-bind-20260715; PYTHONPATH="$BASE_WT:$BASE_WT/services/mlx-worker-python" uv run --project "$BASE_WT/services/mlx-worker-python" python3 "$BASE_WT/scripts/dataset_version_listing_probe.py"
# {"elapsed_ms_mean": 35.581026, "elapsed_ms_min": 34.065976, "elapsed_ms_p95": 35.585697, "sample_count": 7.0, "version_count": 2500.0}
# {"elapsed_ms_mean": 39.07717, "elapsed_ms_min": 34.391786, "elapsed_ms_p95": 37.546506, "sample_count": 7.0, "version_count": 2500.0}
# {"elapsed_ms_mean": 36.062174, "elapsed_ms_min": 34.55918, "elapsed_ms_p95": 38.021628, "sample_count": 7.0, "version_count": 2500.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 0 0 100%` for the registered dataset-version listing probe scope.
- Registered local probe (`dataset-version-listing-scandir`, 3 runs): old_mean=36.906790 ms, new_mean=35.914490 ms, speedup=1.0276x, delta_ms=-0.992300 (-2.69%).
- GitHub Actions PR-scoped performance is required as the merge gate and final registered probe validation.

## Known Gaps
- Local Linux probe timing is noisy; CI PR-scoped performance must confirm the registered probe remains green before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
