### PR TITLE
perf: fast path lowercase mlx repo ids

### DIFF
--- a/docs/plans/2026-07-16-hub-repo-id-mlx-ascii-fastpath.md
+++ b/docs/plans/2026-07-16-hub-repo-id-mlx-ascii-fastpath.md
@@ -1,0 +1,33 @@
+# Hub repo-id MLX lowercase fast path
+
+This Python-only performance slice is limited to the Hub catalog compatibility helper `worker.model_ops.hub_catalog._repo_id_contains_mlx()`.
+
+## Scope
+
+The registered Hub catalog size-hint probe also measures `_payload_is_mlx_compatible()` on representative Hub payloads. Common MLX-compatible repository identifiers already contain lowercase `mlx` in the repo id, such as `owner/model-mlx-suffix`. Before this slice, every repo-id compatibility check lowercased the whole string before checking membership.
+
+This slice preserves case-insensitive behavior while adding a lowercase-ASCII fast path before falling back to `repo_id.lower()` for mixed- or uppercase identifiers.
+
+## Probe coverage
+
+The affected path is covered by the registered PR-scoped probe `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+## Verification plan
+
+1. Run the registered focused tests for the Hub catalog probe locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux and require at least 95% for touched scope.
+3. Run the registered probe command locally on Linux and compare baseline-vs-head metrics.
+4. Use GitHub Actions PR-scoped performance as the final registered probe merge gate.
+
+## Expected metrics
+
+Primary metric: lower `payload_compatibility_elapsed_ms_mean` with unchanged `payload_compatibility_matched_count` and size-hint metrics.
+
+## Boundaries
+
+This slice does not change Hub API requests, summary/card record shaping, size-hint parsing, tag normalization, generated protobuf artifacts, or Swift/runtime behavior.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -559,6 +559,8 @@ def _base_models(value: Any) -> list[str]:
 
 
 def _repo_id_contains_mlx(repo_id: str) -> bool:
+    if "mlx" in repo_id:
+        return True
     return "mlx" in repo_id.lower()
 
 


### PR DESCRIPTION
## Summary
- Add a lowercase `mlx` repo-id fast path before falling back to `repo_id.lower()` in Hub catalog compatibility checks.
- Document the slice plan and registered probe coverage for the Hub catalog size-hint/compatibility probe.

## Plan or Spec
- `docs/plans/2026-07-16-hub-repo-id-mlx-ascii-fastpath.md`
- Registered probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 96 passed.
- Changed-scope coverage: 100.00% for 2 measurable changed lines.
- Probe baseline on `origin/main`: `payload_compatibility_elapsed_ms_mean=193.67496999911964`, `elapsed_ms_mean=1297.7013766299933`, `payload_compatibility_matched_count=160000.0`.
- Probe head: `payload_compatibility_elapsed_ms_mean=187.16757921501994`, `elapsed_ms_mean=1285.2200087858364`, `payload_compatibility_matched_count=160000.0`.
- Local delta: `payload_compatibility_elapsed_ms_mean=-6.507390784099698 ms` (`1.0347677242575433x`), total `elapsed_ms_mean=-12.481367844156921 ms` (`1.009711463997474x`).

## Known Gaps
- Linux local validation covers the Python slice only.
- The registered PR-scoped performance workflow in GitHub Actions remains the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registry entry has focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally with an improving compatibility metric.
- [ ] GitHub Actions PR-scoped performance report completed successfully.