### PR TITLE
perf: compare retrieval context kinds directly

### DIFF
--- a/docs/plans/2026-07-13-retrieval-context-kind-membership.md
+++ b/docs/plans/2026-07-13-retrieval-context-kind-membership.md
@@ -36,3 +36,18 @@ The projection loops avoid repeated two-value literal membership checks and a
 global `type` lookup on the exact-entry path. Expected gains are small but should
 be visible in the registered probe's `optimized_elapsed_ms_mean`, with store and
 lookup sub-metrics remaining directionally neutral or improved.
+
+## Follow-up Slice: Direct Context Kind Comparison
+
+The 2026-07-17 follow-up keeps the same registered probe and narrows to the two
+valid retrieval context-kind checks in the exact `RetrievalContextEntry` and
+exact dict store-record hot paths. The previous slice hoisted the two valid
+literals into a local frozenset; this slice replaces that membership lookup with
+explicit string comparisons for the same two accepted values. Malformed kinds
+still fall through to the existing refusal/admission paths, and receipt contents
+remain unchanged.
+
+Success is accepted only if the focused retrieval context tests, changed-scope
+coverage, and the registered Linux probe pass locally with lower
+`optimized_elapsed_ms_mean`, and if the PR-scoped CI probe completes successfully
+before merge.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -143,7 +143,6 @@ def project_retrieval_contexts(
     bool_type = bool
     strip_text = str.strip
     type_of = type
-    retrieval_context_kinds = _RETRIEVAL_CONTEXT_KINDS
 
     for entry in entries:
         if type_of(entry) is entry_type:
@@ -156,7 +155,7 @@ def project_retrieval_contexts(
             reason = entry.reason
             corrective_action = entry.corrective_action
             if (
-                context_kind in retrieval_context_kinds
+                (context_kind == "retrieved_document" or context_kind == "retrieved_image")
                 and isinstance_of(source_id, str_type)
                 and isinstance_of(payload, dict_type)
                 and isinstance_of(owner_scope_checked, bool_type)
@@ -301,7 +300,6 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
     dict_type = dict
     bool_type = bool
     type_of = type
-    retrieval_context_kinds = _RETRIEVAL_CONTEXT_KINDS
 
     for record in records:
         if type_of(record) is not dict_type and not isinstance(record, Mapping):
@@ -316,7 +314,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
 
         record_get: Any = record.get
         context_kind = record_get("context_kind")
-        if context_kind not in retrieval_context_kinds:
+        if context_kind != "retrieved_document" and context_kind != "retrieved_image":
             source_id = store_record_source_id(record)
             refusal_context_kind = store_record_refusal_context_kind(source_id)
             store_refusal_receipts_append(


### PR DESCRIPTION
## Summary
- Replaces two hot-path retrieval context-kind frozenset membership checks with direct string comparisons for the only two accepted kinds.
- Keeps malformed-kind fallback/refusal behavior unchanged while trimming per-entry projection overhead.

## Plan or Spec
- `docs/plans/2026-07-13-retrieval-context-kind-membership.md`
- Registered PR-scoped probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Synced baseline
GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh auth status && GH_CONFIG_DIR=/root/.hermes/profiles/coder/gh-config gh api user --jq .login -> Zigfreidish
git --git-dir=/root/.hermes/profiles/coder/workspace/melix.git fetch origin main --prune -> origin/main fc319933ecbd18f0d1b2aea4f049294c252dc88f

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_prefers_head_script_for_comparable_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
-> 63 passed in 0.38s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_prefers_head_script_for_comparable_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
-> 63 passed in 0.45s; TOTAL 1 0 100%

# Registered probe, local Linux head, 3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
-> optimized_elapsed_ms_mean: 0.11612788649342422, 0.11052329608771418, 0.10771439714257472

# Baseline worktree from origin/main, same probe, 3 runs
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
-> optimized_elapsed_ms_mean: 0.11691510469453144, 0.118744252457483, 0.13916506178377727

git diff --check -> pass
git status --short -> clean after commit
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/runtime/retrieval_context.py` changed executable lines.
- Local registered probe (`retrieval-context-projection-fastpath`, Linux):
  - base `optimized_elapsed_ms_mean` mean = `0.124941` ms across 3 runs.
  - head `optimized_elapsed_ms_mean` mean = `0.111455` ms across 3 runs.
  - delta = `-0.013486` ms; speedup = `1.121x` for the optimized projection metric.
- CI PR-scoped performance validation is required before merge.

## Known Gaps
- Full `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally; this Python slice used the registered focused tests, changed-scope coverage, and registered probe on Linux.
- No Swift runtime validation is applicable for this Python worker path.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability/debug overhead.
- [x] Deferred work and known gaps are stated explicitly.
