### PR TITLE
perf: fast path common hub size suffixes

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
+++ b/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
@@ -25,6 +25,16 @@ The probe builds synthetic Hub catalog size-hint payloads and exercises both dir
 
 This follow-up Python-only slice stays within `services/mlx-worker-python/worker/model_ops/hub_catalog.py` and the registered `hub-catalog-size-hint-regex-precompile` PR-scoped probe. It narrows `_tag_payload_contains_mlx(...)` by checking exact `"MLX"` / `"mlx"` list membership before falling back to per-item mixed-case atom checks. Behavior remains identical for exact tags, mixed-case tags, list subclasses, string payloads, and non-string tag payloads; the slice only avoids repeated Python-level tag iteration in the common exact-tag Hub compatibility path.
 
+## 2026-07-16 common suffix direct size-hint slice
+
+This follow-up Python-only slice keeps the same registered probe and narrows to
+`_direct_size_hint_from_text(...)`. The common Hub model-size strings use a
+single ASCII space followed by uppercase or lowercase `KB` / `MB` / `GB`, so the
+direct parser now checks that three-character suffix first. Mixed-case units,
+tab-separated units, trailing whitespace, and other uncommon valid formats still
+fall through to the existing full scanner, preserving parser behavior while
+reducing work for the repeated common-card/readme size-hint probe workload.
+
 ## Success Metrics
 
 - Focused Hub catalog tests pass.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -889,26 +889,24 @@ def _size_hint_from_marked_text(text: str) -> int:
 
 
 def _direct_size_hint_from_text(text: str) -> int:
-    if len(text) >= 4 and text[-3].isspace():
-        unit_suffix = ord(text[-1])
-        if unit_suffix == 66 or unit_suffix == 98:  # B or b
-            unit_initial = ord(text[-2])
-            if unit_initial == 77 or unit_initial == 109:  # M or m
-                multiplier = _SIZE_HINT_MB
-            elif unit_initial == 71 or unit_initial == 103:  # G or g
-                multiplier = _SIZE_HINT_GB
-            elif unit_initial == 75 or unit_initial == 107:  # K or k
-                multiplier = _SIZE_HINT_KB
-            else:
-                multiplier = 0
-            if multiplier:
-                value_text = text[:-3]
-                if value_text.isdecimal():
-                    return int(value_text) * multiplier
-                try:
-                    return int(float(value_text) * multiplier)
-                except ValueError:
-                    return 0
+    if len(text) >= 4:
+        unit_suffix = text[-3:]
+        if unit_suffix == " MB" or unit_suffix == " mb":
+            multiplier = _SIZE_HINT_MB
+        elif unit_suffix == " GB" or unit_suffix == " gb":
+            multiplier = _SIZE_HINT_GB
+        elif unit_suffix == " KB" or unit_suffix == " kb":
+            multiplier = _SIZE_HINT_KB
+        else:
+            multiplier = 0
+        if multiplier:
+            value_text = text[:-3]
+            if value_text.isdecimal():
+                return int(value_text) * multiplier
+            try:
+                return int(float(value_text) * multiplier)
+            except ValueError:
+                return 0
 
     text_length = len(text)
     value_start = 0


### PR DESCRIPTION
## Summary
- Fast-path common Hub catalog model-size suffixes (` KB`, ` MB`, ` GB` and lowercase variants) in `_direct_size_hint_from_text`.
- Keep mixed-case units, tab-separated units, trailing whitespace, and uncommon formats on the existing scanner path.
- Document the 2026-07-16 Python performance slice in the governing Hub catalog size-hint plan.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md`
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 96 passed in 0.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 96 passed in 0.58s; TOTAL 17 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python bash -c 'if [ -f "${PWD}/../head/scripts/hub_catalog_size_hint_probe.py" ]; then python3 "${PWD}/../head/scripts/hub_catalog_size_hint_probe.py"; else python3 "${PWD}/scripts/hub_catalog_size_hint_probe.py"; fi'
# elapsed_ms_mean=1265.208721999079; payload_compatibility_elapsed_ms_mean=185.4616080177948

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id hub-catalog-size-hint-regex-precompile --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/hub_size_hint_probe.json
# ok; base elapsed_ms_mean=1312.7290706150234, head elapsed_ms_mean=1301.6806985950097

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `100.00%` (`TOTAL 17 0 100%`).
- Local registered base-vs-head probe (`hub-catalog-size-hint-regex-precompile`):
  - `elapsed_ms_mean`: base `1312.7290706150234` ms -> head `1301.6806985950097` ms (`-11.04837202001367` ms, ~`0.84%` faster).
  - `payload_compatibility_elapsed_ms_mean`: base `197.5039652083069` ms -> head `194.1040808102116` ms (`-3.3998843980953023` ms, ~`1.72%` faster).
  - `size_hint_calls_mean`: base `0.0`, head `0.0`.
  - `checksum`: unchanged (`1545732096.0`).
- CI PR-scoped performance report is required as the final registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed for this slice.
- Probe improvement is small; CI registered probe must confirm no regression before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
