### PR TITLE
perf: stream macOS signing target scans

### DIFF
--- a/docs/plans/2026-07-17-macos-app-signing-targets-unsorted-scan.md
+++ b/docs/plans/2026-07-17-macos-app-signing-targets-unsorted-scan.md
@@ -1,0 +1,33 @@
+# macOS app signing-target unsorted scan
+
+## Scope
+
+This Python-only performance slice is limited to `_iter_nested_macho_signing_targets()` in `services/mlx-worker-python/worker/productization/macos_app_bundle.py`.
+
+The helper must still return a stable sorted list of nested Mach-O signing targets and must continue to avoid following symlinked directories. The optimization removes the per-directory `sorted(os.scandir(...))` materialization because the function already sorts the final target list before returning it.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `macos-app-signing-targets-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries, and watches:
+
+- `services/mlx-worker-python/worker/productization/macos_app_bundle.py`
+- `services/mlx-worker-python/tests/test_macos_app_bundle.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/macos_app_signing_targets_probe.py`
+- `infra/perf/pr_scoped_probes.json`
+
+## Plan
+
+1. Keep the existing final target ordering contract by retaining the final `targets.sort(...)`.
+2. Stream each `os.scandir()` iterator directly instead of sorting every directory's entries before traversal.
+3. Add a regression guard that fails if this helper reintroduces built-in `sorted(...)` for per-directory scans.
+4. Run the registered focused tests, changed-scope coverage command, and registered local probe on Linux before opening the PR.
+
+## Acceptance
+
+- Focused macOS app bundle signing-target tests pass locally.
+- Changed-scope coverage for the touched scope is at least 95%.
+- Registered local probe reports directionally lower `elapsed_ms_mean` versus `origin/main`.
+- GitHub Actions and the PR-scoped performance report complete successfully before merge.

--- a/services/mlx-worker-python/tests/test_macos_app_bundle.py
+++ b/services/mlx-worker-python/tests/test_macos_app_bundle.py
@@ -1265,8 +1265,12 @@ def test_iter_nested_macho_signing_targets_uses_scandir_without_os_walk_or_path_
     def fail_os_walk(*args: object, **kwargs: object):  # pragma: no cover - regression guard
         raise AssertionError("_iter_nested_macho_signing_targets() should use os.scandir() directly")
 
+    def fail_sorted(iterable, *args: object, **kwargs: object):  # pragma: no cover - regression guard
+        raise AssertionError("_iter_nested_macho_signing_targets() should stream unsorted scandir entries")
+
     monkeypatch.setattr(Path, "rglob", fail_rglob)
     monkeypatch.setattr(macos_app_bundle_module.os, "walk", fail_os_walk)
+    monkeypatch.setattr(macos_app_bundle_module, "sorted", fail_sorted, raising=False)
 
     assert _iter_nested_macho_signing_targets(app_path) == [
         launcher,

--- a/services/mlx-worker-python/worker/productization/macos_app_bundle.py
+++ b/services/mlx-worker-python/worker/productization/macos_app_bundle.py
@@ -574,22 +574,21 @@ def _iter_nested_macho_signing_targets(app_path: Path) -> list[Path]:
     while stack:
         current = stack.pop()
         try:
-            with os.scandir(current) as iterator:
-                entries = sorted(iterator, key=lambda entry: entry.name)
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(Path(entry.path))
+                            continue
+                        if entry.is_symlink() or not entry.is_file(follow_symlinks=False):
+                            continue
+                    except OSError:
+                        continue
+                    path = Path(entry.path)
+                    if _is_macho_file(path):
+                        targets.append(path)
         except OSError:
             continue
-        for entry in reversed(entries):
-            try:
-                if entry.is_dir(follow_symlinks=False):
-                    stack.append(Path(entry.path))
-                    continue
-                if entry.is_symlink() or not entry.is_file(follow_symlinks=False):
-                    continue
-            except OSError:
-                continue
-            path = Path(entry.path)
-            if _is_macho_file(path):
-                targets.append(path)
     targets.sort(key=lambda candidate: candidate.as_posix())
     return targets
 


### PR DESCRIPTION
## Summary
- Stream `_iter_nested_macho_signing_targets()` directly from each `os.scandir()` iterator instead of sorting every directory before traversal.
- Preserve the public stable ordering contract by keeping the final `targets.sort(...)` before returning.
- Add a regression guard so the signing-target scanner does not reintroduce per-directory `sorted(...)` work.

## Plan or Spec
- `docs/plans/2026-07-17-macos-app-signing-targets-unsorted-scan.md`
- Registered PR-scoped probe: `macos-app-signing-targets-scandir`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_uses_scandir_without_os_walk_or_path_rglob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_tolerates_scandir_and_entry_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_macho_detection_handles_non_files_and_read_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_signing_targets_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 6 passed in 3.09s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_uses_scandir_without_os_walk_or_path_rglob services/mlx-worker-python/tests/test_macos_app_bundle.py::test_iter_nested_macho_signing_targets_tolerates_scandir_and_entry_errors services/mlx-worker-python/tests/test_macos_app_bundle.py::test_macho_detection_handles_non_files_and_read_errors services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_macos_app_bundle_probes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_macos_app_signing_targets_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/macos_app_bundle.py services/mlx-worker-python/tests/test_macos_app_bundle.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/macos_app_signing_targets_probe.py
# 6 passed in 3.03s; TOTAL 14 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id macos-app-signing-targets-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/macos_app_signing_targets_unsorted_probe.json
# head verification ok; base/head probe ok

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 14 0 100%`.
- Local registered probe `macos-app-signing-targets-scandir`:
  - `elapsed_ms_mean`: base `133.113839` ms → head `130.302740` ms (`-2.811099` ms, ~`2.11%` faster)
  - `elapsed_ms_min`: base `114.444958` ms → head `112.749860` ms (`-1.695098` ms, ~`1.48%` faster)
  - `discovered_count`: base/head `900`
- Observability/probe overhead: N/A; this changes package scanning logic only and uses the existing PR-scoped evidence probe.

## Known Gaps
- Full repository gates were not run locally; this PR is intentionally scoped to the registered focused Linux probe and CI merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
