### PR TITLE
perf: scan export layout manifests once

### DIFF
--- a/docs/plans/2026-06-24-export-artifact-layout-retention.md
+++ b/docs/plans/2026-06-24-export-artifact-layout-retention.md
@@ -87,6 +87,12 @@ reusing that resolved root for manifest rows and evidence files. This avoids
 repeated target-root resolution during layout materialization without relaxing
 per-file path normalization or target-root containment checks.
 
+A follow-up 2026-07-17 report bootstrap slice discovers the fixed fixture
+manifest set with one `os.scandir()` pass instead of `Path.glob()` expansion in
+the layout retention report and registered probe. The runtime export layout and
+retention decisions are unchanged; only the report/probe fixture bootstrap path
+avoids glob object allocation before calling `build_layout_metrics_report`.
+
 ## Verification
 
 Focused verification:

--- a/scripts/export_target_layout_retention_report.py
+++ b/scripts/export_target_layout_retention_report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 import tempfile
@@ -28,7 +29,30 @@ DEFAULT_FIXTURE_ROOT = (
 
 
 def _default_manifest_paths() -> list[Path]:
-    return sorted(DEFAULT_FIXTURE_ROOT.glob("*/export-target-manifest.json"))
+    return _manifest_paths_for_fixture_root(DEFAULT_FIXTURE_ROOT)
+
+
+def _manifest_paths_for_fixture_root(root: Path) -> list[Path]:
+    manifest_paths: list[str] = []
+    manifest_paths_append = manifest_paths.append
+    manifest_name = "export-target-manifest.json"
+    root_path = os.fspath(root)
+    try:
+        with os.scandir(root_path) as entries:
+            for entry in entries:
+                try:
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                except OSError:  # pragma: no cover - disappearing fixture race guard
+                    continue
+                manifest_path = os.path.join(entry.path, manifest_name)
+                if os.path.isfile(manifest_path):
+                    manifest_paths_append(manifest_path)
+    except OSError:  # pragma: no cover - missing fixture root guard
+        return []
+    manifest_paths.sort()
+    path_cls = Path
+    return [path_cls(path) for path in manifest_paths]
 
 
 def build_report(

--- a/scripts/runtime_export_layout_retention_probe.py
+++ b/scripts/runtime_export_layout_retention_probe.py
@@ -34,8 +34,31 @@ def _env_int(name: str, default: int, minimum: int) -> int:
     return max(minimum, value)
 
 
+def _manifest_paths_for_fixture_root(root: Path) -> list[Path]:
+    manifest_paths: list[str] = []
+    manifest_paths_append = manifest_paths.append
+    manifest_name = "export-target-manifest.json"
+    root_path = os.fspath(root)
+    try:
+        with os.scandir(root_path) as entries:
+            for entry in entries:
+                try:
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                except OSError:  # pragma: no cover - disappearing fixture race guard
+                    continue
+                manifest_path = os.path.join(entry.path, manifest_name)
+                if os.path.isfile(manifest_path):
+                    manifest_paths_append(manifest_path)
+    except OSError:  # pragma: no cover - missing fixture root guard
+        return []
+    manifest_paths.sort()
+    path_cls = Path
+    return [path_cls(path) for path in manifest_paths]
+
+
 def main() -> int:
-    manifests = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
+    manifests = _manifest_paths_for_fixture_root(FIXTURE_ROOT)
     iterations = _env_int("MELIX_RUNTIME_EXPORT_LAYOUT_PROBE_ITERATIONS", 40, 1)
     samples = _env_int("MELIX_RUNTIME_EXPORT_LAYOUT_PROBE_SAMPLES", 5, 1)
     elapsed_samples: list[float] = []

--- a/services/mlx-worker-python/tests/test_export_target_layout_retention.py
+++ b/services/mlx-worker-python/tests/test_export_target_layout_retention.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import runpy
 import sys
@@ -90,6 +91,32 @@ def test_materialize_export_target_layout_writes_reports_and_placeholder_files(
     assert report["retained_byte_size"] == retention_payload["retained_byte_size"]
     assert report["cleanable_byte_size"] == retention_payload["cleanable_byte_size"]
     assert report["retention_decision_count"] == retention_payload["retention_decision_count"]
+
+
+def test_layout_retention_report_default_manifests_use_single_scandir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected_manifests = sorted(FIXTURE_ROOT.glob("*/export-target-manifest.json"))
+    glob_calls: list[str] = []
+    scandir_calls: list[str] = []
+    original_scandir = os.scandir
+
+    def fail_glob(self: Path, pattern: str):  # pragma: no cover - regression sentinel
+        glob_calls.append(f"{self}:{pattern}")
+        raise AssertionError("default export layout manifest discovery should use os.scandir")
+
+    def counting_scandir(path: str | os.PathLike[str]):
+        scandir_calls.append(os.fspath(path))
+        return original_scandir(path)
+
+    monkeypatch.setattr(Path, "glob", fail_glob)
+    monkeypatch.setattr(export_target_layout_retention_report.os, "scandir", counting_scandir)
+
+    manifests = export_target_layout_retention_report._default_manifest_paths()
+
+    assert glob_calls == []
+    assert scandir_calls == [os.fspath(export_target_layout_retention_report.DEFAULT_FIXTURE_ROOT)]
+    assert manifests == expected_manifests
 
 
 def test_materialize_export_target_layout_allows_manifest_already_at_layout_path(


### PR DESCRIPTION
## Summary
- Replaces the layout-retention report/probe fixture manifest glob with a single `os.scandir()` pass.
- Adds a regression test that blocks `Path.glob()` for default export layout manifest discovery.
- Records the 2026-07-17 report bootstrap slice in the export layout retention plan.

## Plan or Spec
- `docs/plans/2026-06-24-export-artifact-layout-retention.md`
- Registered probe: `runtime-export-layout-retention` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py::test_layout_retention_report_default_manifests_use_single_scandir`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_manifest_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_layout_retention_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_layout_retention_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_layout.py services/mlx-worker-python/tests/test_export_target_layout_retention.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/export_target_layout_retention_report.py scripts/runtime_export_layout_retention_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py`
- Baseline comparison from detached `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_layout_retention_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 25 passed.
- Changed-scope coverage: `TOTAL 52 2 96%`.
- Local registered probe baseline (`origin/main`): `elapsed_ms_mean=2823.1523745926097`, `target_count=4`, `retention_decision_count=15`.
- Local registered probe head: `elapsed_ms_mean=2770.5738234100863`, `target_count=4`, `retention_decision_count=15`.
- Local delta: `-52.57855118252337 ms` (`~1.86%` faster). CI PR-scoped performance is the merge gate for registered probe validation.

## Known Gaps
- Linux local validation only; this is a Python/report bootstrap slice and does not exercise Swift runtime effects.
- The registered CI PR-scoped performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Governing plan/spec updated.
- [x] Affected path has a registered PR-scoped probe with test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally above 95%.
- [x] Registered probe ran locally on Linux with baseline/head comparison.
- [ ] GitHub Actions and PR-scoped performance report are green.
