### PR TITLE
perf: cache dataset preview supported scan checks

### DIFF
--- a/docs/plans/2026-07-15-dataset-preview-scan-supported-once-performance.md
+++ b/docs/plans/2026-07-15-dataset-preview-scan-supported-once-performance.md
@@ -1,0 +1,43 @@
+# Dataset Preview Scan Supported-Name Predicate Performance Slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.dataset_registry.catalog._supported_scan_entry_records()`, the scan
+record helper used by limited dataset preview discovery.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-registry-preview-limit-short-circuit` in
+`infra/perf/pr_scoped_probes.json`. The entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/dataset_registry/catalog.py`
+- `services/mlx-worker-python/tests/test_dataset_registry.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_registry_limit_probe.py`
+- `scripts/dataset_registry_preview_limit_probe.py`
+
+## Slice
+
+Cache each directory entry's README classification and supported dataset suffix
+predicate result inside `_supported_scan_entry_records()`. The scan helper still
+avoids file stat calls for unsupported names, still yields directories for
+recursive preview traversal, and still filters README metadata files, but it no
+longer recomputes `_is_supported_dataset_file_name()` for unsupported files,
+broken supported files, or supported non-regular entries after the directory
+probe.
+
+## Success Metrics
+
+Use the registered probe metrics:
+
+- `elapsed_ms_mean` lower is better for limit-one preview scans,
+- `multi_limit_elapsed_ms_mean` lower is better for multi-file limited previews,
+- `peak_bytes_mean` and `multi_limit_peak_bytes_mean` lower is better or neutral,
+- returned row/file counts must remain unchanged.
+
+The change is accepted only if focused tests pass, changed-scope coverage is at
+least 95%, and the registered probe improves or remains non-regressive locally
+on Linux and in PR-scoped CI.

--- a/services/mlx-worker-python/tests/test_dataset_registry.py
+++ b/services/mlx-worker-python/tests/test_dataset_registry.py
@@ -650,6 +650,14 @@ def test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names(
     broken = FakeEntry("broken.jsonl", file_error=True)
     non_file = FakeEntry("pipe.jsonl", is_file=False)
     supported = FakeEntry("train.jsonl")
+    support_checks: dict[str, int] = {}
+    original_is_supported = catalog._is_supported_dataset_file_name
+
+    def counting_is_supported(name: str) -> bool:
+        support_checks[name] = support_checks.get(name, 0) + 1
+        return original_is_supported(name)
+
+    monkeypatch.setattr(catalog, "_is_supported_dataset_file_name", counting_is_supported)
 
     records = list(
         catalog._supported_scan_entry_records(
@@ -667,6 +675,13 @@ def test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names(
     assert broken.is_file_calls == 1
     assert non_file.is_file_calls == 1
     assert supported.is_file_calls == 1
+    assert support_checks == {
+        "notes.txt": 1,
+        "raw-data.txt": 1,
+        "broken.jsonl": 1,
+        "pipe.jsonl": 1,
+        "train.jsonl": 1,
+    }
 
     monkeypatch.setattr(
         catalog.os,

--- a/services/mlx-worker-python/worker/dataset_registry/catalog.py
+++ b/services/mlx-worker-python/worker/dataset_registry/catalog.py
@@ -554,7 +554,9 @@ def _supported_scan_entry_records(
         name = entry.name
         if name <= after:
             continue
-        if name not in _README_NAMES and _is_supported_dataset_file_name(name):
+        is_readme = name in _README_NAMES
+        is_supported = False if is_readme else _is_supported_dataset_file_name(name)
+        if is_supported:
             try:
                 if entry.is_file(follow_symlinks=False):
                     yield name, entry.path, False, True
@@ -568,7 +570,7 @@ def _supported_scan_entry_records(
                 continue
         except OSError:
             continue
-        if name in _README_NAMES or not _is_supported_dataset_file_name(name):
+        if is_readme or not is_supported:
             continue
 
 


### PR DESCRIPTION
## Summary
- Cache README classification and supported-suffix predicate results per entry in dataset preview scan records.
- Add a regression assertion that each candidate name is checked once while preserving unsupported-file stat avoidance.

## Plan or Spec
- `docs/plans/2026-07-15-dataset-preview-scan-supported-once-performance.md`
- Registered probe: `dataset-registry-preview-limit-short-circuit` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names
# RED before implementation: failed because notes.txt, broken.jsonl, and pipe.jsonl were checked twice.
# GREEN after implementation: 1 passed in 0.08s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_returns_first_file_rows_directly services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_respects_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_jsonl_limit_one_returns_first_dict_directly services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_file_format_uses_supported_suffixes services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_first_preview_scan_skips_readme_without_rescan services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_first_preview_scan_skips_unsupported_files_before_best services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_scan_records_skip_file_stat_for_unsupported_names services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_preview_scan_streams_multiple_files_without_sorted_walk services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_json_row_reader_limit_uses_incremental_decode services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_text_helper_edges services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_text_reuses_shared_decoder services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_text_reuses_shared_row_array_keys services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_text_fast_paths_first_row_array_key services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_file_streams_before_full_read services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limited_json_file_helper_edges services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_parquet_limit_uses_batched_reader services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_arrow_limit_uses_first_batches services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_zero_limit_returns_empty services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_snapshot_row_reader_zero_limit_skips_file_scan services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_file_scan_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_stops_iterator_after_unsplit_limit services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_limit_one_preview_avoids_full_supported_file_iterator services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_first_preview_file_preserves_sorted_depth_first_edges services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_row_reader_keeps_split_filtering_eager_for_missing_split services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_reads_json_and_csv_snapshots services/mlx-worker-python/tests/test_dataset_registry.py::test_dataset_catalog_selected_split_filters_during_iteration services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_registry_preview_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_limit_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_registry_preview_limit_probe_script_emits_metrics
# 30 passed in 1.26s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered dataset preview test set> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/dataset_registry/catalog.py services/mlx-worker-python/tests/test_dataset_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_registry_limit_probe.py scripts/dataset_registry_preview_limit_probe.py
# 30 passed in 0.37s; TOTAL 11 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 11 0 100%`).
- Registered local Linux probe (`scripts/dataset_registry_preview_limit_probe.py`) on `origin/main`: `elapsed_ms_mean=102.032010`, `multi_limit_elapsed_ms_mean=146.068909`, `peak_bytes_mean=14381.143`, `multi_limit_peak_bytes_mean=20584.857`.
- Registered local Linux probe on this branch: `elapsed_ms_mean=98.382738`, `multi_limit_elapsed_ms_mean=141.315451`, `peak_bytes_mean=14381.143`, `multi_limit_peak_bytes_mean=20598.000`.
- Delta: `elapsed_ms_mean -3.649272 ms` (about 3.58% faster), `multi_limit_elapsed_ms_mean -4.753458 ms` (about 3.25% faster), limit-one peak unchanged, multi-limit peak +13.143 bytes (about 0.06%, neutral).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice.
- Swift/runtime effects are not applicable for this Python-only path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
