### PR TITLE
perf: speed maintenance capability cache hits

### DIFF
--- a/docs/plans/2026-07-16-maintenance-capability-cache-hit-lookup.md
+++ b/docs/plans/2026-07-16-maintenance-capability-cache-hit-lookup.md
@@ -1,0 +1,48 @@
+# Maintenance capability cache-hit lookup fast path
+
+## Scope
+
+This Python-only performance slice is limited to the single-value capability
+metadata parser in `services/mlx-worker-python/worker/engine/maintenance_core.py`.
+The parser already keeps a bounded cache for repeated scalar capability values
+and an LRU-cached tuple for comma-separated values. This slice narrows the hot
+cache-hit branch from `dict.get(..., sentinel)` plus an identity check to direct
+`dict.__getitem__` with a `KeyError` miss path, and uses list-unpack
+materialization for cached comma-separated tuples.
+
+Behavior stays unchanged: comma-separated capability values still use the cached
+tuple splitter, scalar values still return a fresh mutable `list[str]`, blank
+scalar values still return an empty list, and the bounded cache is still cleared
+before inserting after it reaches its maximum size.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`maintenance-capability-split-single-strip` in
+`infra/perf/pr_scoped_probes.json`. The entry includes focused
+`test_command`, `coverage_command`, and `probe_command` values for:
+
+- `services/mlx-worker-python/worker/engine/maintenance_core.py`
+- `services/mlx-worker-python/tests/test_maintenance_service.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/maintenance_capability_split_probe.py`
+
+## Implementation Plan
+
+1. Keep the existing cache and list-returning contract intact.
+2. Use direct dictionary indexing on the scalar cache-hit path, falling back to
+   the existing strip/cache-insert logic only on `KeyError`.
+3. Materialize cached comma-separated tuples with list-unpack syntax while still
+   returning an isolated list.
+4. Run the registered focused test command, changed-scope coverage command,
+   `git diff --check`, and the registered probe locally on Linux before opening
+   the PR.
+5. Use GitHub Actions PR-scoped performance as the final registered probe gate
+   before merge.
+
+## Expected Signal
+
+The registered probe reports both comma-separated split performance and repeated
+single-value split performance. This slice targets `single_elapsed_ms_mean` and
+should keep `elapsed_ms_mean` neutral-to-improved for the comma-separated cached
+tuple path.

--- a/services/mlx-worker-python/worker/engine/maintenance_core.py
+++ b/services/mlx-worker-python/worker/engine/maintenance_core.py
@@ -322,14 +322,15 @@ _CAPABILITY_SINGLE_VALUE_CACHE_MISSING = object()
 def _split_capability_values(raw_value: str) -> list[str]:
     if "," not in raw_value:
         single_value_cache = _CAPABILITY_SINGLE_VALUE_CACHE
-        stripped = single_value_cache.get(raw_value, _CAPABILITY_SINGLE_VALUE_CACHE_MISSING)
-        if stripped is _CAPABILITY_SINGLE_VALUE_CACHE_MISSING:
+        try:
+            stripped = single_value_cache[raw_value]
+        except KeyError:
             stripped = raw_value.strip()
             if len(single_value_cache) >= _CAPABILITY_SINGLE_VALUE_CACHE_MAX_SIZE:
                 single_value_cache.clear()
             single_value_cache[raw_value] = stripped
-        return [stripped] if stripped else []  # type: ignore[list-item]
-    return list(_split_capability_value_tuple(raw_value))
+        return [stripped] if stripped else []
+    return [*_split_capability_value_tuple(raw_value)]
 
 
 @lru_cache(maxsize=128)


### PR DESCRIPTION
## Summary
- Speeds the maintenance capability cache-hit path by using direct dictionary indexing with a `KeyError` miss fallback for scalar values.
- Uses list-unpack materialization for cached comma-separated capability tuples while preserving isolated mutable list results.
- Preserves blank-value behavior, bounded cache clearing, and the existing cached tuple splitter semantics.

## Plan or Spec
- Added `docs/plans/2026-07-16-maintenance-capability-cache-hit-lookup.md` for this slice.
- Registered probe: `maintenance-capability-split-single-strip` in `infra/perf/pr_scoped_probes.json` already covers the touched path and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_strips_once_and_drops_empty_segments services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_returns_isolated_cached_lists services/mlx-worker-python/tests/test_maintenance_service.py::test_split_capability_values_bounds_single_value_cache services/mlx-worker-python/tests/test_maintenance_service.py::test_get_model_info_appends_tool_parser_when_capability_parser_metadata_is_absent services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_maintenance_capability_split_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_maintenance_capability_split_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands` → 7 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...` + `coverage json` + `python3 scripts/changed_scope_coverage.py ...` → 100% changed-line coverage
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id maintenance-capability-split-single-strip --base-repo /tmp/melix-maintenance-capability-cache-hit-base-20260716004258 --head-repo "$PWD" --output /tmp/maintenance-capability-cache-hit-pr-scope-amended.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 7 passed locally on Linux.
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=1`, `aggregate_covered_changed_lines=1`).
- Registered local probe after the amended slice:
  - `elapsed_ms_mean`: base `125.40797740221024`, head `115.33392101991922`, delta `-10.074056382291019` ms (`-8.03%`).
  - `single_elapsed_ms_mean`: base `14.35359416063875`, head `11.180114769376814`, delta `-3.1734793912619352` ms (`-22.11%`).
  - `speedup`: base `3.1472702242591417`, head `3.3962365116260567` (`+7.91%`).
  - `single_speedup`: base `1.3604309094581688`, head `1.5503068206768225` (`+13.96%`).
  - `peak_bytes_mean`: base `896.0`, head `840.0`, delta `-56.0` bytes.
- CI PR-scoped performance must complete successfully before merge.

## Known Gaps
- Swift/macOS runtime effects are not claimed; this is a Python-only Linux-verified slice.
- Probe timings have normal wall-clock noise; merge gating relies on the registered PR-scoped CI probe completing successfully for the pushed commit.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed the affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Implemented exactly one small optimization slice.
- [x] Updated the governing plan/spec under `docs/plans/`.
- [x] Ran focused tests, changed-scope coverage, and registered local probe on Linux.
- [ ] GitHub Actions PR-scoped performance completed successfully.
