### PR TITLE
perf: bind deterministic embedding cycle copy methods

### DIFF
--- a/docs/plans/2026-07-16-deterministic-embedding-cycle-copy-methods.md
+++ b/docs/plans/2026-07-16-deterministic-embedding-cycle-copy-methods.md
@@ -1,0 +1,35 @@
+# Deterministic Embedding Cycle Copy Method Binding
+
+## Slice
+
+This Python-only performance slice targets the repeated multi-input cycle branch
+in `services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`.
+The existing path already detects a repeated cycle and replays copied vectors;
+this slice reduces per-replayed-vector method lookup overhead by binding each
+cycle vector's `copy` method once after the first cycle is embedded.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`deterministic-embedding-duplicate-input-cache` in
+`infra/perf/pr_scoped_probes.json`. The registry entry has focused
+`test_command`, `coverage_command`, and `probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_embedding_runtime.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/deterministic_embedding_duplicate_probe.py`
+
+## Verification plan
+
+1. Run the registered focused test command locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered probe locally on Linux before and after the change and
+   compare `elapsed_ms_mean`, `peak_bytes_mean`, and `embed_text_calls_mean`.
+
+## Expected behavior
+
+The runtime must still return one vector per input, keep repeated vectors as
+separate mutable lists, and preserve the reduced backend call count for repeated
+cycles. The registered probe asserts vector count, checksum, duplicate copy
+identity, and backend call count.

--- a/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
+++ b/services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py
@@ -82,8 +82,9 @@ class DeterministicEmbeddingRuntime:
                 vector = embed_text(backend, text, dimensions)
                 append_vector(vector)
             cycle_vectors = tuple(vectors)
+            cycle_vector_copies = tuple(vector.copy for vector in cycle_vectors)
             for _ in range(input_count // cycle_length - 1):
-                vectors.extend(vector.copy() for vector in cycle_vectors)
+                vectors.extend(copy_vector() for copy_vector in cycle_vector_copies)
             return vectors
 
         vector_cache: dict[str, list[float]] = {}


### PR DESCRIPTION
## Summary
- Bind deterministic embedding repeated-cycle vector copy methods once after the first cycle is embedded.
- Preserve one mutable vector list per replayed input while reducing copy-method lookup overhead in the repeated multi-input cycle path.

## Plan or Spec
- `docs/plans/2026-07-16-deterministic-embedding-cycle-copy-methods.md`
- Registered PR-scoped probe: `deterministic-embedding-duplicate-input-cache`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics` → 20 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_deterministic_embedding_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_deterministic_embedding_duplicate_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/deterministic_embedding_runtime.py services/mlx-worker-python/tests/test_embedding_runtime.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/deterministic_embedding_duplicate_probe.py` → 20 passed; changed-scope coverage 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/deterministic_embedding_duplicate_probe.py` → local registered probe JSON emitted successfully
- `git diff --check` → passed

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`
- Local Linux registered probe comparison, 3 repeated runs each:
  - `elapsed_ms_mean`: base mean `19.488503` ms → head mean `18.824172` ms; delta `-0.664331` ms; speedup `1.035x`
  - `peak_bytes_mean`: base mean `3017030.4` bytes → head mean `3058030.4` bytes; delta `+41000.0` bytes
  - `embed_text_calls_mean`: base `512.0` → head `512.0`
  - `single_cycle_elapsed_ms_mean`: base mean `16.904049` ms → head mean `16.869149` ms; delta `-0.034901` ms
- Final local probe sample on the pushed commit: `elapsed_ms_mean=18.580819`, `peak_bytes_mean=3058030.4`, `embed_text_calls_mean=512.0`, `single_cycle_elapsed_ms_mean=16.568241`.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- The method-binding tuple adds about 41 KB peak allocation in the local probe while improving elapsed time for the repeated multi-input cycle path.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with before/after metrics.
- [ ] GitHub Actions and PR-scoped performance probe completed successfully.
