### PR TITLE
perf: use scandir entry paths in model registry scan

### DIFF
--- a/docs/plans/2026-07-17-model-registry-plain-child-path-deferral.md
+++ b/docs/plans/2026-07-17-model-registry-plain-child-path-deferral.md
@@ -28,6 +28,16 @@ path construction removed from the scan loop.
 4. Run the registered local test command, changed-scope coverage, and registered
    PR-scoped performance probe on Linux; GitHub Actions remains the merge gate.
 
+## 2026-07-17 follow-up: scandir entry-path traversal
+
+This follow-up keeps the same Python-only scanner boundary and registered
+`model-registry-plain-local-manifest-stat-elision` probe. The scanner now stores
+`os.DirEntry.path` while collecting child directories and converts that path text
+into `Path` objects when pushing traversal stack entries. HF cache repository
+detection uses the same entry-path text. This preserves descriptor detection,
+root pruning, HF cache detection, and traversal ordering while eliminating the
+remaining root-child `Path.__truediv__` joins measured by the probe.
+
 ## Verification commands
 
 The full focused test, coverage, and probe commands live in the registered probe

--- a/services/mlx-worker-python/tests/test_model_registry_catalog.py
+++ b/services/mlx-worker-python/tests/test_model_registry_catalog.py
@@ -1165,7 +1165,7 @@ def test_registry_root_tree_defers_plain_child_path_construction_until_stack_pus
     assert manifest_paths == ()
     assert hf_cache_repo_dirs == ()
     assert [scan.model_dir for scan in plain_scans] == expected_dirs
-    assert plain_root_child_joins == 3
+    assert plain_root_child_joins == 0
 
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -6896,7 +6896,7 @@ def test_model_registry_catalog_probe_command_emits_metrics(monkeypatch: pytest.
     metrics = _probe_command_json(probe=probe, repo_root=REPO_ROOT)
 
     assert metrics["elapsed_ms_mean"] > 0
-    assert metrics["root_plain_child_path_joins_mean"] == 800.0
+    assert metrics["root_plain_child_path_joins_mean"] == 0.0
     assert metrics["plain_scan_count_mean"] == metrics["model_count"] == 400.0
     assert metrics["manifest_count_mean"] == 400.0
     assert metrics["sample_count"] == 5.0
@@ -6906,7 +6906,7 @@ def test_model_registry_catalog_probe_command_emits_metrics(monkeypatch: pytest.
     script_globals = runpy.run_path(str(REPO_ROOT / "scripts/model_registry_plain_child_path_probe.py"), run_name="melix_probe_under_test")
     assert script_globals["main"]() == 0
     direct_metrics = json.loads(capsys.readouterr().out)
-    assert direct_metrics["root_plain_child_path_joins_mean"] == 6.0
+    assert direct_metrics["root_plain_child_path_joins_mean"] == 0.0
     assert direct_metrics["plain_scan_count_mean"] == direct_metrics["manifest_count_mean"] == 3.0
 
 

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -3961,7 +3961,7 @@ class WorkerModelCatalog:
                 continue
             try:
                 with os.scandir(os.fspath(current)) as entries:
-                    child_names: list[str] = []
+                    child_entries: list[tuple[str, str]] = []
                     has_manifest = False
                     has_config = False
                     has_generation_config = False
@@ -3989,12 +3989,13 @@ class WorkerModelCatalog:
                                 has_model_weight_files = True
                                 continue
                             if entry.is_dir():
+                                entry_path = entry.path
                                 if current == resolved_root and entry_name.startswith("models--"):
-                                    child_path = current / entry_name
+                                    child_path = Path(entry_path)
                                     if _hf_cache_repo_id(child_path) is not None:
                                         hf_cache_repo_dirs.append(child_path)
                                         continue
-                                child_names.append(entry_name)
+                                child_entries.append((entry_name, entry_path))
                         except OSError:
                             continue
             except OSError:
@@ -4012,8 +4013,8 @@ class WorkerModelCatalog:
                     )
                 )
                 continue
-            child_names.sort(reverse=True)
-            stack.extend(current / name for name in child_names)
+            child_entries.sort(reverse=True)
+            stack.extend(Path(entry_path) for _name, entry_path in child_entries)
         return tuple(manifest_paths), tuple(plain_local_model_dirs), tuple(sorted(hf_cache_repo_dirs))
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Use `os.DirEntry.path` while scanning model registry child directories, avoiding root-child `Path.__truediv__` joins on the plain-local traversal path.
- Keep manifest detection, plain-local model detection, HF cache repository detection, and traversal ordering unchanged.
- Update the focused probe expectations and governing performance plan for this slice.

## Plan or Spec
- `docs/plans/2026-07-17-model-registry-plain-child-path-deferral.md`

## Commands Run
```text
# focused registered test command for model-registry-plain-local-manifest-stat-elision
bash /tmp/melix_model_test_command.sh
# result: 23 passed in 3.11s

# changed-scope registered coverage command
bash /tmp/melix_model_coverage_command.sh
# result: 23 passed in 1.75s; TOTAL 9 0 100%

# registered local Linux probe on head
bash /tmp/melix_model_probe_command.sh
# result: {"elapsed_ms_mean": 17.153848, "manifest_count_mean": 400.0, "model_count": 400.0, "plain_scan_count_mean": 400.0, "root_plain_child_path_joins_mean": 0.0, "sample_count": 5.0}

# stable 10-sample base/head comparison
MELIX_MODEL_REGISTRY_PLAIN_CHILD_PROBE_SAMPLES=10 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_registry_plain_child_path_probe.py
# base result: {"elapsed_ms_mean": 17.051488, "manifest_count_mean": 400.0, "model_count": 400.0, "plain_scan_count_mean": 400.0, "root_plain_child_path_joins_mean": 800.0, "sample_count": 10.0}
# head result: {"elapsed_ms_mean": 12.286624, "manifest_count_mean": 400.0, "model_count": 400.0, "plain_scan_count_mean": 400.0, "root_plain_child_path_joins_mean": 0.0, "sample_count": 10.0}

git diff --check
# result: passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (9/9 measurable changed lines covered).
- Registered probe: `model-registry-plain-local-manifest-stat-elision`.
- Base/head 10-sample metrics: `elapsed_ms_mean` 17.051488 ms → 12.286624 ms (`delta_ms=-4.764864`, ~1.388x speedup); `root_plain_child_path_joins_mean` 800.0 → 0.0.
- Local validation boundary: Python-only scanner path validated locally on Linux. GitHub Actions PR-scoped performance workflow remains the merge gate.

## Known Gaps
- None.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead is limited to synthetic CI/local probe execution.
- [x] Deferred work and known gaps are stated explicitly.
