### PR TITLE
perf: scan Gemma README markers backwards

### DIFF
--- a/docs/plans/2026-06-08-model-registry-readme-source-fastpath.md
+++ b/docs/plans/2026-06-08-model-registry-readme-source-fastpath.md
@@ -25,6 +25,16 @@ and speedup.
 4. Run the registered local test, changed-scope coverage, and probe on Linux;
    GitHub PR-scoped performance remains the merge gate.
 
+## 2026-07-18 quoted-marker backwards precheck
+
+This follow-up slice keeps the same parser behavior and registered probe while
+using `str.rfind` for the pre-quoted-marker validation scan. The common quoted
+Gemma 4 QAT README path only needs to know whether a valid earlier line-start
+`base_model:` marker exists before the quote-wrapped marker, so scanning
+backwards starts nearest to the quoted marker and avoids a forward pass over the
+whole model card when there is no earlier marker. Line-start, quoted, and
+fallback-source semantics remain unchanged.
+
 ## Verification commands
 
 ```bash

--- a/services/mlx-worker-python/worker/model_registry/catalog.py
+++ b/services/mlx-worker-python/worker/model_registry/catalog.py
@@ -2037,12 +2037,12 @@ def _gemma4_qat_source_model(
     quoted_marker_index = readme_text.find(_GEMMA4_QAT_QUOTED_BASE_MODEL_MARKER)
     if quoted_marker_index >= 0:
         quoted_marker_start = quoted_marker_index + len("\n  '")
-        marker_index = readme_text.find(marker, 0, quoted_marker_start)
+        marker_index = readme_text.rfind(marker, 0, quoted_marker_start)
         while marker_index >= 0:
             line_start = readme_text.rfind("\n", 0, marker_index) + 1
             if not readme_text[line_start:marker_index].strip(" \t\r'\""):
                 break
-            marker_index = readme_text.find(marker, marker_index + 1, quoted_marker_start)
+            marker_index = readme_text.rfind(marker, 0, marker_index)
         if marker_index >= 0:
             quoted_marker_index = -1
     if quoted_marker_index >= 0:


### PR DESCRIPTION
## Summary
- Change the Gemma 4 QAT README source parser to scan backward when validating whether an earlier line-start `base_model:` marker precedes a quoted marker.
- Keep parser semantics unchanged while reducing the common late quoted-marker probe path.

## Plan or Spec
- `docs/plans/2026-06-08-model-registry-readme-source-fastpath.md`
- Registered PR-scoped probe: `model-registry-readme-source-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_registry_catalog.py::test_raw_model_spec_loads_config_payload_when_not_supplied services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_direct_mlx_signal_accepts_exact_and_normalized_values services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_has_mlx_signal_skips_json_for_direct_metadata services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_payload_has_mlx_signal_does_not_request_sorted_json services/mlx-worker-python/tests/test_model_registry_catalog.py::test_metadata_text_has_mlx_signal_short_circuits_negative_metadata services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_keeps_gemma4_qat_target_when_readme_mentions_assistant services/mlx-worker-python/tests/test_model_registry_catalog.py::test_gemma4_qat_source_model_rejects_non_marker_prefix_without_prefix_strip services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_snapshot_marks_gemma4_qat_assistant_as_draft_companion services/mlx-worker-python/tests/test_model_registry_catalog.py::test_registry_root_tree_records_plain_local_weight_presence_during_single_scandir_pass services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_model_registry_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_model_registry_readme_source_probe_command_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 13 passed in 4.40s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused selection> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_registry/catalog.py services/mlx-worker-python/tests/test_model_registry_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/model_registry_readme_source_probe.py
# 13 passed in 5.65s; TOTAL 2 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_registry_readme_source_probe.py
# {"new_elapsed_ms_mean": 0.08174397982656956, "new_peak_bytes_mean": 413, "old_elapsed_ms_mean": 2.896694228053093, "speedup": 35.43617810386532, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id model-registry-readme-source-fastpath --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/model_registry_readme_source_rfind_probe.json
# coverage_ok=true; coverage_pct=100.0; base_new_elapsed_ms_mean=0.116110516525805; head_new_elapsed_ms_mean=0.06883892063051462; speedup_head_over_base=1.6866986795016077; peak stayed 413 bytes

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100.00% (`TOTAL 2 0 100%`).
- Registered local probe (`model-registry-readme-source-fastpath`) base vs head:
  - `base_new_elapsed_ms_mean=0.116110516525805 ms`
  - `head_new_elapsed_ms_mean=0.06883892063051462 ms`
  - `delta_ms=-0.04727159589529037 ms`
  - `speedup=1.6866986795016077x`
  - `base_new_peak_bytes_mean=413`, `head_new_peak_bytes_mean=413`
- CI PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- Full repository gates were not run locally; this is a focused Python performance slice. GitHub Actions is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: existing PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
