### PR TITLE
perf: cache empty tool registry selections

### DIFF
--- a/docs/unified-agentic-tool-runtime-contract.md
+++ b/docs/unified-agentic-tool-runtime-contract.md
@@ -124,7 +124,12 @@ Each tool descriptor must include:
 The worker-facing default registry must be serializable to a deterministic
 `ToolConfig` receipt. Explicit selections are resolved against the selectable
 catalog, must preserve request order, deduplicate repeated names, and fail
-before execution on unknown names.
+before execution on unknown names. Empty selections are a hot-path selector
+case and must reuse the registry's direct empty-selection cache slot rather
+than performing a dictionary cache lookup on every request. The registered
+PR-scoped performance probe for this path is
+`tool-registry-select-name-index-cache`, which reports selection timings,
+including `empty_selection_elapsed_ms_mean` for the empty-selection fast path.
 
 Every selectable tool schema must also have matching index metadata with the
 same tool ID and retrieval description as the schema description. Non-always

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import pytest
 
@@ -483,6 +484,26 @@ def test_tool_registry_empty_selection_reuses_cached_registry() -> None:
     assert selected.metrics().required_argument_count == 0
     assert registry.select(()) is selected
     assert registry.select([]) is selected
+
+
+def test_tool_registry_empty_selection_uses_direct_cache_slot() -> None:
+    registry = ToolRegistry(built_in_tool_registry().tools)
+    selected = registry.select([])
+
+    class LookupBlockedCache:
+        def get(
+            self,
+            key: tuple[str, ...],
+            default: ToolRegistry | None = None,
+        ) -> ToolRegistry | None:
+            raise AssertionError("empty selection should use the direct cache slot")
+
+    registry._selection_cache = cast(
+        dict[tuple[str, ...], ToolRegistry], LookupBlockedCache()
+    )
+
+    assert registry.select([]) is selected
+    assert registry.select(()) is selected
 
 
 def test_tool_registry_empty_selection_openai_tools_returns_fresh_empty_list() -> None:

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -268,6 +268,7 @@ class ToolIndexMetadata:
 
 class ToolRegistry:
     __slots__ = (
+        "_empty_selection",
         "_metrics",
         "_openai_tool_templates",
         "_parser",
@@ -313,6 +314,7 @@ class ToolRegistry:
             for tool in self._tools
         )
         self._selection_cache: dict[tuple[str, ...], ToolRegistry] = {}
+        self._empty_selection: ToolRegistry | None = None
         self._worker_tool_config_bytes: bytes = b""
         self._worker_tool_config_template: common_pb2.ToolConfig | None = None
         self._metrics = ToolRegistryMetrics(
@@ -333,7 +335,7 @@ class ToolRegistry:
 
     def select(self, names: list[str] | tuple[str, ...]) -> ToolRegistry:
         if not names:
-            cached_selection = self._selection_cache.get(())
+            cached_selection = self._empty_selection
             if cached_selection is not None:
                 return cached_selection
             selection = ToolRegistry(
@@ -343,6 +345,7 @@ class ToolRegistry:
                 parser=self._parser,
                 parser_contract_version=self._parser_contract_version,
             )
+            self._empty_selection = selection
             self._selection_cache[()] = selection
             return selection
         if isinstance(names, tuple):


### PR DESCRIPTION
## Summary
- Cache empty `ToolRegistry.select([]/())` results in a direct slot instead of paying a dictionary lookup on every empty-selection call.
- Add a regression test that blocks selection-cache dictionary reads for the empty-selection fast path.
- Document the registered PR-scoped probe and metric for this hot path.

## Plan or Spec
- `docs/unified-agentic-tool-runtime-contract.md` — Tool Registry Contract now records the empty-selection direct-cache expectation and the registered `tool-registry-select-name-index-cache` probe.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_empty_selection_reuses_cached_registry services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_empty_selection_uses_direct_cache_slot services/mlx-worker-python/tests/test_tool_registry.py::test_tool_registry_empty_selection_openai_tools_returns_fresh_empty_list
# 3 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 123 passed in 0.42s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.tool_registry -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py
# 123 passed in 0.51s; changed_line_coverage=100.00% (3/3)

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# head probe emitted JSON metrics successfully

python3 /tmp/run_tool_probe_compare.py
# 3-run base/head comparison with MELIX_TOOL_REGISTRY_SELECT_SAMPLES=7 completed successfully

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/tool_registry.py` changed lines 317, 338, 348 covered; `TOTAL 3 0 100%`.
- Registered probe: `tool-registry-select-name-index-cache` (`scripts/tool_registry_select_probe.py`).
- Local Linux 3-run base/head probe comparison (`MELIX_TOOL_REGISTRY_SELECT_SAMPLES=7`):
  - `elapsed_ms_mean`: base `21.868785`, head `21.866990`, delta `-0.001795 ms`, speedup `1.000082x`.
  - `empty_selection_elapsed_ms_mean`: base `2.728809`, head `2.179179`, delta `-0.549630 ms`, speedup `1.252219x`.
  - `raw_single_config_elapsed_ms_mean`: base `16.029932`, head `15.951819`, delta `-0.078113 ms`, speedup `1.004897x`.
  - `missing_selection_elapsed_ms_mean`: base `14.878340`, head `13.877550`, delta `-1.000790 ms`, speedup `1.072116x`.
  - `selector_planning_elapsed_ms_mean`: base `31.290100`, head `30.895174`, delta `-0.394926 ms`, speedup `1.012783x`.
- CI PR-scoped performance workflow is required as the merge-gating registered probe validation.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime effect is claimed for this slice.
- CI must still run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
