### PR TITLE
perf: classify report deltas in one pass

### DIFF
--- a/docs/plans/2026-07-17-benchmark-report-delta-classification.md
+++ b/docs/plans/2026-07-17-benchmark-report-delta-classification.md
@@ -1,0 +1,36 @@
+# Benchmark report delta classification slice
+
+This Python-only performance slice keeps benchmark/evaluation report semantics unchanged while reducing repeated classification scans over comparison delta rows.
+
+## Affected path
+
+- `services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py`
+- `services/mlx-worker-python/tests/test_benchmark_evaluation_report.py`
+- `infra/perf/pr_scoped_probes.json`
+
+The affected path is covered by the registered PR-scoped probe `benchmark-evaluation-report-running-aggregates`. The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries for the benchmark/evaluation report builder.
+
+## Optimization
+
+`_comparison_section()` materializes benchmark/evaluation metric deltas, then derives comparison buckets for regressions, improvements, and unchanged rows. Previously those three buckets were built with three separate list comprehensions over the combined delta rows. This slice adds a small `_classify_comparison_delta_rows()` helper that classifies the same rows in one pass.
+
+The behavior is intentionally equivalent:
+
+- `result == "fail"` rows still populate `regressions`;
+- lower-is-better negative deltas and higher-is-better positive deltas still populate `improvements`;
+- zero numeric deltas still populate `unchanged`;
+- rows can still appear in more than one bucket when their independent predicates match.
+
+## Verification plan
+
+Run on Linux:
+
+1. Focused regression test proving each row's `result` and `delta` are read once during classification.
+2. Full benchmark-evaluation report tests through the registered focused command.
+3. Changed-scope coverage through the registered coverage command.
+4. Registered benchmark-evaluation report probe locally with the registry command, comparing `origin/main` baseline to this slice.
+5. GitHub Actions PR-scoped performance as the merge gate.
+
+## Metrics
+
+Primary metric: `elapsed_ms_mean` from the registered `benchmark-evaluation-report-running-aggregates` probe. Secondary metrics: `load_input_ms_mean`, `peak_bytes_mean`, `row_count`, and `sample_count`.

