### PR TITLE
perf: build dataset source paths with list comprehension

### DIFF
--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1279,7 +1279,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return list(map(path_cls, file_paths))
+    return [path_cls(path) for path in file_paths]
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Replace the final `list(map(Path, ...))` conversion in dataset source file discovery with a list comprehension.
- Keeps the existing `os.scandir` traversal, sorted ordering, and `Path` output semantics unchanged while shaving conversion overhead in the registered dataset-source records probe.

## Plan or Spec
- Governing standard: `docs/engineering-standards.md` small performance-slice guidance.
- Registered PR-scoped probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/productization/dataset_preparation.py` with focused test, coverage, and probe commands.
- No docs update required: behavior and workflow are unchanged.

## Commands Run
```text
# Baseline before the implementation
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
-> exit 0; elapsed_ms_mean=12.156658361411907, source_kind_elapsed_ms_mean=20.41289071679454, record_elapsed_ms_mean=19.390116826715794

# Focused probe test while iterating
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics
-> exit 0; 1 passed in 1.24s

# Registered probe test_command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
-> exit 0; 47 passed in 0.80s

# Registered probe coverage_command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
-> exit 0; 47 passed in 1.24s; TOTAL 1 0 100%

# Registered probe locally (direct equivalent of probe_command's selected script)
PYTHONPATH=services/mlx-worker-python:. uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
-> exit 0; elapsed_ms_mean=11.609108314256776, source_kind_elapsed_ms_mean=18.283701459453866, record_elapsed_ms_mean=18.132516839118168

git diff --check
-> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` from `scripts/changed_scope_coverage.py`.
- Registered probe: `dataset-source-records-scandir`.
- Local Linux probe comparison:
  - `elapsed_ms_mean`: old `12.156658361411907`, new `11.609108314256776`, delta `-0.5475500471551307 ms`, speedup `1.0471655559008526x` (`4.504116434604951%` lower).
  - `source_kind_elapsed_ms_mean`: old `20.41289071679454`, new `18.283701459453866`.
  - `record_elapsed_ms_mean`: old `19.390116826715794`, new `18.132516839118168`.
- CI PR-scoped performance report is required as the merge validation source.

## Known Gaps
- None for the Python slice. The local registered probe was run on Linux; CI remains required before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs, or explicitly N/A: no behavior/workflow change.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: no observability mode change; existing evidence probe reused.
- [x] Deferred work and known gaps are stated explicitly.
