### PR TITLE
perf: fast path changed-scope allowlist cache

### DIFF
--- a/docs/plans/2026-07-16-changed-scope-allowlist-exact-cache.md
+++ b/docs/plans/2026-07-16-changed-scope-allowlist-exact-cache.md
@@ -1,0 +1,29 @@
+# Changed-scope allowlist exact-cache slice
+
+## Scope
+
+This Python performance slice is limited to `scripts/changed_scope_coverage.py`, specifically repeated `_coverage_path_allowlist(...)` calls from registered changed-scope coverage probes.
+
+## Registered probe
+
+The affected path is covered by the existing registered PR-scoped probe `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.
+
+That registry entry already includes focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_measured_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+The probe reports `allowlist_parse_elapsed_ms_mean` over repeated allowlist lookups, which is the direct metric for this slice.
+
+## Optimization hypothesis
+
+Registered coverage commands repeatedly call `_coverage_path_allowlist(...)` with the exact same JSON environment value. The function already caches the normalized raw value, but it strips the environment value before checking the last-value fast path. Checking the exact raw value first keeps whitespace-normalized behavior unchanged while avoiding a repeated `str.strip()` call for the common no-whitespace JSON payload.
+
+## Verification plan
+
+1. Keep the existing allowlist cache regression tests green.
+2. Add/retain behavior coverage for whitespace-normalized payloads so the exact-cache branch does not change semantics.
+3. Run the registered focused test command and changed-scope coverage command locally on Linux.
+4. Run the registered `changed-scope-coverage-measured-set-filter` probe locally against `origin/main` and this branch, using `allowlist_parse_elapsed_ms_mean` as the primary metric.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -180,7 +180,10 @@ def _coverage_path_allowlist_from_raw(raw_value: str) -> frozenset[str] | None:
 def _coverage_path_allowlist(env: Mapping[str, str]) -> frozenset[str] | None:
     global _ALLOWLIST_LAST_RAW, _ALLOWLIST_LAST_RESULT
 
-    raw_value = env.get("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "").strip()
+    raw_value = env.get("MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON", "")
+    if raw_value == _ALLOWLIST_LAST_RAW and _ALLOWLIST_LAST_RESULT is not _ALLOWLIST_CACHE_MISS:
+        return _ALLOWLIST_LAST_RESULT  # type: ignore[return-value]
+    raw_value = raw_value.strip()
     if raw_value == _ALLOWLIST_LAST_RAW and _ALLOWLIST_LAST_RESULT is not _ALLOWLIST_CACHE_MISS:
         return _ALLOWLIST_LAST_RESULT  # type: ignore[return-value]
     allowlist = _coverage_path_allowlist_from_raw(raw_value)

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -351,6 +351,28 @@ def test_coverage_path_allowlist_reuses_last_raw_payload_without_lru_entry(monke
     assert calls == 1
 
 
+def test_coverage_path_allowlist_normalizes_whitespace_before_cache_compare(monkeypatch) -> None:
+    changed_scope_coverage._coverage_path_allowlist_from_raw.cache_clear()
+    calls = 0
+    original_from_raw = changed_scope_coverage._coverage_path_allowlist_from_raw
+
+    def counted_from_raw(raw_value: str) -> frozenset[str] | None:
+        nonlocal calls
+        calls += 1
+        return original_from_raw(raw_value)
+
+    monkeypatch.setattr(changed_scope_coverage, "_coverage_path_allowlist_from_raw", counted_from_raw)
+    payload = '["direct.py", "context.py"]'
+
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": payload}
+    ) == {"direct.py", "context.py"}
+    assert changed_scope_coverage._coverage_path_allowlist(
+        {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": f"  {payload}\n"}
+    ) == {"direct.py", "context.py"}
+    assert calls == 1
+
+
 def test_coverage_path_allowlist_escaped_string_uses_json_decoder() -> None:
     assert changed_scope_coverage._coverage_path_allowlist(
         {"MELIX_CHANGED_SCOPE_COVERAGE_PATHS_JSON": '"pkg/\\u0064irect.py"'}


### PR DESCRIPTION
## Summary
- Fast-path repeated changed-scope coverage allowlist lookups by checking the exact cached environment value before stripping.
- Add a regression test proving whitespace-normalized payloads still reuse the normalized cache result.
- Document the slice and registered probe coverage for the measured allowlist path.

## Plan or Spec
- `docs/plans/2026-07-16-changed-scope-allowlist-exact-cache.md`
- Registered probe: `changed-scope-coverage-measured-set-filter` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 54 passed in 1.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 54 passed in 0.73s; TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id changed-scope-coverage-measured-set-filter --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-allowlist-exact-cache-20260716 --head-repo "$PWD" --output /tmp/changed_scope_allowlist_exact_cache_probe.json
# head verification ok; base_probe ok; head_probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered local probe `changed-scope-coverage-measured-set-filter`:
  - `allowlist_parse_elapsed_ms_mean`: base `3.14695414687906 ms`, head `2.9117021643157517 ms`, delta `-0.2352519825633082 ms` (`~7.48%` faster).
  - `elapsed_ms_mean`: base `0.3087215591222048 ms`, head `0.2666235834892307 ms`.
  - `sparse_elapsed_ms_mean`: base `10.277954013352948 ms`, head `8.981815156792957 ms`.
  - `dense_elapsed_ms_mean`: base `58.786664839967024 ms`, head `56.86637544671872 ms`.
- CI PR-scoped performance workflow is required as the merge gate for registered probe validation.

## Known Gaps
- None for the Python/Linux scope. Swift/macOS runtime effects are not applicable to this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: off; probe overhead: existing registered probe only.
- [x] Deferred work and known gaps are stated explicitly.
