### PR TITLE
perf: skip startup log scans without paths

### DIFF
--- a/docs/plans/2026-07-16-startup-signals-empty-log-path-fast-path.md
+++ b/docs/plans/2026-07-16-startup-signals-empty-log-path-fast-path.md
@@ -1,0 +1,46 @@
+# Startup Signals Empty Log Path Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to startup failure classification in
+`worker.productization.startup_signals.classify_startup_failure`.
+
+The optimization keeps existing startup-hang behavior for manifests without
+control-plane or worker log paths, but returns the hang report before invoking the
+log-excerpt helpers. It also binds discovered manifest log-path values once and
+reuses those bindings for the control-plane and worker fallback scans.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance
+probe `startup-signals-lazy-worker-log-excerpts` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes:
+
+- `test_command` for focused startup-signal behavior and PR-scoped probe tests.
+- `coverage_command` for changed-scope coverage over `startup_signals.py`,
+  `test_startup_signals.py`, `test_pr_scoped_performance.py`, and
+  `scripts/startup_signals_log_probe.py`.
+- `probe_command` executing `scripts/startup_signals_log_probe.py` with
+  machine-readable metrics for direct conflict/crash, empty-manifest hangs,
+  log-backed control/worker crash, tail scanning, and report allocation paths.
+
+## Verification Plan
+
+1. Add a focused regression test proving empty startup manifests skip log-excerpt
+   helper calls while preserving `startup_hang` output.
+2. Run the registered focused `test_command` locally on Linux.
+3. Run the registered changed-scope `coverage_command` locally on Linux.
+4. Run the registered `probe_command` locally on Linux and compare against a
+   pre-change baseline.
+5. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+## Expected Metrics
+
+The empty-manifest path should improve or remain stable:
+
+- `empty_hang_elapsed_ms_mean`
+- `empty_hang_log_reads_mean`
+- `empty_hang_log_path_exists_checks_mean`
+
+Log-backed paths should preserve behavior and remain covered by the same
+registered probe.

--- a/services/mlx-worker-python/tests/test_startup_signals.py
+++ b/services/mlx-worker-python/tests/test_startup_signals.py
@@ -640,6 +640,26 @@ def test_classify_startup_failure_skips_log_reads_when_error_text_reports_port_c
     assert read_paths == []
 
 
+def test_classify_startup_failure_skips_log_excerpt_helpers_without_log_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_log_excerpt(*paths: object) -> str:  # pragma: no cover - sentinel
+        raise AssertionError(f"empty startup manifests should not scan log paths: {paths}")
+
+    monkeypatch.setattr(startup_signals_module, "_log_excerpt", fail_log_excerpt)
+
+    report = classify_startup_failure(
+        {
+            "http_port": 11434,
+            "ready_probe_url": "http://127.0.0.1:11434/v1/models",
+        },
+        error_text="handshake timed out",
+    )
+
+    assert report.classification == "startup_hang"
+    assert report.log_excerpt == "handshake timed out"
+
+
 def test_classify_startup_failure_skips_logs_when_error_text_reports_control_plane_crash(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -480,9 +480,34 @@ def classify_startup_failure(
         classification = ""
 
     if not classification:
+        control_plane_stderr_path = manifest.get("control_plane_stderr_path")
+        control_plane_stdout_path = manifest.get("control_plane_stdout_path")
+        python_worker_stderr_path = manifest.get("python_worker_stderr_path")
+        swift_text_worker_stderr_path = manifest.get("swift_text_worker_stderr_path")
+        python_worker_stdout_path = manifest.get("python_worker_stdout_path")
+        swift_text_worker_stdout_path = manifest.get("swift_text_worker_stdout_path")
+
+        if not (
+            control_plane_stderr_path
+            or control_plane_stdout_path
+            or python_worker_stderr_path
+            or swift_text_worker_stderr_path
+            or python_worker_stdout_path
+            or swift_text_worker_stdout_path
+        ):
+            return StartupFailureReport(
+                classification="startup_hang",
+                summary=f"Melix startup timed out before {ready_probe_url} became ready.",
+                detail="Inspect the startup logs and ready probe path to determine whether the services hung or never launched.",
+                http_port=http_port,
+                ready_probe_url=ready_probe_url,
+                primary_log_path=primary_log_path,
+                log_excerpt=error_text,
+            )
+
         control_plane_excerpt = _log_excerpt(
-            manifest.get("control_plane_stderr_path"),
-            manifest.get("control_plane_stdout_path"),
+            control_plane_stderr_path,
+            control_plane_stdout_path,
         )
 
         if control_plane_excerpt:
@@ -512,10 +537,10 @@ def classify_startup_failure(
             classification = "control_plane_crash"
         else:
             worker_excerpt_value = _log_excerpt(
-                manifest.get("python_worker_stderr_path"),
-                manifest.get("swift_text_worker_stderr_path"),
-                manifest.get("python_worker_stdout_path"),
-                manifest.get("swift_text_worker_stdout_path"),
+                python_worker_stderr_path,
+                swift_text_worker_stderr_path,
+                python_worker_stdout_path,
+                swift_text_worker_stdout_path,
             )
             worker_crash = bool(worker_excerpt_value) and _contains_any(
                 worker_excerpt_value.lower(), CRASH_PATTERNS


### PR DESCRIPTION
## Summary
- Skip startup log-excerpt helper calls when a startup failure manifest has no control-plane or worker log paths.
- Bind startup log manifest paths once before fallback scanning, preserving existing classification output.
- Add a focused regression test for the empty-log-path startup hang path.

## Plan or Spec
- `docs/plans/2026-07-16-startup-signals-empty-log-path-fast-path.md`

## Commands Run
```text
# Baseline probe before the change
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; empty_hang_elapsed_ms_mean=0.889333; conflict_elapsed_ms_mean=0.828551; control_crash_elapsed_ms_mean=9.055175; worker_crash_elapsed_ms_mean=9.14468

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics
# exit 0; 58 passed in 1.97s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_startup_signals_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/startup_signals.py services/mlx-worker-python/tests/test_startup_signals.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/startup_signals_log_probe.py
# exit 0; TOTAL 13 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_log_probe.py
# exit 0; empty_hang_elapsed_ms_mean=0.761626; conflict_elapsed_ms_mean=0.824384; control_crash_elapsed_ms_mean=8.645987; worker_crash_elapsed_ms_mean=8.70169

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 13 0 100%`.
- Registered probe: `startup-signals-lazy-worker-log-excerpts`.
- Local Linux probe delta for the optimized empty-manifest path: `empty_hang_elapsed_ms_mean` 0.889333 ms -> 0.761626 ms (`delta_ms=-0.127707`, `speedup=1.168x`, `speedup_pct=14.36%`).
- CI PR-scoped performance must validate the registered probe before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime behavior is changed in this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
