### PR TITLE
perf: return sorted code eval payload literal

### DIFF
--- a/docs/plans/2026-07-18-code-eval-sorted-payload-literal-return.md
+++ b/docs/plans/2026-07-18-code-eval-sorted-payload-literal-return.md
@@ -1,0 +1,44 @@
+# Code eval sorted payload literal return
+
+## Scope
+
+This Python-only performance slice stays limited to the sorted code-evaluation
+payload fast path in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+The behavior remains unchanged: successful compact sorted payloads still return
+only the normalized code-evaluation result fields and still fall back to the
+existing JSON parser for unsupported payload shapes.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`code-eval-payload-json-bytes` in `infra/perf/pr_scoped_probes.json`. The probe
+already has focused `test_command`, `coverage_command`, and `probe_command`
+entries for:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_payload_json_probe.py`
+
+## Optimization
+
+After every required sorted-payload field has been validated, return the final
+payload mapping as a single dict literal instead of allocating an empty dict near
+the start of the extractor and mutating it as fields are discovered. This avoids
+intermediate dict writes on the hot success path while preserving the existing
+failure behavior.
+
+## Validation plan
+
+Run locally on Linux before opening the PR:
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_uses_compact_field_offsets services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_skips_reserved_metadata_keys services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_returns_none_for_missing_or_malformed_fields services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_uses_compact_field_offsets services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_skips_reserved_metadata_keys services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_returns_none_for_missing_or_malformed_fields services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
+python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_payload_literal_return_probe.json
+```
+
+GitHub Actions PR-scoped performance remains the final registered probe
+validation source before merge.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -560,7 +560,6 @@ def _extract_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object]
 
 
 def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, object] | None:
-    payload: dict[str, object] = {}
     field_value_start = _compact_json_field_value_start_for_token
     reverse_field_value_start = _compact_json_field_value_start_for_token_reverse
     extract_int_and_end = _extract_json_int_field_value_and_end
@@ -572,7 +571,6 @@ def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, 
     )
     if failure_start is None or not payload_startswith(b'""', failure_start):
         return None
-    payload["failure_detail"] = ""
 
     timeout_start = reverse_field_value_start(
         payload_bytes,
@@ -621,13 +619,14 @@ def _extract_sorted_code_eval_payload_fields(payload_bytes: bytes) -> dict[str, 
     )
     if runtime_start is None or not payload_startswith(b'"ok"', runtime_start):
         return None
-    payload["runtime_status"] = "ok"
-    payload["test_status"] = "passed"
-    payload["tests_passed"] = tests_passed
-    payload["tests_total"] = tests_total
-    payload["timeout_status"] = "ok"
-
-    return payload
+    return {
+        "failure_detail": "",
+        "runtime_status": "ok",
+        "test_status": "passed",
+        "tests_passed": tests_passed,
+        "tests_total": tests_total,
+        "timeout_status": "ok",
+    }
 
 
 def _compact_json_field_value_start_for_token(


### PR DESCRIPTION
## Summary
- Return the sorted code-evaluation payload fast-path mapping as a final dict literal instead of allocating and mutating an intermediate dict.
- Keep the extractor behavior and fallback paths unchanged for malformed or unsupported payloads.

## Plan or Spec
- `docs/plans/2026-07-18-code-eval-sorted-payload-literal-return.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_rejects_invalid_and_non_mapping_json services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_reads_payload_bytes_without_text_decode services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_uses_os_read_for_real_paths services/mlx-worker-python/tests/test_code_eval_runner.py::test_read_payload_file_bytes_handles_fallback_and_fd_errors services/mlx-worker-python/tests/test_code_eval_runner.py::test_runner_script_loads_config_from_bytes services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_uses_compact_field_offsets services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_skips_reserved_metadata_keys services/mlx-worker-python/tests/test_code_eval_runner.py::test_compact_field_offset_fallback_reuses_known_key_index services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_extracts_sorted_payload_without_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_sorted_payload_fast_path_returns_none_for_missing_or_malformed_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_fast_path_decodes_known_status_values services/mlx-worker-python/tests/test_code_eval_runner.py::test_code_eval_payload_missing_required_field_falls_back_to_json_parse services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_reuses_precomputed_key_tokens services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_unexpected_key_order services/mlx-worker-python/tests/test_code_eval_runner.py::test_load_payload_file_fast_path_falls_back_for_escaped_fields services/mlx-worker-python/tests/test_code_eval_runner.py::test_payload_fast_path_field_extractors_cover_malformed_edges services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_code_eval_stdio_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_code_eval_payload_json_probe_script_emits_metrics
# 19 passed in 0.68s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same registered code-eval-payload-json-bytes focused selection>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/code_eval_runner.py services/mlx-worker-python/tests/test_code_eval_runner.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/code_eval_payload_json_probe.py
# 19 passed in 3.96s; changed-scope TOTAL 1 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id code-eval-payload-json-bytes --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/code_eval_payload_literal_return_probe_1784333944.json
# head verification ok; base/head probes ok
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 1 0 100%`).
- Registered local probe `code-eval-payload-json-bytes`:
  - `elapsed_ms_mean`: base `58.175185695290565` ms, head `53.91046035635684` ms, delta `-4.264725338933725` ms (~7.33% faster).
  - `peak_bytes_mean`: base `52795.0`, head `52795.0`, delta `0`.
  - `payload_bytes`: `51874.0`; `iteration_count`: `1200.0`; `sample_count`: `7.0`.
- CI is required for the final registered PR-scoped performance validation before merge.

## Known Gaps
- None. Swift runtime effects are not involved in this Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, no runtime observability change; probe overhead unchanged by this code-only fast-path slice.
- [x] Deferred work and known gaps are stated explicitly.
