### PR TITLE
perf: bind prompt token counter for generate usage

### DIFF
--- a/docs/plans/2026-07-18-engine-prompt-token-counter-bind.md
+++ b/docs/plans/2026-07-18-engine-prompt-token-counter-bind.md
@@ -1,0 +1,29 @@
+# Engine generate prompt token counter binding
+
+## Slice
+
+Optimize the generate usage trailer path in `services/mlx-worker-python/worker/engine/engine_core.py` by resolving the optional runtime `prompt_token_count` callable once per request instead of probing the runtime attribute at usage-finalization time.
+
+## Registered probe
+
+The affected path is covered by registered PR-scoped probe `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/engine_core.py`
+- `services/mlx-worker-python/tests/test_generate_stream.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/engine_generate_usage_token_probe.py`
+
+## Optimization hypothesis
+
+Usage accounting only needs to know whether the runtime provides `prompt_token_count`. Binding that optional callable once keeps behavior equivalent while removing repeated attribute-existence checks from the usage fallback path. Requests with `return_usage=false` keep the value as `None` and continue to avoid prompt-token accounting work.
+
+## Validation plan
+
+1. Run the focused tests from the registered probe locally on Linux.
+2. Run the changed-scope coverage command from the registered probe locally on Linux.
+3. Run the registered probe locally on Linux before and after the change and compare `fallback_elapsed_ms_mean`, `elapsed_ms_mean`, and counter metrics.
+4. Use GitHub Actions PR-scoped performance as the final registered probe validation and merge gate.
+
+## Acceptance
+
+Accept only if behavior tests pass, changed-scope coverage remains at or above 95%, and the registered probe does not regress usage-elision counters while improving or holding elapsed metrics within noise.

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -397,6 +397,7 @@ class EngineCore:
         effective_sampling = self._sampling_with_resolved_stop(sampling, stop_contract.sequences)
         prompt_tokens_default: int | None = None
         track_usage = bool(request.return_usage)
+        prompt_token_counter = getattr(runtime, "prompt_token_count", None) if track_usage else None
         completion_token_count = 0
         finalized_prompt_tokens: int = 0
         finalized_completion_tokens: int = 0
@@ -627,8 +628,8 @@ class EngineCore:
                 else:
                     if prompt_tokens_default is None:
                         prompt_tokens_default = int(
-                            runtime.prompt_token_count(prompt)
-                            if hasattr(runtime, "prompt_token_count")
+                            prompt_token_counter(prompt)
+                            if prompt_token_counter is not None
                             else _whitespace_token_count(prompt)
                         )
                     prompt_tokens = prompt_tokens_default


### PR DESCRIPTION
## Summary
- Bind the optional runtime `prompt_token_count` callable once per generate request when usage accounting is requested.
- Keep `return_usage=false` requests on the existing elision path and preserve the whitespace fallback for runtimes without a prompt-token counter.

## Plan or Spec
- `docs/plans/2026-07-18-engine-prompt-token-counter-bind.md`
- Registered probe: `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py` on `origin/main` baseline
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py` on this branch
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `49 passed in 1.01s`.
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Registered local probe baseline (`origin/main`): `elapsed_ms_mean=36.529126`, `fallback_elapsed_ms_mean=141.343998`, `fallback_peak_bytes_mean=86476.8`, `prompt_token_count_calls_mean=0.0`, `request_state_append_calls_mean=0.0`.
- Registered local probe branch: `elapsed_ms_mean=34.625059`, `fallback_elapsed_ms_mean=140.497247`, `fallback_peak_bytes_mean=86926.6`, `prompt_token_count_calls_mean=0.0`, `request_state_append_calls_mean=0.0`.
- Delta: `elapsed_ms_mean=-1.904068ms` (~5.21% faster), `fallback_elapsed_ms_mean=-0.846751ms` (~0.60% faster), peak memory +449.8 bytes (~0.52%, treated as noise).

## Known Gaps
- Linux local validation covers the Python generate usage path only.
- Final registered probe validation must come from GitHub Actions PR-scoped performance.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe was run locally against `origin/main` and this branch.
- [ ] GitHub Actions PR-scoped performance completed successfully.
