### PR TITLE
perf: collect PR scoped report results in place

### DIFF
--- a/docs/plans/2026-07-16-pr-scoped-report-results-name-sort.md
+++ b/docs/plans/2026-07-16-pr-scoped-report-results-name-sort.md
@@ -1,0 +1,24 @@
+# PR-scoped report results in-place path collection
+
+## Scope
+
+This Python-only performance slice is limited to `scripts/pr_scoped_performance_report.py::_load_results`, the helper that loads per-probe JSON result files before rendering the PR-scoped performance report.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe `pr-scoped-performance-report-results-scandir` in `infra/perf/pr_scoped_probes.json`. The probe has focused `test_command`, `coverage_command`, and `probe_command` entries for `scripts/pr_scoped_performance_report.py`, `scripts/pr_scoped_performance_report_results_probe.py`, and focused PR-scoped performance tests.
+
+## Optimization plan
+
+1. Preserve deterministic path ordering and existing JSON filtering behavior.
+2. Replace `sorted(...)` over a generator with an explicit list append loop plus in-place `list.sort()`, preserving the existing path-order contract while avoiding generator/sorted call overhead in the hot result scan.
+3. Keep `os.scandir`, binary reads, module-level `_OPEN`, and no pre-existence stat checks.
+4. Verify focused tests, changed-scope coverage, and the registered probe locally on Linux before PR.
+
+## Expected metrics direction
+
+The registered probe should report lower or stable `elapsed_ms_mean` / `elapsed_ms_min` for directories with many result JSON files because result path collection avoids the generator-to-sorted pipeline while retaining the same deterministic sort order.
+
+## Linux validation boundary
+
+This slice is Python-only and fully locally validated on Linux. GitHub Actions PR-scoped performance remains the merge gate.

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -26,9 +26,14 @@ def _load_results(results_dir: Path) -> list[dict[str, object]]:
     results: list[dict[str, object]] = []
     try:
         with os.scandir(results_dir) as entries:
-            result_paths = sorted(entry.path for entry in entries if entry.name.endswith(".json"))
+            result_paths: list[str] = []
+            append_path = result_paths.append
+            for entry in entries:
+                if entry.name.endswith(".json"):
+                    append_path(entry.path)
     except OSError:
         return []
+    result_paths.sort()
     results_append = results.append
     json_loads = json.loads
     open_file = _OPEN


### PR DESCRIPTION
## Summary
- Optimize `scripts/pr_scoped_performance_report.py::_load_results` by collecting JSON result paths into a list and sorting it in place instead of passing a generator through `sorted(...)`.
- Add a focused plan for this Python-only performance slice.

## Plan or Spec
- `docs/plans/2026-07-16-pr-scoped-report-results-name-sort.md`
- Registered probe: `pr-scoped-performance-report-results-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_report.py scripts/pr_scoped_performance_report_results_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report_results_probe.py`

## Coverage and Metrics
- Focused tests: 6 passed.
- Changed-scope coverage: 100% (`TOTAL 6 0 100%`).
- Registered local probe latest run: `elapsed_ms_mean=24.307812`, `elapsed_ms_min=22.29552`, `file_count=2000`, `result_count=2000`.
- Local old/new repeated probe comparison (3 runs each): old means `24.337743`, `24.609558`, `23.170128`; new means `23.397849`, `23.420722`, `24.567974`.

## Known Gaps
- Python-only slice validated locally on Linux. GitHub Actions PR-scoped performance is still required as the merge gate.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Focused tests pass locally.
- [x] Changed-scope coverage is at least 95% for touched measurable lines.
- [x] Registered probe ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
