### PR TITLE
perf: reduce changed-scope diff parser prefix work

### DIFF
--- a/docs/plans/2026-07-17-changed-scope-diff-prefix-probe-performance.md
+++ b/docs/plans/2026-07-17-changed-scope-diff-prefix-probe-performance.md
@@ -1,0 +1,35 @@
+# Changed-Scope Diff Prefix Probe Performance Slice
+
+## Scope
+
+Optimize exactly one Python hot path in `scripts/changed_scope_coverage.py`:
+`_parse_changed_lines`, the changed-scope coverage unified-diff parser used by
+coverage gates and the PR-scoped performance workflow.
+
+The affected path is already covered by the registered PR-scoped performance
+probe `changed-scope-coverage-diff-parser` in `infra/perf/pr_scoped_probes.json`.
+That registry entry includes focused `test_command`, `coverage_command`, and
+`probe_command` entries.
+
+## Slice
+
+Keep the parser behavior unchanged while reducing repeated hot-loop work for
+header and hunk detection:
+
+- bind the byte hunk new-range marker once before the loop; and
+- use the bytes prefix predicate for diff header detection instead of slicing a
+  new prefix-length bytes object for each candidate header line.
+
+## Verification Plan
+
+- Run the registered focused test command for
+  `changed-scope-coverage-diff-parser`.
+- Run the registered changed-scope coverage command and require at least 95%
+  coverage for the touched scope.
+- Run the registered probe command locally on Linux and compare it against an
+  `origin/main` baseline from the same host.
+- Let GitHub Actions run the PR-scoped performance workflow before merge.
+
+## Boundary
+
+This is a Linux-verifiable Python slice. No Swift runtime effect is claimed.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -95,6 +95,7 @@ def _parse_changed_lines(diff_text: str | bytes) -> dict[str, set[int]]:
     header_separator = _DIFF_HEADER_SEPARATOR_BYTES
     header_prefix_len = len(header_prefix)
     header_separator_len = len(header_separator)
+    hunk_new_range_marker = b" +"
     parse_hunk_new_start_from_digit = _parse_hunk_new_start_from_digit_bytes
     ascii_backslash = _ASCII_BACKSLASH
     ascii_plus = _ASCII_PLUS
@@ -110,7 +111,7 @@ def _parse_changed_lines(diff_text: str | bytes) -> dict[str, set[int]]:
                 new_line += 1
             continue
         first_char = line[0]
-        if first_char == ascii_lower_d and line[:header_prefix_len] == header_prefix:
+        if first_char == ascii_lower_d and line.startswith(header_prefix):
             separator_index = line.find(header_separator, header_prefix_len)
             add_changed_line = None
             if separator_index >= 0:
@@ -119,7 +120,7 @@ def _parse_changed_lines(diff_text: str | bytes) -> dict[str, set[int]]:
             new_line = None
             continue
         if first_char == ascii_at and len(line) > 1 and line[1] == ascii_at:
-            new_range_index = line.find(b" +")
+            new_range_index = line.find(hunk_new_range_marker)
             if new_range_index < 0:
                 new_line = None
                 continue


### PR DESCRIPTION
## Summary
- Reduces hot-loop prefix work in the changed-scope coverage diff parser.
- Binds the hunk new-range bytes marker once per parse and uses bytes prefix detection instead of slicing header candidates.

## Plan or Spec
- `docs/plans/2026-07-17-changed-scope-diff-prefix-probe-performance.md`
- Registered PR-scoped probe: `changed-scope-coverage-diff-parser`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py tests/test_changed_scope_coverage.py scripts/changed_scope_coverage_parse_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `python3 scripts/changed_scope_coverage_parse_probe.py` (3 local samples)
- `git diff --check`

## Coverage and Metrics
- Focused tests: 54 passed.
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local Linux registered probe samples on this branch:
  - `elapsed_ms_mean=3.1495390188259385`
  - `elapsed_ms_mean=3.032947841954107`
  - `elapsed_ms_mean=3.0561455932911485`
- Same-host `origin/main` baseline samples before the change:
  - `elapsed_ms_mean=3.0998415992750474`
  - `elapsed_ms_mean=3.5091669124085456`
  - `elapsed_ms_mean=3.1509875843767077`
- Mean of local samples: baseline `3.253332032020765`, branch `3.0795441513570647`, delta `-0.1737878806637003 ms` (`~5.34%` faster).

## Known Gaps
- Linux-only Python validation; no Swift runtime effect is claimed.
- CI PR-scoped performance report remains the merge gate for the registered probe.

## Evidence Checklist
- [x] Registered probe exists and covers the changed path.
- [x] Focused test command passed locally.
- [x] Changed-scope coverage command passed locally at >=95%.
- [x] Registered probe command ran locally on Linux.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
