### PR TITLE
perf: fast-path quantized header string keys

### DIFF
--- a/docs/plans/2026-07-17-quantized-safetensor-header-string-key-fastpath.md
+++ b/docs/plans/2026-07-17-quantized-safetensor-header-string-key-fastpath.md
@@ -1,0 +1,31 @@
+# Quantized safetensor header string-key fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.runtime.quantized_tensor_metadata._safetensors_header_tensor_names()`.
+
+Safetensors headers are JSON objects, so decoded tensor-name keys are already strings on the hot path. The helper still called `str(key)` for every header key before filtering empty names, which adds repeated string-conversion calls while scanning large multi-shard quantized model headers.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `quantized-tensor-metadata-prepass` in `infra/perf/pr_scoped_probes.json`.
+
+The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py`
+- `services/mlx-worker-python/tests/test_mlx_vlm_runtime.py`
+- `scripts/quantized_tensor_metadata_prepass_probe.py`
+
+## Plan
+
+1. Preserve header parsing, `__metadata__` skipping, empty-name filtering, and non-string fallback behavior.
+2. Fast-path decoded string keys by appending the key directly when it is non-empty.
+3. Keep the `str(key)` fallback for non-standard mappings used by direct helper callers.
+4. Run the registered focused tests, changed-scope coverage, and quantized metadata probe locally on Linux before opening the PR.
+
+## Acceptance
+
+- Focused quantized metadata behavior tests pass locally.
+- Changed-scope coverage for the touched Python files is at least 95 percent.
+- The registered local probe reports a lower `header_elapsed_ms_mean` for the safetensor header prepass workload.
+- GitHub Actions and the PR-scoped performance report complete successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
+++ b/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py
@@ -300,6 +300,10 @@ def _safetensors_header_tensor_names(path: str | os.PathLike[str]) -> tuple[str,
     for key in header:
         if key == "__metadata__":
             continue
+        if isinstance(key, str):
+            if key:
+                append_tensor_name(key)
+            continue
         tensor_name = str(key)
         if tensor_name:
             append_tensor_name(tensor_name)


### PR DESCRIPTION
## Summary
- Fast-path safetensors header tensor-name extraction when decoded JSON keys are already strings.
- Keep the existing `str(key)` fallback for non-standard direct helper callers.
- Add the governing performance-slice plan for this quantized metadata header scan.

## Plan or Spec
- `docs/plans/2026-07-17-quantized-safetensor-header-string-key-fastpath.md`
- Registered PR-scoped probe: `quantized-tensor-metadata-prepass`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...` (registered focused quantized metadata test command) — 32 passed
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --include='*/services/mlx-worker-python/worker/runtime/quantized_tensor_metadata.py,...' -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json ...` — TOTAL 4 0 100%
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_QUANTIZED_TENSOR_METADATA_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/quantized_tensor_metadata_prepass_probe.py` — baseline/head probe runs below
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `aggregate_measurable_changed_lines=4`, `aggregate_covered_changed_lines=4`, `TOTAL 4 0 100%`.
- Local Linux registered probe metric (`header_elapsed_ms_mean`, 3 independent process runs):
  - base: 44.257815 ms, 46.912193 ms, 43.615616 ms; mean 44.928541 ms
  - head: 43.535961 ms, 43.150662 ms, 44.664478 ms; mean 43.783700 ms
  - delta: -1.144841 ms; speedup: 1.026148x; improvement: 2.548%
- CI PR-scoped performance report is required for registered probe validation before merge.

## Known Gaps
- Local validation is Linux-only. This slice changes Python header parsing; no Swift runtime effect is claimed locally.
- Non-target probe submetrics may be noisy; acceptance is based on the registered header prepass metric and CI report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage met the 95% gate locally.
- [x] Registered probe ran locally and showed directional improvement on the target metric.
- [ ] GitHub Actions and PR-scoped performance workflow completed successfully.
