### PR TITLE
perf: template tool registry fallback receipts

### DIFF
--- a/docs/plans/2026-06-11-tool-registry-empty-context-skip.md
+++ b/docs/plans/2026-06-11-tool-registry-empty-context-skip.md
@@ -17,3 +17,9 @@ The affected path is covered by the registered PR-scoped performance probe `tool
 ## Expected Metrics
 
 The primary expected metric is a lower `selector_planning_elapsed_ms_mean` in the registered `tool_registry_select_probe.py` workload. Other select/config metrics should remain stable because the slice only affects the selector planning branch.
+
+## 2026-07-17 Follow-up: Always-only receipt template
+
+This incremental Python performance slice keeps the same registered `tool-registry-select-name-index-cache` probe. The default catalog always-only fallback now copies a precomputed receipt base and an isolated selected-tool payload instead of rebuilding the unchanged metrics fields for every no-keyword/whitespace fallback result. Behavior remains unchanged: callers still receive mutable per-call `receipt` and `selected_tools` objects, vector-enabled fallback receipts still preserve `vector_available=True`, and policy receipts continue through the existing full assembly path.
+
+Expected metrics are lower `always_only_planning_elapsed_ms_mean`, `no_keyword_fallback_planning_elapsed_ms_mean`, and `whitespace_turn_planning_elapsed_ms_mean` in `scripts/tool_registry_select_probe.py`; selection/config metrics outside the always-only fallback path should remain stable.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -1293,6 +1293,32 @@ def test_agentic_tool_selection_no_keyword_fallback_reuses_always_only_cache(
     ]
 
 
+def test_agentic_tool_selection_always_only_receipts_are_isolated() -> None:
+    first_result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer the researcher briefly about cropland.",
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+    first_result.receipt["selected_tools"][0]["tool_id"] = "mutated"
+    first_result.receipt["selected_tools"].append(
+        {"tool_id": "mutated", "source": "test"}
+    )
+
+    second_result = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Answer the researcher briefly about cropland.",
+            vector_available=False,
+            max_selected_tools=4,
+        )
+    )
+
+    assert second_result.receipt["selected_tools"] == [
+        {"tool_id": "local_compute", "source": "always"}
+    ]
+
+
 def test_agentic_tool_selection_always_only_supports_custom_registry() -> None:
     registry = ToolRegistry(tool_registry_module.agentic_tool_catalog_registry().tools)
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -1045,6 +1045,14 @@ def _build_always_only_tool_selection_result(
         registry_metrics = _AGENTIC_TOOL_CATALOG_METRICS
         selected_metrics = _ALWAYS_ONLY_TOOL_METRICS
         dropped_tool_count = _ALWAYS_ONLY_DROPPED_TOOL_COUNT
+        if (
+            tool_policy_receipt is None
+            and fallback_reason == "no_keyword_match"
+            and not selection_input.vector_available
+        ):
+            receipt = _ALWAYS_ONLY_RECEIPT_BASE.copy()
+            receipt["selected_tools"] = [_ALWAYS_ONLY_SELECTED_TOOL_RECEIPT.copy()]
+            return ToolSelectionResult(registry=selected_registry, receipt=receipt)
     else:
         selected_registry = registry.select((selected_name,))
         registry_metrics = registry.metrics()
@@ -1470,6 +1478,18 @@ _ALWAYS_ONLY_DROPPED_TOOL_COUNT = max(
     0,
     _AGENTIC_TOOL_CATALOG_METRICS.tool_count - _ALWAYS_ONLY_TOOL_METRICS.tool_count,
 )
+_ALWAYS_ONLY_SELECTED_TOOL_RECEIPT = {"tool_id": "local_compute", "source": "always"}
+_ALWAYS_ONLY_RECEIPT_BASE: dict[str, Any] = {
+    "schema_version": "melix.agentic_tool_selection.v1",
+    "toolset_version": BUILTIN_TOOLSET_VERSION,
+    "selection_mode": "fallback",
+    "vector_available": False,
+    "fallback_reason": "no_keyword_match",
+    "selected_tools": [],
+    "dropped_tool_count": _ALWAYS_ONLY_DROPPED_TOOL_COUNT,
+    "full_schema_bytes": _AGENTIC_TOOL_CATALOG_METRICS.schema_bytes,
+    "selected_schema_bytes": _ALWAYS_ONLY_TOOL_METRICS.schema_bytes,
+}
 _BUILTIN_TOOL_CONFIG_REGISTRY = ToolRegistry(_BUILTIN_AGENTIC_TOOLS)
 _BUILTIN_TOOL_CONFIG_NAMES_LIST = list(BUILTIN_AGENTIC_TOOL_NAMES)
 _BUILTIN_TOOL_CONFIG_BYTES = (


### PR DESCRIPTION
## Summary
- Add a precomputed receipt-base fast path for the default catalog always-only tool selection fallback.
- Preserve per-call mutable `receipt["selected_tools"]` isolation while avoiding repeated metrics/dropped-count assembly on no-keyword and whitespace fallback paths.
- Add a regression test for receipt isolation and update the tool-registry performance plan.

## Plan or Spec
- `docs/plans/2026-06-11-tool-registry-empty-context-skip.md`
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` (includes `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# baseline before change: exit 0; key metrics below

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 125 passed in 1.73s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
# exit 0; 125 passed in 0.65s; changed-scope coverage TOTAL 12 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
# exit 0; head metrics below

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Local registered probe (`scripts/tool_registry_select_probe.py`, 5 samples, 80,000 iterations):
  - `always_only_planning_elapsed_ms_mean`: baseline `21.654264`, head `21.545880`, delta `-0.108383 ms` (`-0.50%`).
  - `no_keyword_fallback_planning_elapsed_ms_mean`: baseline `63.441171`, head `62.418415`, delta `-1.022756 ms` (`-1.61%`).
  - `whitespace_turn_planning_elapsed_ms_mean`: baseline `20.114614`, head `19.009344`, delta `-1.105270 ms` (`-5.49%`).
  - `selector_planning_elapsed_ms_mean`: baseline `33.370159`, head `31.601657`, delta `-1.768502 ms` (`-5.30%`).
  - `elapsed_ms_mean`: baseline `23.484226`, head `23.437954`, delta `-0.046271 ms` (`-0.20%`).
- CI is required to validate the registered PR-scoped performance workflow report before merge.

## Known Gaps
- Full repository `make bootstrap`, `make proto`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally; this Linux slice used focused Python tests, changed-scope coverage, and the registered Python probe.
- No protocol or dependency changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts, or N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles, or N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or N/A: existing PR-scoped performance evidence probe only; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
