### PR TITLE
perf: fast-path exact MLX hub tags

### DIFF
--- a/docs/plans/2026-07-17-hub-catalog-mlx-tag-exact-membership-performance.md
+++ b/docs/plans/2026-07-17-hub-catalog-mlx-tag-exact-membership-performance.md
@@ -1,0 +1,44 @@
+# Hub Catalog MLX Tag Exact Membership Performance Slice
+
+## Status
+
+Accepted for the 2026-07-17 performance slice.
+
+## Scope
+
+Optimize the Python hub catalog MLX compatibility check in
+`services/mlx-worker-python/worker/model_ops/hub_catalog.py` by short-circuiting
+exact `"mlx"` and `"MLX"` tag payload membership before entering the mixed-case
+atom scanner.
+
+## Registered Probe
+
+This slice is covered by the existing PR-scoped performance probe:
+
+- `hub-catalog-size-hint-regex-precompile`
+- watched path: `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- focused tests: `services/mlx-worker-python/tests/test_hub_catalog.py`
+- coverage command: registered `coverage_command` in
+  `infra/perf/pr_scoped_probes.json`
+- probe command: registered `probe_command` in
+  `infra/perf/pr_scoped_probes.json`
+
+The registered probe reports both the size-hint path and
+`payload_compatibility_elapsed_ms_mean`, which exercises the compatibility
+payload path changed by this slice.
+
+## Behavior
+
+Exact lowercase and uppercase MLX tags now return before calling the per-item
+case-insensitive atom helper. Mixed-case tags such as `"mLx"` still use the
+existing helper, preserving compatibility semantics for list subclasses and
+non-string payload entries.
+
+## Verification Plan
+
+1. Run the focused hub catalog tests and PR-scoped registry tests.
+2. Run changed-scope coverage using the registered coverage command.
+3. Run `scripts/hub_catalog_size_hint_probe.py` locally on Linux and compare the
+   metrics against the pre-change baseline.
+4. Let GitHub Actions run the registered PR-scoped performance workflow before
+   merge.

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -190,12 +190,12 @@ def test_payload_mlx_tag_detection_fast_paths_exact_membership(monkeypatch: pyte
     assert hub_catalog._payload_is_mlx_compatible(
         {"id": "plain/model", "tags": ["Text-Generation", "MLX", object()]}
     ) is True
-    assert calls == 1
+    assert calls == 0
 
     assert hub_catalog._payload_is_mlx_compatible(
         {"id": "plain/model", "tags": ["Text-Generation", "mLx", object()]}
     ) is True
-    assert calls == 2
+    assert calls == 1
 
 
 class FakeHTTPResponse:
@@ -1702,7 +1702,7 @@ def test_tag_payload_contains_exact_mlx_uses_atom_helper_once(
     monkeypatch.setattr(hub_catalog_module, "_is_mlx_atom", counted_is_mlx_atom)
 
     assert hub_catalog_module._tag_payload_contains_mlx(["Text-Generation", "MLX", object()]) is True
-    assert calls == 1
+    assert calls == 0
 
 
 def test_tag_lowering_fallbacks_preserve_direct_helper_compatibility() -> None:

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -496,12 +496,16 @@ def _is_mlx_atom(value: str) -> bool:
 def _tag_payload_contains_mlx(value: Any) -> bool:
     if type(value) is list:
         for item in value:
-            if type(item) is str and len(item) == 3 and _is_mlx_atom(item):
+            if type(item) is str and len(item) == 3 and (
+                item == "mlx" or item == "MLX" or _is_mlx_atom(item)
+            ):
                 return True
         return False
     if isinstance(value, list):
         for item in value:
-            if isinstance(item, str) and len(item) == 3 and _is_mlx_atom(item):
+            if isinstance(item, str) and len(item) == 3 and (
+                item == "mlx" or item == "MLX" or _is_mlx_atom(item)
+            ):
                 return True
         return False
     if isinstance(value, str):


### PR DESCRIPTION
## Summary
- Fast-path exact `"mlx"` and `"MLX"` tag atoms inside the hub catalog tag payload scanner before calling the mixed-case atom helper.
- Update focused tests to assert exact atoms avoid the helper while mixed-case tags still use the existing compatibility path.
- Add the governing performance-slice plan for this small Python optimization.

## Plan or Spec
- `docs/plans/2026-07-17-hub-catalog-mlx-tag-exact-membership-performance.md`

## Commands Run
```text
git fetch origin && git reset --hard origin/main && git status --short && git rev-parse --short HEAD
# origin/main at b4099691; clean baseline.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 97 passed in 0.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 97 passed in 0.54s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"elapsed_ms_mean": 1326.9377310527489, "payload_compatibility_elapsed_ms_mean": 189.01140501257032, "size_hint_calls_mean": 0.0, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered probe: `hub-catalog-size-hint-regex-precompile`.
- Local Linux baseline before change: `payload_compatibility_elapsed_ms_mean=194.56664379686117`, `elapsed_ms_mean=1294.5575445890427`.
- Local Linux final probe: `payload_compatibility_elapsed_ms_mean=189.01140501257032` (`-5.55523878429085 ms`, about `2.85%` faster), `elapsed_ms_mean=1326.9377310527489`.
- Additional post-fix probe samples showed compatibility means of `185.73650382459164`, `193.6691225739196`, and `186.9489511474967` ms; the registered CI probe remains the merge gate.

## Known Gaps
- None for the Python slice. Swift/macOS runtime effects are not involved.
- CI is required for the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped probe; no production observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
