### PR TITLE
perf: cache schema-free evaluation score identities

### DIFF
--- a/services/mlx-worker-python/tests/test_evaluation_final_result.py
+++ b/services/mlx-worker-python/tests/test_evaluation_final_result.py
@@ -91,6 +91,66 @@ def test_json_typed_score_short_circuits_exact_root_match_before_child_iteration
         _json_typed_score(expected=expected, actual={"answer": {"value": 0}}, ignored_paths=())
 
 
+def test_schema_free_json_scoring_reuses_identity_cache_before_hashing_ignored_paths() -> None:
+    class _HashCountingTuple(tuple[str, ...]):
+        hash_count = 0
+
+        def __hash__(self) -> int:
+            type(self).hash_count += 1
+            return super().__hash__()
+
+    ignored_paths = _HashCountingTuple(("metadata",))
+    profile = EvaluationProfileDefinition(
+        profile_type="final_result",
+        result_kind="json",
+        extraction_mode="strict_full_response",
+        scoring_mode="json_field_match",
+        threshold=1.0,
+        ignored_paths=ignored_paths,
+    )
+    target = '{"answer":"Paris","metadata":{"confidence":0.9}}'
+    extracted = '{"answer":"Paris","metadata":{"confidence":0.1}}'
+
+    evaluation_final_result_module._schema_free_score_identity_cache.clear()
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
+    evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
+
+    first = score_final_result(
+        extracted_result=extracted,
+        target=target,
+        profile=profile,
+    )
+    initial_hash_count = _HashCountingTuple.hash_count
+    second = score_final_result(
+        extracted_result=extracted,
+        target=target,
+        profile=profile,
+    )
+
+    assert first == second == evaluation_final_result_module.ScoringOutcome(
+        typed_score=1.0,
+        validation_status="validated",
+    )
+    assert initial_hash_count > 0
+    assert _HashCountingTuple.hash_count == initial_hash_count
+
+
+def test_schema_free_json_scoring_identity_cache_stays_bounded() -> None:
+    evaluation_final_result_module._schema_free_score_identity_cache.clear()
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
+    ignored_paths: tuple[str, ...] = ()
+    for index in range(evaluation_final_result_module._SCHEMA_FREE_SCORE_IDENTITY_CACHE_LIMIT + 1):
+        evaluation_final_result_module._schema_free_json_scoring_outcome(
+            target=f'{{"answer":{index}}}',
+            extracted_result=f'{{"answer":{index}}}',
+            ignored_paths=ignored_paths,
+        )
+
+    assert len(evaluation_final_result_module._schema_free_score_identity_cache) == 1
+    evaluation_final_result_module._schema_free_score_identity_cache.clear()
+    evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
+
+
 def test_write_jsonl_rows_streams_each_row_without_joining_the_full_payload(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -407,6 +467,7 @@ def test_score_final_result_reuses_cached_parsed_json_payloads(monkeypatch: pyte
 
 
 def test_score_final_result_reuses_cached_schema_free_json_outcomes() -> None:
+    evaluation_final_result_module._schema_free_score_identity_cache.clear()
     evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
     evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
     target = json.dumps(
@@ -440,7 +501,9 @@ def test_score_final_result_reuses_cached_schema_free_json_outcomes() -> None:
         validation_status="validated",
     )
     assert first is second
-    assert evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_info().hits >= 1
+    assert len(evaluation_final_result_module._schema_free_score_identity_cache) == 1
+    assert evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_info().hits == 0
+    evaluation_final_result_module._schema_free_score_identity_cache.clear()
     evaluation_final_result_module._cached_schema_free_json_scoring_outcome.cache_clear()
     evaluation_final_result_module._ignored_paths_for_profile.cache_clear()
 

--- a/services/mlx-worker-python/worker/productization/evaluation_final_result.py
+++ b/services/mlx-worker-python/worker/productization/evaluation_final_result.py
@@ -38,7 +38,10 @@ _TEXT_ANSWER_MARKER_PATTERN = re.compile(
     r"(?im)^\s*(?:final\s+answer|answer)\s*[:\-]?"
 )
 _HF_DATASETS_SERVER_URL = "https://datasets-server.huggingface.co"
+_SCHEMA_FREE_SCORE_IDENTITY_CACHE_LIMIT = 32
 HFEvaluationDatasetFetcher = Callable[[str, dict[str, str]], dict[str, Any]]
+_SchemaFreeScoreCacheEntry = tuple[str, str, tuple[str, ...], "ScoringOutcome"]
+_schema_free_score_identity_cache: dict[tuple[int, int, int], _SchemaFreeScoreCacheEntry] = {}
 
 
 @dataclass(frozen=True, slots=True)
@@ -322,7 +325,7 @@ def _score_json_result(
     output_schema = profile.output_schema
     if not output_schema:
         try:
-            return _cached_schema_free_json_scoring_outcome(
+            return _schema_free_json_scoring_outcome(
                 target=target,
                 extracted_result=extracted_result,
                 ignored_paths=profile.ignored_paths,
@@ -357,6 +360,39 @@ def _loads_json_payload(payload: str) -> Any:
 @lru_cache(maxsize=128)
 def _ignored_paths_for_profile(profile_ignored_paths: tuple[str, ...]) -> frozenset[str]:
     return _DEFAULT_IGNORED_PATHS | frozenset(profile_ignored_paths)
+
+
+def _schema_free_json_scoring_outcome(
+    *,
+    target: str,
+    extracted_result: str,
+    ignored_paths: tuple[str, ...],
+) -> ScoringOutcome:
+    cache_key = (id(target), id(extracted_result), id(ignored_paths))
+    cache_entry = _schema_free_score_identity_cache.get(cache_key)
+    if cache_entry is not None:
+        cached_target, cached_extracted_result, cached_ignored_paths, cached_outcome = cache_entry
+        if (
+            cached_target is target
+            and cached_extracted_result is extracted_result
+            and cached_ignored_paths is ignored_paths
+        ):
+            return cached_outcome
+
+    outcome = _cached_schema_free_json_scoring_outcome(
+        target=target,
+        extracted_result=extracted_result,
+        ignored_paths=ignored_paths,
+    )
+    if len(_schema_free_score_identity_cache) >= _SCHEMA_FREE_SCORE_IDENTITY_CACHE_LIMIT:
+        _schema_free_score_identity_cache.clear()
+    _schema_free_score_identity_cache[cache_key] = (
+        target,
+        extracted_result,
+        ignored_paths,
+        outcome,
+    )
+    return outcome
 
 
 @lru_cache(maxsize=128)


### PR DESCRIPTION
## Summary
- Add a bounded identity cache in schema-free final-result JSON scoring so repeated calls with the same target/result/ignored-path objects avoid re-hashing large ignored-path tuples before the existing LRU cache.
- Add regression coverage for the identity-cache fast path and bounded cache behavior.

## Plan or Spec
- Governing spec: `docs/superpowers/specs/2026-04-13-structured-output-evaluation-profile-design.md` for deterministic final-result extraction and typed scoring.
- Registered PR-scoped probe: `Evaluation final-result JSON typed-score running aggregate` in `infra/perf/pr_scoped_probes.json`.
- No behavior or workflow contract change; this is an internal cache fast path for identical schema-free scoring inputs.

## Commands Run
```text
$ git fetch origin && git worktree add -b perf/evaluation-json-list-item-fastpath-20260718 /root/.hermes/profiles/coder/workspace/worktrees/melix-evaluation-json-list-item-fastpath-20260718 origin/main
OK; branch created at 62b23c7f.

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py::test_schema_free_json_scoring_reuses_identity_cache_before_hashing_ignored_paths
1 passed in 0.17s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
47 passed in 0.33s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_evaluation_final_result_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_evaluation_json_typed_score_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/evaluation_final_result.py services/mlx-worker-python/tests/test_evaluation_final_result.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/evaluation_json_typed_score_probe.py
47 passed in 0.46s; TOTAL 48 0 100%

$ git diff --check
OK
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 48 0 100%`.
- Local registered probe (`scripts/evaluation_json_typed_score_probe.py`) repeated 3x against base and head on Linux:
  - base elapsed mean samples: 14.423496974632144, 17.408116813749075, 14.011929463595152 ms; mean `15.281181083992124` ms.
  - head elapsed mean samples: 13.034619996324182, 15.1229212526232, 12.30387301184237 ms; mean `13.487138086929917` ms.
  - delta: `-1.7940429970622063` ms; speedup: `11.740211618469496%`.
  - peak bytes: base `713689.8`, head `713851.4`, delta `+161.59999999997672` bytes (`+0.022642890510692%`, below 5% warning threshold).
  - score checksum unchanged: `35.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and integration gates were not run locally; this slice used the registered focused test, coverage, and probe commands on Linux.
- No Swift runtime validation is claimed; this is a Python-only slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs. (N/A: internal cache optimization only; no behavior/workflow contract change.)
- [x] Protocol changes include regenerated generated artifacts. (N/A: no protocol changes.)
- [x] Dependency changes include updated lockfiles. (N/A: no dependency changes.)
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. (N/A: no observability-mode change; probe overhead measured by registered local probe and CI report.)
- [x] Deferred work and known gaps are stated explicitly.
