### PR TITLE
perf: bind tool selector input fields

### DIFF
--- a/docs/plans/2026-07-16-tool-registry-selector-field-locals.md
+++ b/docs/plans/2026-07-16-tool-registry-selector-field-locals.md
@@ -1,0 +1,41 @@
+# Tool registry selector field locals
+
+## Goal
+
+Reduce repeated dataclass attribute reads in `select_agentic_tools_for_turn()` while
+preserving the existing tool-selection receipt semantics.
+
+## Scope
+
+This Python-only slice is limited to the non-policy selector path in
+`services/mlx-worker-python/worker/runtime/tool_registry.py`. It keeps the
+selection rules, fallback behavior, selected registry, and receipt payloads
+unchanged.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `tool-registry-select-name-index-cache` in
+`infra/perf/pr_scoped_probes.json`. That probe includes focused `test_command`,
+`coverage_command`, and `probe_command` entries covering `tool_registry.py`, the
+focused tool-registry tests, PR-scoped probe selection tests, and
+`scripts/tool_registry_select_probe.py`.
+
+## Implementation
+
+- Snapshot the hot `ToolSelectionInput` fields into local variables at selector
+  entry.
+- Reuse those locals through vector, current-turn keyword, context keyword, and
+  fallback-reason branches.
+- Remove the unreachable `selection_mode != "vector"` guard after vector
+  selection because successful vector selection returns immediately; unsuccessful
+  vector selection must still continue to keyword fallback as before.
+
+## Verification
+
+- Run the focused registered test command locally on Linux.
+- Run the changed-scope coverage command locally on Linux.
+- Run `scripts/tool_registry_select_probe.py` before and after the change and
+  compare `selector_planning_elapsed_ms_mean` plus adjacent selector metrics.
+- Let the PR-scoped performance workflow validate the registered probe in CI
+  before merging.

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -732,27 +732,30 @@ def _append_policy_selected_tool(
 
 
 def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSelectionResult:
+    vector_selected_tool_ids = selection_input.vector_selected_tool_ids
+    recent_user_turns = selection_input.recent_user_turns
+    vector_available = selection_input.vector_available
+    current_user_turn = selection_input.current_user_turn
     if selection_input.allow_web is not None:
         return _select_agentic_tools_for_turn_with_policy(selection_input)
     registry = agentic_tool_catalog_registry()
     max_selected_tools = selection_input.max_selected_tools
     if max_selected_tools <= 1:
         return _build_always_only_tool_selection_result(registry, selection_input)
-    current_user_turn = selection_input.current_user_turn
     if (
-        not selection_input.vector_selected_tool_ids
-        and not selection_input.recent_user_turns
+        not vector_selected_tool_ids
+        and not recent_user_turns
         and (not current_user_turn or current_user_turn.isspace())
     ):
         return _build_always_only_tool_selection_result(registry, selection_input)
     current_matches: tuple[str, ...] | None = None
     context_matches: tuple[str, ...] | None = None
-    if not selection_input.vector_selected_tool_ids:
+    if not vector_selected_tool_ids:
         current_matches = _keyword_tool_matches(current_user_turn)
         if not current_matches:
-            if selection_input.recent_user_turns:
+            if recent_user_turns:
                 context_matches = _keyword_tool_matches(
-                    _recent_user_turns_keyword_context(selection_input.recent_user_turns)
+                    _recent_user_turns_keyword_context(recent_user_turns)
                 )
                 if not context_matches:
                     return _build_always_only_tool_selection_result(
@@ -780,8 +783,8 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
             fallback_reason,
         )
 
-    if selection_input.vector_available and selection_input.vector_selected_tool_ids:
-        for tool_name in selection_input.vector_selected_tool_ids:
+    if vector_available and vector_selected_tool_ids:
+        for tool_name in vector_selected_tool_ids:
             if append_selected_tool(
                 selected_names,
                 selected_sources,
@@ -801,37 +804,36 @@ def select_agentic_tools_for_turn(selection_input: ToolSelectionInput) -> ToolSe
                 "",
             )
 
-    if selection_mode != "vector":
-        if current_matches is None:
-            current_matches = _keyword_tool_matches(selection_input.current_user_turn)
-        for tool_name in current_matches:
+    if current_matches is None:
+        current_matches = _keyword_tool_matches(current_user_turn)
+    for tool_name in current_matches:
+        if append_selected_tool(
+            selected_names,
+            selected_sources,
+            selected_tools,
+            tool_name,
+            "keyword",
+            max_selected_tools,
+        ):
+            has_keyword_selection = True
+    if recent_user_turns and len(selected_names) < max_selected_tools:
+        if context_matches is None:
+            context_matches = _keyword_tool_matches(
+                _recent_user_turns_keyword_context(recent_user_turns)
+            )
+        for tool_name in context_matches:
             if append_selected_tool(
                 selected_names,
                 selected_sources,
                 selected_tools,
                 tool_name,
-                "keyword",
+                "keyword_context",
                 max_selected_tools,
             ):
                 has_keyword_selection = True
-        if selection_input.recent_user_turns and len(selected_names) < max_selected_tools:
-            if context_matches is None:
-                context_matches = _keyword_tool_matches(
-                    _recent_user_turns_keyword_context(selection_input.recent_user_turns)
-                )
-            for tool_name in context_matches:
-                if append_selected_tool(
-                    selected_names,
-                    selected_sources,
-                    selected_tools,
-                    tool_name,
-                    "keyword_context",
-                    max_selected_tools,
-                ):
-                    has_keyword_selection = True
-        if has_keyword_selection:
-            selection_mode = "keyword"
-            fallback_reason = "vector_unavailable" if not selection_input.vector_available else "vector_no_match"
+    if has_keyword_selection:
+        selection_mode = "keyword"
+        fallback_reason = "vector_unavailable" if not vector_available else "vector_no_match"
 
     if not has_vector_selection and not has_keyword_selection:
         return _build_always_only_tool_selection_result(registry, selection_input)


### PR DESCRIPTION
## Summary
- Bind hot `ToolSelectionInput` fields to locals in `select_agentic_tools_for_turn()`.
- Remove the unreachable non-policy selector guard after successful vector selection returns immediately.
- Add the governing performance-slice plan for this selector-local binding change.

## Plan or Spec
- `docs/plans/2026-07-16-tool-registry-selector-field-locals.md`

## Commands Run
```text
# Baseline from origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; selector_planning_elapsed_ms_mean=32.81533378176391; current_capacity_planning_elapsed_ms_mean=30.69171078968793; no_keyword_fallback_planning_elapsed_ms_mean=62.61846940033138

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 124 passed in 1.56s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; selector_planning_elapsed_ms_mean=31.964706373400986; current_capacity_planning_elapsed_ms_mean=29.991002823226154; no_keyword_fallback_planning_elapsed_ms_mean=59.949909429997206

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 124 passed in 0.60s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; TOTAL 20 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 20 0 100%` for `tool_registry.py`, `test_tool_registry.py`, `test_pr_scoped_performance.py`, and `scripts/tool_registry_select_probe.py`.
- Registered local probe: `scripts/tool_registry_select_probe.py`.
  - `selector_planning_elapsed_ms_mean`: 32.81533378176391 -> 31.964706373400986 (`-0.850627408362924 ms`, `-2.59%`).
  - `current_capacity_planning_elapsed_ms_mean`: 30.69171078968793 -> 29.991002823226154 (`-0.7007079664617777 ms`, `-2.28%`).
  - `no_keyword_fallback_planning_elapsed_ms_mean`: 62.61846940033138 -> 59.949909429997206 (`-2.668559970334174 ms`, `-4.26%`).
- CI PR-scoped performance report is required before merge for the registered probe `tool-registry-select-name-index-cache`.

## Known Gaps
- Linux local validation covers the Python selector path only. No Swift runtime effect is claimed.
- Final registered-probe validation is expected from GitHub Actions PR-scoped performance workflow.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