--- a/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
@@ -14,6 +14,7 @@ from worker.productization.benchmark_evaluation_report import (
     _agentic_adapter_report_rows,
     _benchmark_probe_label,
     _build_metric_row,
+    _classify_comparison_delta_rows,
     _collect_benchmark_probe_metrics,
     _collect_evaluation_sample_probe_metrics,
     _collect_runtime_metadata,
@@ -283,6 +284,39 @@ def test_status_counts_reads_each_row_status_once() -> None:
     assert [row.status_reads for row in rows] == [1, 1, 1, 1]
     with pytest.raises(AssertionError, match="status was read more than once"):
         rows[0].get("status")
+
+
+def test_comparison_delta_classification_reads_each_row_once() -> None:
+    class _TrackedDelta(dict[str, object]):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
+            self.result_reads = 0
+            self.delta_reads = 0
+
+        def get(self, key: str, default: object = None) -> object:
+            if key == "result":
+                self.result_reads += 1
+                if self.result_reads > 1:
+                    raise AssertionError("result was read more than once")
+            elif key == "delta":
+                self.delta_reads += 1
+                if self.delta_reads > 1:
+                    raise AssertionError("delta was read more than once")
+            return super().get(key, default)
+
+    rows = [
+        _TrackedDelta(result="fail", delta=1.0, direction="lower_is_better"),
+        _TrackedDelta(result="pass", delta=-1.0, direction="lower_is_better"),
+        _TrackedDelta(result="pass", delta=0.0, direction="neutral"),
+    ]
+
+    regressions, improvements, unchanged = _classify_comparison_delta_rows(rows)
+
+    assert regressions == [rows[0]]
+    assert improvements == [rows[1]]
+    assert unchanged == [rows[2]]
+    assert [row.result_reads for row in rows] == [1, 1, 1]
+    assert [row.delta_reads for row in rows] == [1, 1, 1]
 
 
 def test_report_marks_overlapping_repeat_group_ci_as_informational() -> None:

--- a/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py
@@ -1178,6 +1178,7 @@ def _comparison_section(
         row for row in metric_deltas if str(row.get("metric") or "").startswith("telemetry.")
     ]
     all_delta_rows = [*metric_deltas, *agentic_adapter_deltas]
+    regressions, improvements, unchanged = _classify_comparison_delta_rows(all_delta_rows)
     return {
         "baseline_report_id": _side_report_id("baseline", baseline_evidence),
         "current_report_id": _side_report_id("candidate", candidate_evidence),
@@ -1186,12 +1187,35 @@ def _comparison_section(
         "probe_deltas": probe_deltas,
         "telemetry_deltas": telemetry_deltas,
         "agentic_adapter_deltas": list(agentic_adapter_deltas),
-        "regressions": [row for row in all_delta_rows if row.get("result") == "fail"],
-        "improvements": [row for row in all_delta_rows if _is_improvement(row)],
-        "unchanged": [row for row in all_delta_rows if _float_or_none(row.get("delta")) == 0.0],
+        "regressions": regressions,
+        "improvements": improvements,
+        "unchanged": unchanged,
         "reproducibility_warnings": list(reproducibility_warnings),
         "comparison_validity": "valid" if baseline_evidence and candidate_evidence and not reproducibility_warnings else "partial",
     }
+
+
+def _classify_comparison_delta_rows(
+    rows: list[dict[str, object]],
+) -> tuple[list[dict[str, object]], list[dict[str, object]], list[dict[str, object]]]:
+    regressions: list[dict[str, object]] = []
+    improvements: list[dict[str, object]] = []
+    unchanged: list[dict[str, object]] = []
+    for row in rows:
+        if row.get("result") == "fail":
+            regressions.append(row)
+        delta = _float_or_none(row.get("delta"))
+        if delta is None:
+            continue
+        direction = str(row.get("direction") or "")
+        if (
+            (direction == "lower_is_better" and delta < 0)
+            or (direction == "higher_is_better" and delta > 0)
+        ):
+            improvements.append(row)
+        if delta == 0.0:
+            unchanged.append(row)
+    return regressions, improvements, unchanged
 
 
 def _comparison_delta(row: dict[str, object]) -> dict[str, object]:
@@ -2207,18 +2231,6 @@ def _render_artifacts_markdown(artifacts: object) -> list[str]:
         lines.append(f"- {label}: `{_markdown_cell(path)}`")
     lines.append("")
     return lines
-
-
-def _is_improvement(row: dict[str, object]) -> bool:
-    delta = _float_or_none(row.get("delta"))
-    if delta is None:
-        return False
-    direction = str(row.get("direction") or "")
-    if direction == "lower_is_better":
-        return delta < 0
-    if direction == "higher_is_better":
-        return delta > 0
-    return False
 
 
 def _dict_list(value: object) -> list[dict[str, object]]:


### PR DESCRIPTION
## Summary
- Classify benchmark/evaluation report comparison delta rows into regressions, improvements, and unchanged buckets in one pass.
- Add a focused regression test proving each row's `result` and `delta` are read once during classification.
- Document the slice and registered probe coverage in `docs/plans/2026-07-17-benchmark-report-delta-classification.md`.

## Plan or Spec
- `docs/plans/2026-07-17-benchmark-report-delta-classification.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py::test_comparison_delta_classification_reads_each_row_once
# 1 passed in 0.10s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 67 passed in 0.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_evaluation_report.py && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report -m services/mlx-worker-python/worker/productization/benchmark_evaluation_report.py services/mlx-worker-python/tests/test_benchmark_evaluation_report.py
# 67 passed in 0.39s; TOTAL 98%; benchmark_evaluation_report.py 97%; test_benchmark_evaluation_report.py 98%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id benchmark-evaluation-report-running-aggregates --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-benchmark-report-delta-baseline-20260717 --head-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-eval-report-chain-filter-20260717 --output .runtime/perf/benchmark-report-delta-classification.json
# head verification ok; base probe ok; head probe ok

git diff --check
# ok
```

## Coverage and Metrics
- Changed-scope coverage: TOTAL 98%; `benchmark_evaluation_report.py` 97%; `test_benchmark_evaluation_report.py` 98%.
- Registered probe: `benchmark-evaluation-report-running-aggregates`.
- Local Linux probe result (`sample_count=5`, `row_count=5990`):
  - `elapsed_ms_mean`: base `330.785772 ms`, head `319.785658 ms`, delta `-11.000114 ms` (`-3.325%`).
  - `load_input_ms_mean`: base `7.713475 ms`, head `6.502762 ms`, delta `-1.210713 ms` (`-15.696%`).
  - `peak_bytes_mean`: base `13,636,836.8 bytes`, head `13,636,841.6 bytes`, delta `+4.8 bytes` (`~0.000%`).
- CI PR-scoped performance is still required as the merge gate.

## Known Gaps
- None. Local validation is Linux/Python only; no Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no new runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
