### PR TITLE
perf: parse hub size hints from spans

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
+++ b/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
@@ -46,3 +46,15 @@ reducing work for the repeated common-card/readme size-hint probe workload.
 1. Add module-level byte multiplier constants and reuse them in `_direct_size_hint_from_text(...)` and `_size_hint_from_text(...)`.
 2. Extend the focused size-hint parser test to cover KB, fractional MB, and GB through both direct and regex-backed paths.
 3. Run focused pytest, changed-scope coverage, `git diff --check`, and the registered local probe before opening the PR.
+
+## 2026-07-16 explicit-line span parse slice
+
+This follow-up Python-only slice keeps the same registered probe and narrows to
+`_direct_size_hint_from_line(...)`, which is used by direct explicit Hub card and
+README size-hint parsing. Common size-hint lines that end with a single ASCII
+space plus `KB` / `MB` / `GB` or lowercase variants now parse directly from the
+original text span instead of slicing a temporary line string before delegating to
+`_direct_size_hint_from_text(...)`. Uncommon valid formats, including mixed-case
+units, tab-separated units, and trailing whitespace, still fall back to the
+existing full direct parser on the sliced span, preserving behavior while reducing
+allocation and dispatch in the repeated registered size-hint workload.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -626,7 +626,26 @@ def test_direct_size_hint_fast_paths_cache_repeated_text(monkeypatch: pytest.Mon
             == 12 * MB
         )
 
-    assert direct_calls == ["12 MB", "12 MB"]
+    assert direct_calls == ["12 MB"]
+
+
+def test_direct_size_hint_from_line_parses_common_suffix_without_text_slice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    direct_parser = Mock(side_effect=AssertionError("common suffix should parse from span"))
+    monkeypatch.setattr(hub_catalog_module, "_direct_size_hint_from_text", direct_parser)
+
+    text = "README\nModel size: 1.5 GB\nother metadata"
+
+    assert hub_catalog_module._direct_size_hint_from_line(text, text.index("1.5")) == int(
+        1.5 * GB
+    )
+    separator_text = "prefix Model size: 2 MB\u2028other metadata"
+    assert hub_catalog_module._direct_size_hint_from_line(
+        separator_text, separator_text.index("2")
+    ) == 2 * MB
+    assert hub_catalog_module._direct_size_hint_from_span("bad MB", 0, 6) == 0
+    direct_parser.assert_not_called()
 
 
 def test_weight_or_config_file_preserves_case_insensitive_matches() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -963,6 +963,28 @@ def _direct_size_hint_from_text(text: str) -> int:
         return 0
 
 
+def _direct_size_hint_from_span(text: str, value_start: int, value_end: int) -> int:
+    if value_end - value_start >= 4:
+        unit_suffix = text[value_end - 3 : value_end]
+        if unit_suffix == " MB" or unit_suffix == " mb":
+            multiplier = _SIZE_HINT_MB
+        elif unit_suffix == " GB" or unit_suffix == " gb":
+            multiplier = _SIZE_HINT_GB
+        elif unit_suffix == " KB" or unit_suffix == " kb":
+            multiplier = _SIZE_HINT_KB
+        else:
+            multiplier = 0
+        if multiplier:
+            value_text = text[value_start : value_end - 3]
+            if value_text.isdecimal():
+                return int(value_text) * multiplier
+            try:
+                return int(float(value_text) * multiplier)
+            except ValueError:
+                return 0
+    return _direct_size_hint_from_text(text[value_start:value_end])
+
+
 @lru_cache(maxsize=4096)
 def _direct_card_size_hint_from_text(text: str) -> int:
     stripped_text = _strip_model_size_label(text)
@@ -974,7 +996,7 @@ def _direct_card_size_hint_from_text(text: str) -> int:
 def _direct_size_hint_from_line(text: str, value_start: int) -> int:
     newline_index = text.find("\n", value_start)
     if newline_index >= 0:
-        return _direct_size_hint_from_text(text[value_start:newline_index])
+        return _direct_size_hint_from_span(text, value_start, newline_index)
     value_end = value_start
     text_length = len(text)
     while (
@@ -982,7 +1004,7 @@ def _direct_size_hint_from_line(text: str, value_start: int) -> int:
         and text[value_end] not in "\r\v\f\x1c\x1d\x1e\x85\u2028\u2029"
     ):
         value_end += 1
-    return _direct_size_hint_from_text(text[value_start:value_end])
+    return _direct_size_hint_from_span(text, value_start, value_end)
 
 
 @lru_cache(maxsize=4096)


### PR DESCRIPTION
## Summary
- Optimizes Hub catalog explicit size-hint line parsing by parsing common `KB` / `MB` / `GB` suffixes directly from the original text span.
- Keeps uncommon valid formats on the existing `_direct_size_hint_from_text(...)` fallback path.
- Adds regression coverage for span parsing and updates the governing performance-slice plan.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md` (`2026-07-16 explicit-line span parse slice`).
- Registered PR-scoped probe: `hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Base probe from origin/main worktree
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
=> {"elapsed_ms_mean": 1306.9769341964275, "payload_compatibility_elapsed_ms_mean": 196.71961362473667, "peak_bytes_mean": 230837.2, "matched_hint_count": 120000.0, "size_hint_calls_mean": 0.0, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py::test_direct_size_hint_fast_paths_cache_repeated_text services/mlx-worker-python/tests/test_hub_catalog.py::test_direct_size_hint_from_line_parses_common_suffix_without_text_slice services/mlx-worker-python/tests/test_hub_catalog.py::test_direct_explicit_size_hint_handles_common_readme_lines services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
=> 4 passed in 1.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
=> 97 passed in 0.49s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
=> TOTAL 31 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
=> {"elapsed_ms_mean": 1299.7557480121031, "payload_compatibility_elapsed_ms_mean": 184.35736482497305, "peak_bytes_mean": 230837.2, "matched_hint_count": 120000.0, "size_hint_calls_mean": 0.0, ...}

git diff --check
=> pass
```

## Coverage and Metrics
- Changed-scope coverage: `100%` (`31/31` changed executable lines covered).
- Local registered probe (`hub-catalog-size-hint-regex-precompile`):
  - base `elapsed_ms_mean=1306.9769341964275`
  - head `elapsed_ms_mean=1299.7557480121031`
  - delta `-7.221186184324324 ms` (`~0.55%` faster)
  - `peak_bytes_mean=230837.2` unchanged
  - `matched_hint_count=120000.0`, `size_hint_calls_mean=0.0`
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Linux local validation covers the Python worker path only. CI remains the source of truth for the PR-scoped performance workflow report.
- No protocol, dependency, or generated artifact changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
