### PR TITLE
perf: fast-path uppercase hub cursor escapes

### DIFF
--- a/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
+++ b/docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md
@@ -58,3 +58,16 @@ original text span instead of slicing a temporary line string before delegating 
 units, tab-separated units, and trailing whitespace, still fall back to the
 existing full direct parser on the sliced span, preserving behavior while reducing
 allocation and dispatch in the repeated registered size-hint workload.
+
+## 2026-07-17 uppercase cursor decode slice
+
+This follow-up Python-only slice keeps registered probe coverage through
+`hub-catalog-next-cursor-fast-parse` and narrows to
+`_unquote_plus_ascii_cursor(...)`, which decodes Hub pagination cursors extracted
+from the `Link` header. The common Hugging Face cursor encoding observed by the
+registered probe uses uppercase `%2F` and `%2B` escapes, so the decoder now tries
+those replacements first and returns before the lowercase escape pass when the
+cursor is fully decoded. Lowercase escapes, Unicode percent escapes, malformed
+percent sequences, and plus-to-space decoding still fall through to the existing
+lowercase or general decoding paths, preserving cursor behavior while reducing
+string replacement work for the common uppercase cursor path.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -417,10 +417,12 @@ def _unquote_plus_ascii_cursor(value: str) -> str:
     common_cursor = (
         value.replace("+", " ")
         .replace("%2F", "/")
-        .replace("%2f", "/")
         .replace("%2B", "+")
-        .replace("%2b", "+")
     )
+    if "%" not in common_cursor:
+        return common_cursor
+
+    common_cursor = common_cursor.replace("%2f", "/").replace("%2b", "+")
     if "%" not in common_cursor:
         return common_cursor
 


### PR DESCRIPTION
## Summary
- Fast-path common uppercase `%2F` / `%2B` Hub pagination cursor escapes before trying lowercase escape replacements.
- Preserve lowercase escape, Unicode percent escape, malformed percent, and plus-to-space behavior through the existing fallback paths.

## Plan or Spec
- `docs/plans/2026-05-06-hub-catalog-empty-size-hint-fast-path.md` now records the 2026-07-17 uppercase cursor decode slice.
- Registered PR-scoped probe: `hub-catalog-next-cursor-fast-parse` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
# focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
-> 97 passed in 0.33s

# changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
-> TOTAL 3 0 100%

# registered local probe, base vs head, 3 runs each with 7 internal samples
base (/root/.hermes/profiles/coder/workspace/melix): 910.270 ms, 890.822 ms, 910.242 ms
head: 866.453 ms, 876.336 ms, 854.559 ms

# post-format smoke probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_CURSOR_SAMPLES=7 MELIX_HUB_CATALOG_CURSOR_ITERATIONS=80000 uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
-> {"checksum": 10421830.0, "cursor_parse_calls_mean": 80000.0, "elapsed_ms_mean": 866.1865387111902, "peak_bytes_mean": 832.0, "sample_count": 7.0}

git diff --check
-> passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` for `hub_catalog.py` plus registered probe/test paths.
- Local registered probe comparison: old_mean=903.778 ms, new_mean=865.783 ms, delta=-37.995 ms, speedup=1.0439x, improvement=4.20%.
- Peak bytes stayed neutral at 832 bytes in the base/head comparison.
- CI is required for the authoritative registered PR-scoped performance validation before merge.

## Known Gaps
- Local validation is Linux/Python-only; no Swift runtime effect is claimed.
- Awaiting GitHub Actions PR-scoped performance report for final registered-probe validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead unchanged; no debug instrumentation added.
- [x] Deferred work and known gaps are stated explicitly.
