### PR TITLE
perf: fast-path native mtp exact string keys

### DIFF
--- a/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
+++ b/docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md
@@ -20,6 +20,8 @@ The probe is extended to measure the model safetensor listing path directly agai
 
 2026-07-12 follow-up slice: `_extra_mtp_safetensor_file_paths()` now short-circuits top-level `model*.safetensors` sidecar candidates before scanning for `os.sep`. Nested `*/model*.safetensors` candidates still use the basename check and remain excluded, preserving the historical base-shard elision semantics while reducing string scans for noisy index maps with many duplicate base-model MTP entries.
 
+2026-07-18 follow-up slice: `_is_mtp_weight_key()` now keeps the exact `str` fast path on two direct prefix checks instead of the tuple-prefix form. The behavior for `str` subclasses and custom key objects remains unchanged through the existing compatibility branches, while direct callers scanning JSON-decoded string keys avoid the tuple dispatch overhead measured by the registered probe's `key_*` metrics.
+
 ## Verification plan
 
 ```bash

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -33,7 +33,7 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
 
 def _is_mtp_weight_key(key: Any) -> bool:
     if type(key) is str:
-        return key.startswith(_MTP_WEIGHT_KEY_PREFIXES)
+        return key.startswith("language_model.mtp.") or key.startswith("mtp.")
     if isinstance(key, str):
         return key.startswith(_MTP_WEIGHT_KEY_PREFIXES)
     return str(key).startswith(_MTP_WEIGHT_KEY_PREFIXES)


### PR DESCRIPTION
## Summary
- Fast-path exact `str` native-MTP weight keys with two direct prefix checks instead of tuple-prefix dispatch.
- Preserve `str` subclass and custom key fallback behavior through the existing compatibility branches.
- Update the governing native-MTP performance plan with this 2026-07-18 follow-up slice.

## Plan or Spec
- `docs/plans/2026-05-31-native-mtp-model-safetensor-name-loop.md`
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json` (already covers the changed loader path, focused tests, coverage command, and probe command).

## Commands Run
```text
# Baseline probe on origin/main before the slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_SAMPLES=5 MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS=2500 MELIX_NATIVE_MTP_LOADER_WEIGHT_LOAD_ITERATIONS=500 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0; key_old_mean_ms=6101.970376353711; key_new_mean_ms=5083.973884163424; key_speedup=1.2002363732357761

# Focused registered test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_weight_load_probe_tolerates_loader_timer_noise_without_weakening_counts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_model_listing_probe_tolerates_loader_timer_noise_without_weakening_counts
exit 0; 13 passed in 2.45s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
exit 0; changed_line_coverage=100.00%; TOTAL 1 0 100%

# Registered probe implementation locally on Linux
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0; key_old_mean_ms=6025.659569352865; key_new_mean_ms=6000.217442633584; key_delta_ms=-25.442126719281077; key_speedup=1.004240200786476

# Stabilized key-path probe run
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_LOADER_SAMPLES=7 MELIX_NATIVE_MTP_LOADER_KEY_ITERATIONS=5000 MELIX_NATIVE_MTP_LOADER_WEIGHT_LOAD_ITERATIONS=200 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0; key_old_mean_ms=12178.286110250545; key_new_mean_ms=11933.034623640457; key_delta_ms=-245.25148661008825; key_speedup=1.0205523150099827

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed line coverage `100.00%` (`TOTAL 1 0 100%`).
- Registered probe (local Linux, stabilized key workload): `key_old_mean_ms=12178.286110250545`, `key_new_mean_ms=11933.034623640457`, `key_delta_ms=-245.25148661008825`, `key_speedup=1.0205523150099827`.
- Registered probe also preserved parity counts: `key_count=10502`, `key_true_count=9001`, `result_count=10500`, `extra_result_count=1500`, `weight_load_result_count=3002`.
- GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.

## Known Gaps
- Local validation is Linux-only; this slice touches Python helper logic and not Swift runtime behavior.
- The exact `str` fast path is intentionally narrow; `str` subclasses and custom key objects continue through the previous compatibility branches.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
