### PR TITLE
perf: fast-path ampersand hub cursor params

### DIFF
--- a/docs/plans/2026-05-07-hub-catalog-cursor-param-find.md
+++ b/docs/plans/2026-05-07-hub-catalog-cursor-param-find.md
@@ -28,3 +28,7 @@ Use the existing registered probe `hub-catalog-next-cursor-fast-parse` in `infra
 - Changed-scope coverage for touched executable Python lines is at least 95%.
 - Local base-vs-head probe reports lower `elapsed_ms_mean` without checksum drift.
 - The PR-scoped performance workflow runs the registered probe successfully before merge.
+
+## 2026-07-17 ampersand cursor fast path
+
+This follow-up Python-only slice keeps the same registered `hub-catalog-next-cursor-fast-parse` probe and narrows to `_next_cursor_from_link(...)`. The common Hugging Face next-link URL places `cursor` after earlier query parameters (`...&cursor=...`), so the parser now checks the query-start `cursor=` case once and otherwise searches directly for the bounded `&cursor=` parameter. This removes the repeated generic `cursor=` substring scan and previous-character boundary check in the common path while preserving exact query-parameter behavior for `cursor` at query start, `notcursor`/`mycursor`, fragment boundaries, and encoded cursor decoding.

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -34,6 +34,8 @@ _EXPLICIT_SIZE_HINT_SEARCH = _EXPLICIT_SIZE_HINT_RE.search
 _NEXT_LINK_REL_MARKER = 'rel="next"'
 _CURSOR_QUERY_KEY = "cursor="
 _CURSOR_QUERY_KEY_LEN = len(_CURSOR_QUERY_KEY)
+_CURSOR_QUERY_PARAM = "&cursor="
+_CURSOR_QUERY_PARAM_LEN = len(_CURSOR_QUERY_PARAM)
 _URL_HEX_DIGITS = {
     "0": 0,
     "1": 1,
@@ -372,17 +374,22 @@ def _next_cursor_from_link(link_header: str) -> str:
         query_end = link_header.find("#", url_content_start, url_end)
         if query_end < 0:
             query_end = url_end
-        cursor_start = link_header.find(_CURSOR_QUERY_KEY, url_content_start, query_end)
-        while cursor_start >= 0:
-            previous_char = link_header[cursor_start - 1] if cursor_start > url_content_start else ""
-            if previous_char == "?" or previous_char == "&":
-                value_start = cursor_start + _CURSOR_QUERY_KEY_LEN
-                value_end = link_header.find("&", value_start, query_end)
-                if value_end < 0:
-                    value_end = query_end
-                return _unquote_plus_ascii_cursor(link_header[value_start:value_end])
-            cursor_start = link_header.find(_CURSOR_QUERY_KEY, cursor_start + _CURSOR_QUERY_KEY_LEN, query_end)
-        return ""
+        query_start = link_header.find("?", url_content_start, query_end)
+        if query_start < 0:
+            return ""
+        value_start = query_start + 1
+        if link_header.startswith(_CURSOR_QUERY_KEY, value_start, query_end):
+            value_start += _CURSOR_QUERY_KEY_LEN
+        else:
+            cursor_start = link_header.find(_CURSOR_QUERY_PARAM, value_start, query_end)
+            if cursor_start < 0:
+                return ""
+            value_start = cursor_start + _CURSOR_QUERY_PARAM_LEN
+
+        value_end = link_header.find("&", value_start, query_end)
+        if value_end < 0:
+            value_end = query_end
+        return _unquote_plus_ascii_cursor(link_header[value_start:value_end])
 
 
 def _cursor_query_value(url: str, start: int, end: int) -> str:


### PR DESCRIPTION
## Summary
- Fast-path Hub next-link cursor extraction for the common `&cursor=` query parameter placement.
- Preserve exact cursor parameter semantics for query-start `cursor=`, `notcursor`/`mycursor`, fragments, and existing percent decoding.
- Update the governing Hub cursor performance plan with this follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-07-hub-catalog-cursor-param-find.md`

## Commands Run
```text
# Baseline on origin/main before edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 97 passed in 1.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# exit 0; {"checksum": 6509477.0, "cursor_parse_calls_mean": 50000.0, "elapsed_ms_mean": 577.4491001851857, "peak_bytes_mean": 832.0, "sample_count": 5.0}

# Head after edits
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 97 passed in 0.38s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_next_cursor_probe.py
# exit 0; TOTAL 16 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# exit 0; {"checksum": 6509477.0, "cursor_parse_calls_mean": 50000.0, "elapsed_ms_mean": 555.0777087453753, "peak_bytes_mean": 832.0, "sample_count": 5.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 16 0 100%`.
- Registered local probe: `hub-catalog-next-cursor-fast-parse` via `scripts/hub_catalog_next_cursor_probe.py`.
- Local probe delta: old_mean=`577.4491001851857 ms`, new_mean=`555.0777087453753 ms`, delta=`-22.371391 ms`, improvement=`3.874%`, speedup=`4.030%`; checksum unchanged at `6509477.0`.
- CI PR-scoped performance is required for the registered probe report before merge.

## Known Gaps
- None for the Python slice. Local validation was Linux-only; GitHub Actions remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; probe overhead is isolated to CI/local synthetic probe and not runtime production code.
- [x] Deferred work and known gaps are stated explicitly.
