### PR TITLE
perf: materialize dataset source paths with list comprehension

### DIFF
--- a/docs/plans/2026-07-16-dataset-source-path-materialization-listcomp.md
+++ b/docs/plans/2026-07-16-dataset-source-path-materialization-listcomp.md
@@ -1,0 +1,25 @@
+# Dataset Source Path Materialization List Comprehension
+
+## Context
+
+Dataset ingest source discovery walks large local input trees with `_iter_source_file_paths()` in `services/mlx-worker-python/worker/productization/dataset_preparation.py`. The PR-scoped probe `Dataset source records scandir` covers this path through `scripts/dataset_source_records_probe.py` and verifies source-file count, deterministic ordering, source-kind classification, and record byte accounting.
+
+## Slice
+
+Use a direct list comprehension when converting sorted filesystem path strings into `Path` instances. The traversal, symlink handling, sort order, and returned `Path` values stay unchanged; only the final materialization step changes from `list(map(Path, file_paths))` to a comprehension.
+
+## Verification Plan
+
+- Run the registered focused tests for `Dataset source records scandir`.
+- Run changed-scope coverage for `dataset_preparation.py`, the ingest tests, PR-scoped registry tests, and the probe script.
+- Run the registered probe locally on Linux and compare `elapsed_ms_mean` against the `origin/main` baseline.
+
+## Results
+
+Local Linux probe comparison on a synthetic tree with 250 directories, 28 files per directory, and 11 samples:
+
+- `origin/main`: `elapsed_ms_mean=11.5307918114757`, `elapsed_ms_p95=12.23217905499041`
+- candidate: `elapsed_ms_mean=11.482173100706529`, `elapsed_ms_p95=12.08088407292962`
+- delta: `-0.04861871076917102 ms` mean (`~0.42%` faster), `-0.15129498206079006 ms` p95
+
+This is a small Python-only hot-path improvement with unchanged behavior and local Linux validation.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1278,7 +1278,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return list(map(path_cls, file_paths))
+    return [path_cls(file_path) for file_path in file_paths]
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Materialize sorted dataset source path strings with a direct list comprehension instead of `list(map(Path, ...))`.
- Keeps traversal, symlink handling, sort order, and returned `Path` values unchanged for the registered dataset source records hot path.

## Plan or Spec
- `docs/plans/2026-07-16-dataset-source-path-materialization-listcomp.md`

## Commands Run
```text
# Baseline probe on origin/main (temporarily checked out dataset_preparation.py from origin/main)
MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
=> exit 0; elapsed_ms_mean=11.5307918114757; elapsed_ms_p95=12.23217905499041; file_count_mean=7000; sample_count=11

# Candidate focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
=> exit 0; 47 passed in 1.98s

# Candidate changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
=> exit 0; 47 passed in 1.15s; TOTAL 1 0 100%

# Candidate registered probe
MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
=> exit 0; elapsed_ms_mean=11.482173100706529; elapsed_ms_p95=12.08088407292962; file_count_mean=7000; sample_count=11

git diff --check
=> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`TOTAL 1 0 100%`).
- Registered probe: `Dataset source records scandir` already covers this path with focused `test_command`, `coverage_command`, and `probe_command` entries in `infra/perf/pr_scoped_probes.json`.
- Local Linux probe delta: `elapsed_ms_mean` improved from `11.5307918114757` to `11.482173100706529` (`-0.04861871076917102 ms`, about `0.42%` faster); p95 improved from `12.23217905499041` to `12.08088407292962` (`-0.15129498206079006 ms`).
- CI PR-scoped performance workflow is required as the merge validation source for the registered probe.

## Known Gaps
- Local validation is Linux-only. This slice is Python-only and does not claim Swift runtime validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
