### PR TITLE
perf: reduce dataset quality completion lookups

### DIFF
--- a/docs/plans/2026-07-16-dataset-quality-completion-sentinel.md
+++ b/docs/plans/2026-07-16-dataset-quality-completion-sentinel.md
@@ -1,0 +1,40 @@
+# Dataset quality completion sentinel lookup
+
+## Scope
+
+This Python-only performance slice is limited to output-length accounting in
+`worker.productization.dataset_preparation._append_rows_output_lengths()`.
+
+The hot path computes dataset quality summary lengths for prompt/completion and
+message-shaped generated rows. Completion rows currently perform a key-presence
+check and then a second dictionary lookup to read the completion value.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The probe
+has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- dataset preparation focused tests
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Plan
+
+1. Keep output-length behavior unchanged for string, non-string, missing, and
+   message rows.
+2. Replace the completion-row key-presence check plus item lookup with a single
+   sentinel-backed `row.get("completion", missing)` lookup.
+3. Update the focused regression tripwire so completion rows avoid
+   `__contains__` instead of forbidding `get()`.
+4. Run focused tests, changed-scope coverage, and the registered local probe on
+   Linux before opening the PR.
+5. Use GitHub Actions PR-scoped performance as the final registered probe and
+   merge gate.
+
+## Expected metrics
+
+The registered probe should report a lower or stable `elapsed_ms_mean` for the
+quality-summary output-length workload. Failed-segment partition metrics are
+reported by the same probe but are not expected to change because this slice
+does not alter `_partition_failed_segments()`.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -221,12 +221,12 @@ def test_dataset_quality_output_lengths_preserve_completion_and_message_semantic
     assert _sample_output_length_stats([], []) == (0, 0, 0)
 
 
-def test_dataset_quality_completion_rows_use_key_presence_fast_path() -> None:
+def test_dataset_quality_completion_rows_use_get_sentinel_fast_path() -> None:
     class CompletionRow(dict[str, object]):
-        def get(self, key: str, default: object = None) -> object:  # pragma: no cover - regression tripwire
+        def __contains__(self, key: object) -> bool:  # pragma: no cover - regression tripwire
             if key == "completion":  # pragma: no cover - regression tripwire
-                raise AssertionError("completion rows should not call get() for completion")
-            return super().get(key, default)  # pragma: no cover - regression tripwire
+                raise AssertionError("completion rows should use a sentinel get() instead of a contains lookup")
+            return super().__contains__(key)  # pragma: no cover - regression tripwire
 
     row = CompletionRow({"completion": "hello"})
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -52,6 +52,7 @@ _CODE_SOURCE_LANGUAGE_BY_SUFFIX = {
 _SOURCE_KIND_NAME_CACHE_MAX = 4096
 _SOURCE_KIND_BY_NAME: dict[str, str | None] = {}
 _SHA256 = hashlib.sha256
+_MISSING = object()
 
 
 def preflight_workspace(*args: Any, **kwargs: Any) -> dict[str, Any]:
@@ -1878,9 +1879,11 @@ def _append_rows_output_lengths(
     len_ = len
     str_ = str
     dict_ = dict
+    missing = _MISSING
     output_length_total = 0
     for row in rows:
-        if "completion" not in row:
+        completion = row.get("completion", missing)
+        if completion is missing:
             messages = row.get("messages", [])
             if not isinstance(messages, list):
                 append(0)
@@ -1901,7 +1904,6 @@ def _append_rows_output_lengths(
             append(total)
             output_length_total += total
         else:
-            completion = row["completion"]
             if type(completion) is str:
                 length = len_(completion)
             else:


### PR DESCRIPTION
## Summary
- Reduce dataset quality output-length completion row lookups from contains+getitem to one sentinel-backed `get()`.
- Update the focused regression tripwire to guard against reintroducing the completion `__contains__` lookup.
- Document the slice and registered probe in `docs/plans/2026-07-16-dataset-quality-completion-sentinel.md`.

## Plan or Spec
- `docs/plans/2026-07-16-dataset-quality-completion-sentinel.md`
- Registered probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_completion_rows_use_get_sentinel_fast_path services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_message_rows_skip_completion_key_lookup services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_length_stats_accumulates_total_inline`
- Registered `dataset-quality-lengths-chain` `test_command`
- Registered `dataset-quality-lengths-chain` `coverage_command`
- Registered `dataset-quality-lengths-chain` `probe_command`
- `MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=100 ... python3 scripts/dataset_quality_lengths_probe.py` on base and head for a local comparison
- `git diff --check`

## Coverage and Metrics
- Focused tests: 4 passed.
- Registered tests: 60 passed.
- Changed-scope coverage: 100% (`aggregate_measurable_changed_lines=5`, `aggregate_covered_changed_lines=5`).
- Registered local probe (head, default samples): `elapsed_ms_mean=2.584976`, `elapsed_ms_min=2.489061`, `elapsed_ms_p95=2.832013`, `failed_partition_elapsed_ms_mean=1.122496`.
- Local 100-sample comparison: base `elapsed_ms_mean=2.627633`, head `elapsed_ms_mean=2.570368`, delta `-0.057265 ms` (`~2.18%` faster). Failed-partition metrics are unchanged by this slice and remain informational.

## Known Gaps
- Linux local validation covers the Python slice. The registered PR-scoped performance workflow is required as the final CI validation source before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Behavior-preserving focused regression coverage updated.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe ran locally with a positive 100-sample local comparison.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
