### PR TITLE
perf: cache local job tuple copy length

### DIFF
--- a/docs/plans/2026-07-18-local-job-copy-tuple-len.md
+++ b/docs/plans/2026-07-18-local-job-copy-tuple-len.md
@@ -1,0 +1,42 @@
+# Local Job Follow-up Tuple Copy Length Cache
+
+## Context
+
+The registered PR-scoped probe `local-job-followup-scan-scandir` covers
+`worker.runtime.local_job_continuation` follow-up scanning, claim projection, and
+JSON-like payload copy helpers used by local-job follow-up receipts.
+
+The `_copy_json_like_value()` tuple fast path handles common two- and three-item
+tuples separately, but it previously called `len(value)` once per length branch.
+This slice keeps copy semantics unchanged while caching the tuple length once for
+that exact-type tuple path.
+
+## Scope
+
+- Limit code changes to `_copy_json_like_value()` tuple handling in
+  `services/mlx-worker-python/worker/runtime/local_job_continuation.py`.
+- Preserve exact behavior for JSON scalar reuse, dict/list copying, tuple copying,
+  and container subclass fallback handling.
+- Use the existing focused tests that cover tuple payload copying and container
+  subclass preservation.
+
+## Measurement
+
+Registered probe: `local-job-followup-scan-scandir`
+
+Required local Linux commands:
+
+- Focused registry test command for `local-job-followup-scan-scandir`.
+- Changed-scope coverage command for the same registry entry.
+- Registered probe command from `infra/perf/pr_scoped_probes.json`.
+
+Success is accepted only if behavior tests pass, changed-scope coverage remains
+at or above 95%, and the local registered probe remains directionally
+non-regressive for the local-job follow-up copy and scan metrics. GitHub Actions
+PR-scoped performance remains the merge gate after push.
+
+## Linux Boundary
+
+This is a Python worker path and can be validated locally on Linux. CI remains
+the source of truth for the registered PR-scoped performance report after the PR
+is opened.

--- a/services/mlx-worker-python/worker/runtime/local_job_continuation.py
+++ b/services/mlx-worker-python/worker/runtime/local_job_continuation.py
@@ -1074,9 +1074,10 @@ def _copy_json_like_value(value: Any) -> Any:
                 append(_copy_json_like_value(item))
         return copied_list
     if value_type is tuple:
-        if len(value) == 2:
+        value_len = len(value)
+        if value_len == 2:
             return (_copy_json_like_value(value[0]), _copy_json_like_value(value[1]))
-        if len(value) == 3:
+        if value_len == 3:
             return (
                 _copy_json_like_value(value[0]),
                 _copy_json_like_value(value[1]),


### PR DESCRIPTION
## Summary
- Cache the exact tuple length once in `worker.runtime.local_job_continuation._copy_json_like_value()` before the two- and three-item tuple fast paths.
- Keep local-job follow-up copy semantics unchanged for JSON scalars, nested dict/list payloads, and container subclass fallbacks.

## Plan or Spec
- `docs/plans/2026-07-18-local-job-copy-tuple-len.md`
- Registered PR-scoped probe: `local-job-followup-scan-scandir`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_reads_json_bytes services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_uses_direct_binary_open services/mlx-worker-python/tests/test_local_job_continuation.py::test_local_job_continuation_load_record_avoids_path_join_wrapper services/mlx-worker-python/tests/test_local_job_continuation.py::test_load_record_tolerates_record_deleted_between_path_resolution_and_read services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reconciles_and_filters_ready_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_reuses_reconciliation_evidence_receipt services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_uses_single_scandir_without_path_glob services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_live_evidence_lookup_when_absent services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_does_not_follow_record_symlinks services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_records_store_errors services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_returns_empty_for_missing_root services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_tolerates_root_deleted_during_scandir services/mlx-worker-python/tests/test_local_job_continuation.py::test_store_scan_followup_candidates_skips_unreadable_records services/mlx-worker-python/tests/test_local_job_continuation.py::test_claim_local_job_followup_uses_direct_record_copy_for_claim services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_uses_narrow_receipt_copies services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_copy_preserves_json_scalars_by_value services/mlx-worker-python/tests/test_local_job_continuation.py::test_project_local_job_session_followup_copy_preserves_container_subclasses services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_local_job_followup_scan_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_local_job_followup_scan_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 21 passed in 3.78s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused test list> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/local_job_continuation.py services/mlx-worker-python/tests/test_local_job_continuation.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/local_job_followup_scan_probe.py
# 21 passed in 6.93s; TOTAL 3 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_LOCAL_JOB_SCAN_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/local_job_followup_scan_probe.py
# {"candidate_count_mean": 500.0, "candidate_receipt_baseline_elapsed_ms_mean": 201.327183, "candidate_receipt_delta_ms": -76.809775, "candidate_receipt_iterations": 200000.0, "candidate_receipt_optimized_elapsed_ms_mean": 124.517408, "candidate_receipt_speedup": 1.61686, "claim_copy_baseline_elapsed_ms_mean": 976.222616, "claim_copy_delta_ms": -409.635005, "claim_copy_iterations": 200000.0, "claim_copy_optimized_elapsed_ms_mean": 566.587611, "claim_copy_speedup": 1.722986, "elapsed_ms_mean": 23.514474, "elapsed_ms_min": 21.373263, "path_exists_calls_mean": 0.0, "path_glob_calls_mean": 0.0, "projection_count_mean": 250.0, "projection_elapsed_ms_mean": 143.549081, "projection_elapsed_ms_min": 130.686977, "projection_followup_message_count_mean": 250.0, "projection_receipt_count_mean": 500.0, "receipt_count_mean": 500.0, "record_count": 500.0, "sample_count": 5.0, "scalar_copy_baseline_elapsed_ms_mean": 2768.979096, "scalar_copy_delta_ms": -1075.527275, "scalar_copy_iterations": 200000.0, "scalar_copy_optimized_elapsed_ms_mean": 1693.451821, "scalar_copy_speedup": 1.635109, "scandir_calls_mean": 1.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local registered probe (`local-job-followup-scan-scandir`): `scalar_copy_speedup=1.635109`, `claim_copy_speedup=1.722986`, `candidate_receipt_speedup=1.61686`, `scandir_calls_mean=1.0`, `path_glob_calls_mean=0.0`, `path_exists_calls_mean=0.0`.
- CI PR-scoped performance is required before merge.

## Known Gaps
- Local Linux validates the Python path only. The registered PR-scoped performance workflow is the remote merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
