### PR TITLE
perf: bind dataset record path id conversion

### DIFF
--- a/docs/plans/2026-07-18-dataset-record-path-id-local-bind-performance.md
+++ b/docs/plans/2026-07-18-dataset-record-path-id-local-bind-performance.md
@@ -1,0 +1,52 @@
+# Dataset Record Path ID Local Bind Performance Slice
+
+## Scope
+
+This slice keeps dataset ingest record behavior unchanged and narrows the hot
+path inside `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+The target is `_record()` source-id generation while the registered dataset
+source records probe builds thousands of source record payloads.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+## Implementation Plan
+
+1. Preserve record source-id and source-uri semantics with focused regression
+   assertions in `test_dataset_preparation_ingest.py`.
+2. Bind `os.fspath` at module scope and use it directly in `_record()` to avoid
+   repeated global `str` conversion lookup on the per-record source-id hot path.
+3. Run the registered focused tests, changed-scope coverage, and local Linux
+   `dataset-source-records-scandir` probe before pushing.
+4. Let the PR-scoped performance workflow validate the registered probe in CI
+   before merge.
+
+## Linux Probe Notes
+
+Pre-change local probe from synced `origin/main` worktree:
+
+```text
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" \
+MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=7 \
+uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
+
+record_elapsed_ms_mean=19.496, elapsed_ms_mean=13.119, source_kind_elapsed_ms_mean=20.048
+```
+
+Initial post-change local probe:
+
+```text
+record_elapsed_ms_mean=19.006, elapsed_ms_mean=11.954, source_kind_elapsed_ms_mean=19.305
+```
+
+The authoritative merge gate remains the registered PR-scoped performance CI
+report.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -240,6 +240,8 @@ def test_dataset_ingest_record_reuses_normalized_text_digest_cache() -> None:
     assert first_record["byte_size"] == second_record["byte_size"] == len(b"hello\n")
     assert first_record["source_id"] == hashlib.sha256(b"first.txt").hexdigest()[:16]
     assert second_record["source_id"] == hashlib.sha256(b"second.txt").hexdigest()[:16]
+    assert first_record["source_uri"] == "first.txt"
+    assert second_record["source_uri"] == "second.txt"
     assert first_record["source_id"] != second_record["source_id"]
 
 

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -52,6 +52,7 @@ _CODE_SOURCE_LANGUAGE_BY_SUFFIX = {
 _SOURCE_KIND_NAME_CACHE_MAX = 4096
 _SOURCE_KIND_BY_NAME: dict[str, str | None] = {}
 _SHA256 = hashlib.sha256
+_OS_FSPATH = os.fspath
 _MISSING = object()
 
 
@@ -1527,7 +1528,7 @@ def _record(
     content_sha256, byte_size = _record_content_digest_and_size(normalized_text)
     record_metadata = dict(metadata) if metadata else {}
     sha256 = _SHA256
-    path_key = str(path).encode("utf-8")
+    path_key = _OS_FSPATH(path).encode("utf-8")
     return {
         "source_id": sha256(path_key).hexdigest()[:16],
         "source_uri": path.name,


### PR DESCRIPTION
## Summary
- Bind `os.fspath` at module scope and use it in dataset ingest `_record()` source-id generation.
- Add regression assertions that the normalized digest cache path still preserves source URI and per-path source IDs.
- Document the performance slice and registered probe coverage.

## Plan or Spec
- `docs/plans/2026-07-18-dataset-record-path-id-local-bind-performance.md`

## Commands Run
```text
# Baseline probe from synced origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=7 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# exit 0; record_elapsed_ms_mean=19.49571748264134; elapsed_ms_mean=13.118569107194032

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting
# exit 0; 47 passed in 2.11s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py
# exit 0; 47 passed in 1.36s; TOTAL 4 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" MELIX_DATASET_SOURCE_RECORDS_PROBE_SAMPLES=11 uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py
# exit 0; record_elapsed_ms_mean=18.94466807557778; elapsed_ms_mean=12.104302263734015

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Registered probe: `dataset-source-records-scandir` covers the changed path with focused test, coverage, and probe commands in `infra/perf/pr_scoped_probes.json`.
- Local Linux probe delta (baseline samples=7 vs post-change samples=11): `record_elapsed_ms_mean` 19.496 ms -> 18.945 ms (`delta=-0.551 ms`, `speedup=1.029x`).
- CI PR-scoped performance report is required before merge and is the authoritative registered-probe validation.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this PR uses the registered focused Python gate for the touched path.
- No protocol, dependency, or generated artifact changes.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
