### PR TITLE
perf: skip empty native parser metrics

### DIFF
--- a/docs/plans/2026-07-17-engine-native-parser-metrics-fastpath.md
+++ b/docs/plans/2026-07-17-engine-native-parser-metrics-fastpath.md
@@ -1,0 +1,46 @@
+# Engine Native Parser Metrics Plain-Token Fast Path
+
+## Scope
+
+This Python-only performance slice is limited to terminal Generate response
+metrics assembly in `worker.engine.engine_core.EngineCore.generate()`.
+
+Plain text token events do not carry native-MTP timing, speculative decoding, or
+prefix-cache parser metrics. The hot Generate finalization path should avoid
+calling the native parser-metrics materializer for those events while preserving
+all existing metrics when native parser metadata is present.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`.
+The probe has focused `test_command`, `coverage_command`, and `probe_command`
+entries and watches:
+
+- `services/mlx-worker-python/worker/engine/engine_core.py`
+- `services/mlx-worker-python/tests/test_generate_stream.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/engine_generate_usage_token_probe.py`
+
+## Implementation plan
+
+1. Preserve Generate response semantics and all native parser metrics when the
+   runtime token event includes native-MTP timing, speculative, or prefix-cache
+   fields.
+2. Add a lightweight predicate for whether a runtime token event can emit native
+   parser metrics.
+3. Use that predicate before materializing native parser metrics during Generate
+   finalization so plain token events skip the empty metrics helper path.
+4. Add focused regression coverage proving plain usage-tracked token events do
+   not call the native parser metrics materializer.
+5. Run the registered focused tests, changed-scope coverage, and registered
+   probe locally on Linux before pushing. GitHub Actions PR-scoped performance
+   remains the merge gate.
+
+## Success criteria
+
+- Focused Generate tests pass.
+- Changed-scope coverage for the touched files remains above the repository
+  threshold.
+- The registered local probe remains green and reports stable/improved metrics
+  for Generate no-usage and fallback usage paths.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4646,6 +4646,18 @@
         "warn_pct": 0.0
       },
       {
+        "key": "fallback_native_parser_calls_per_request",
+        "unit": "calls/request",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
+        "key": "fallback_native_parser_calls_mean",
+        "unit": "calls",
+        "direction": "lower_is_better",
+        "warn_pct": 0.0
+      },
+      {
         "key": "elapsed_ms_mean",
         "unit": "ms",
         "direction": "informational"

--- a/scripts/engine_generate_usage_token_probe.py
+++ b/scripts/engine_generate_usage_token_probe.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(repo_root / "services/mlx-worker-python"))
 
 from packages.protocol.python.worker.v1 import common_pb2, inference_pb2, runtime_pb2
+import worker.engine.engine_core as engine_core_module
 from worker.engine.request_state import RequestState
 from worker.grpc_server import WorkerInferenceService, WorkerRuntimeService
 from worker.model_registry.catalog import WorkerModelCatalog
@@ -147,10 +148,19 @@ def _run_no_usage_sample(*, request_count: int, prompt_words: int, sample: int) 
     return (time.perf_counter() - start) * 1000.0, runtime.prompt_token_count_calls, append_count, token_count
 
 
-def _run_fallback_sample(*, request_count: int, prompt_words: int, sample: int) -> tuple[float, float, int]:
+def _run_fallback_sample(*, request_count: int, prompt_words: int, sample: int) -> tuple[float, float, int, int]:
     runtime = FallbackRuntime(prompt_words=prompt_words)
     inference_service, model_handle = _load_services(runtime)
     prompt_tokens = 0
+    native_parser_calls = 0
+    original_native_parser = engine_core_module._text_native_mtp_parser_metrics
+
+    def counting_native_parser(event):  # pragma: no cover - current head should bypass this guard.
+        nonlocal native_parser_calls
+        native_parser_calls += 1  # pragma: no cover
+        return original_native_parser(event)  # pragma: no cover
+
+    engine_core_module._text_native_mtp_parser_metrics = counting_native_parser
     tracemalloc.start()
     start = time.perf_counter()
     try:
@@ -164,11 +174,12 @@ def _run_fallback_sample(*, request_count: int, prompt_words: int, sample: int) 
             usage = next(event.usage_delta for event in events if event.HasField("usage_delta"))
             prompt_tokens = int(usage.prompt_tokens)
     finally:
+        engine_core_module._text_native_mtp_parser_metrics = original_native_parser
         _, peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
     if prompt_tokens != prompt_words:
         raise SystemExit(f"unexpected fallback prompt tokens: {prompt_tokens} != {prompt_words}")  # pragma: no cover
-    return (time.perf_counter() - start) * 1000.0, float(peak), prompt_tokens
+    return (time.perf_counter() - start) * 1000.0, float(peak), prompt_tokens, native_parser_calls
 
 
 def run_probe() -> dict[str, float | int | str]:
@@ -182,6 +193,7 @@ def run_probe() -> dict[str, float | int | str]:
     token_events: list[int] = []
     fallback_elapsed_ms: list[float] = []
     fallback_peak_bytes: list[float] = []
+    fallback_native_parser_calls: list[int] = []
 
     for sample in range(samples):
         elapsed, calls, appends, tokens = _run_no_usage_sample(
@@ -194,13 +206,14 @@ def run_probe() -> dict[str, float | int | str]:
         append_counts.append(appends)
         token_events.append(tokens)
 
-        fallback_elapsed, fallback_peak, _ = _run_fallback_sample(
+        fallback_elapsed, fallback_peak, _, native_parser_calls = _run_fallback_sample(
             request_count=fallback_request_count,
             prompt_words=prompt_words,
             sample=sample,
         )
         fallback_elapsed_ms.append(fallback_elapsed)
         fallback_peak_bytes.append(fallback_peak)
+        fallback_native_parser_calls.append(native_parser_calls)
 
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_ms),
@@ -211,6 +224,9 @@ def run_probe() -> dict[str, float | int | str]:
         "request_state_append_calls_per_request": statistics.fmean(append_counts) / request_count,
         "token_events_mean": statistics.fmean(token_events),
         "fallback_elapsed_ms_mean": statistics.fmean(fallback_elapsed_ms),
+        "fallback_native_parser_calls_mean": statistics.fmean(fallback_native_parser_calls),
+        "fallback_native_parser_calls_per_request": statistics.fmean(fallback_native_parser_calls)
+        / fallback_request_count,
         "fallback_peak_bytes_mean": statistics.fmean(fallback_peak_bytes),
         "fallback_request_count": fallback_request_count,
         "request_count": request_count,

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -693,6 +693,26 @@ def generate_usage_request(model_handle: str, *, return_usage: bool) -> inferenc
     )
 
 
+def test_generate_plain_token_skips_native_metric_parser(monkeypatch) -> None:
+    runtime = UsageCountingRuntime(prompt_tokens=0)
+    inference_service, model_handle = build_usage_counting_services(runtime)
+    native_parser_calls = 0
+    original_parser = engine_core_module._text_native_mtp_parser_metrics
+
+    def counted_native_parser(event):  # pragma: no cover - regression guard should stay unused.
+        nonlocal native_parser_calls
+        native_parser_calls += 1  # pragma: no cover
+        return original_parser(event)  # pragma: no cover
+
+    monkeypatch.setattr(engine_core_module, "_text_native_mtp_parser_metrics", counted_native_parser)
+
+    events = list(inference_service.Generate(generate_usage_request(model_handle, return_usage=True), context=None))
+
+    completed = next(event.completed for event in events if event.HasField("completed"))
+    assert completed.finish_reason == "stop"
+    assert native_parser_calls == 0
+
+
 def test_generate_without_usage_skips_prompt_token_count_fallback(monkeypatch) -> None:
     runtime = UsageCountingRuntime(prompt_tokens=0)
     inference_service, model_handle = build_usage_counting_services(runtime)

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -7829,6 +7829,8 @@ def test_engine_generate_usage_token_probe_script_emits_metrics(
     assert metrics["request_state_append_calls_per_request"] == 0
     assert metrics["token_events_mean"] == 3
     assert metrics["fallback_request_count"] == 2
+    assert metrics["fallback_native_parser_calls_mean"] == 0
+    assert metrics["fallback_native_parser_calls_per_request"] == 0
     assert metrics["fallback_elapsed_ms_mean"] > 0
     assert metrics["fallback_peak_bytes_mean"] > 0
 

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -127,25 +127,27 @@ def _apply_prompt_context_receipt_metrics(parser_metrics: dict[str, str], execut
             parser_metrics[metric_key] = value
 
 
-def _text_native_mtp_parser_metrics(event: RuntimeTokenEvent | None) -> dict[str, str]:
+def _runtime_token_event_has_native_parser_metrics(event: RuntimeTokenEvent | None) -> bool:
     if event is None:
-        return {}
-
-    t = event.native_mtp_timings
-    has_timing = t is not None
-    has_speculative = (
-        event.speculative_accepted_tokens is not None
+        return False
+    return (
+        event.native_mtp_timings is not None
+        or event.speculative_accepted_tokens is not None
         or event.speculative_rejected_tokens is not None
         or event.speculative_target_verify_ms is not None
-    )
-    has_cache = (
-        event.cache_hit_mode is not None
+        or event.cache_hit_mode is not None
         or event.recovered_prefix_tokens is not None
         or event.cache_fallback_reason is not None
         or event.cache_hit_tier is not None
     )
-    if not has_timing and not has_speculative and not has_cache:
+
+
+def _text_native_mtp_parser_metrics(event: RuntimeTokenEvent | None) -> dict[str, str]:
+    if not _runtime_token_event_has_native_parser_metrics(event):
         return {}
+
+    assert event is not None
+    t = event.native_mtp_timings
 
     metric_fields: dict[str, object] = {
         "text_batch_generator_speculative_cycle_count_total": t.cycle_count if t else None,
@@ -662,7 +664,7 @@ class EngineCore:
                 parser_metrics = {key: _parser_metric_text(value) for key, value in assembled.metrics.items()}
             else:
                 parser_metrics = {}
-            if last_token_event is not None:
+            if _runtime_token_event_has_native_parser_metrics(last_token_event):
                 parser_metrics.update(_text_native_mtp_parser_metrics(last_token_event))
             resolved_stop_token_count = str(stop_contract.resolved_stop_token_count)
             if plain_text_fast_path:


### PR DESCRIPTION
## Summary
- Skip native parser-metrics materialization for plain usage-tracked Generate token events that have no native-MTP, speculative, or prefix-cache fields.
- Extend the registered `engine-generate-usage-token-elision` probe with deterministic native parser call-count metrics.
- Add focused regression coverage and a governing performance-slice plan.

## Plan or Spec
- `docs/plans/2026-07-17-engine-native-parser-metrics-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py::test_generate_plain_token_skips_native_metric_parser
# Before implementation: failed with native_parser_calls == 1; after implementation: 1 passed.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 49 passed in 2.02s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
# 49 passed; changed-scope coverage TOTAL 30 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# head: fallback_native_parser_calls_per_request=0.0, fallback_elapsed_ms_mean=137.22420011514

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Registered local probe (`engine-generate-usage-token-elision`, 7 samples):
  - baseline (`origin/main` code with head probe): `fallback_native_parser_calls_per_request=1.0`, `fallback_native_parser_calls_mean=60.0`, `fallback_elapsed_ms_mean=144.2439453676343`, `elapsed_ms_mean=38.843996856095536`.
  - head: `fallback_native_parser_calls_per_request=0.0`, `fallback_native_parser_calls_mean=0.0`, `fallback_elapsed_ms_mean=137.22420011514`, `elapsed_ms_mean=35.77968431636691`.
  - deterministic call-count delta: `-1.0 calls/request`; fallback elapsed delta: `-7.0197452524943 ms` (~4.87% faster).
- Observability mode: evidence (registered PR-scoped performance probe). Probe overhead: N/A for production runtime; the monkeypatch call counter only runs inside `scripts/engine_generate_usage_token_probe.py`.
- CI is required for final registered PR-scoped performance validation before merge.

## Known Gaps
- Full `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this Linux slice used the registered focused Python test/coverage/probe gate.
- CI PR-scoped performance report is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
