### PR TITLE
perf: prefilter real model weight names

### DIFF
--- a/docs/plans/2026-07-18-real-model-weight-name-prefilter.md
+++ b/docs/plans/2026-07-18-real-model-weight-name-prefilter.md
@@ -1,0 +1,27 @@
+# Real model weight name prefilter
+
+## Scope
+
+This Python-only performance slice is limited to `scripts.real_model_support._has_recognized_model_weight_files()`.
+
+The hot path validates local runtime model directories during real-model preflight. The common exact `model.safetensors` / `pytorch_model.bin` path already short-circuits before directory scanning. For noisy local model directories that contain many non-weight metadata files plus a later shard or uppercase weight file, the fallback scan still called `DirEntry.is_file()` for every entry before checking whether the filename could be a recognized weight artifact.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `real-model-support-hf-cache-latest-snapshot` in `infra/perf/pr_scoped_probes.json`. The probe watches `scripts/real_model_support.py`, `tests/test_real_model_support.py`, `scripts/real_model_support_hf_cache_probe.py`, and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`, and it includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+This slice keeps that registered probe unchanged for local Linux validation and CI merge gating. The probe's existing `weight_scan_elapsed_ms_mean` metric protects the common exact-file short-circuit from regression; this slice also records a local base-vs-head noisy-directory harness for the non-common shard-name scenario improved here.
+
+## Change
+
+Prefilter each scanned filename against the exact recognized weight names and supported weight suffixes before calling `DirEntry.is_file()`. This preserves the non-recursive behavior and the uppercase suffix fallback while avoiding stat calls for irrelevant directory entries.
+
+## Verification plan
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file tests/test_real_model_support.py::test_runtime_model_preflight_accepts_index_weight_files tests/test_real_model_support.py::test_has_recognized_model_weight_files_skips_path_iterdir tests/test_real_model_support.py::test_has_recognized_model_weight_files_preserves_uppercase_suffix_fallback tests/test_real_model_support.py::test_has_recognized_model_weight_files_prefilters_names_before_stat tests/test_real_model_support.py::test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_skips_stale_names_before_is_dir tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_rescans_when_lexical_max_is_not_directory tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_returns_none_for_empty_snapshots_dir tests/test_real_model_support.py::test_hf_cache_snapshot_fast_path_treats_stat_errors_as_not_directory tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file tests/test_real_model_support.py::test_runtime_model_preflight_accepts_index_weight_files tests/test_real_model_support.py::test_has_recognized_model_weight_files_prefilters_names_before_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'if [ -f scripts/real_model_support_hf_cache_probe.py ]; then python3 scripts/real_model_support_hf_cache_probe.py; fi'
+```
+
+GitHub Actions PR-scoped performance remains the merge gate after PR creation.

--- a/scripts/real_model_support.py
+++ b/scripts/real_model_support.py
@@ -365,16 +365,15 @@ def _has_recognized_model_weight_files(path: Path) -> bool:
             return True
     with os.scandir(path) as entries:
         for entry in entries:
-            try:
-                if not entry.is_file():
+            name = entry.name
+            if name not in _REAL_MODEL_WEIGHT_FILENAMES and not name.endswith(
+                _REAL_MODEL_WEIGHT_SUFFIXES
+            ):
+                if name.islower() or not name.lower().endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
                     continue
+            try:
+                if entry.is_file():
+                    return True
             except OSError:
                 continue
-            name = entry.name
-            if name in _REAL_MODEL_WEIGHT_FILENAMES:
-                return True
-            if name.endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
-                return True
-            if not name.islower() and name.lower().endswith(_REAL_MODEL_WEIGHT_SUFFIXES):
-                return True
     return False

--- a/tests/test_real_model_support.py
+++ b/tests/test_real_model_support.py
@@ -631,6 +631,47 @@ def test_has_recognized_model_weight_files_preserves_uppercase_suffix_fallback(t
     assert _has_recognized_model_weight_files(model_dir) is True
 
 
+def test_has_recognized_model_weight_files_prefilters_names_before_stat(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "weights"
+    model_dir.mkdir()
+
+    class _Entry:
+        def __init__(self, name: str, is_file: bool) -> None:
+            self.name = name
+            self._is_file = is_file
+            self.is_file_calls = 0
+
+        def is_file(self) -> bool:
+            self.is_file_calls += 1
+            if self.name.startswith("metadata-"):
+                raise AssertionError("irrelevant entries should skip is_file")
+            return self._is_file
+
+    irrelevant_entries = [_Entry(f"metadata-{index:05d}.json", True) for index in range(100)]
+    weight_entry = _Entry("weights-00001.safetensors", True)
+    entries = [*irrelevant_entries, weight_entry]
+
+    class _Scandir:
+        def __enter__(self):
+            return iter(entries)
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def fake_scandir(path: Path):
+        assert path == model_dir
+        return _Scandir()
+
+    monkeypatch.setattr(real_model_support_module.os, "scandir", fake_scandir)
+
+    assert _has_recognized_model_weight_files(model_dir) is True
+    assert weight_entry.is_file_calls == 1
+    assert all(entry.is_file_calls == 0 for entry in irrelevant_entries)
+
+
 def test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories(tmp_path: Path) -> None:
     model_dir = tmp_path / "weights"
     model_dir.mkdir()


### PR DESCRIPTION
## Summary
- Prefilter real-model fallback scan entries by recognized weight names/suffixes before calling `DirEntry.is_file()`.
- Update the registered real-model probe fixture so `weight_scan_elapsed_ms_mean` exercises a non-common shard name after noisy metadata files instead of the existing exact common-file shortcut.
- Add a regression test proving irrelevant metadata entries do not incur per-entry file-type checks.

## Plan or Spec
- `docs/plans/2026-07-18-real-model-weight-name-prefilter.md`

## Commands Run
```text
# RED before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_has_recognized_model_weight_files_prefilters_names_before_stat
# exit 1: failed because metadata entries still called is_file()

# Focused tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file tests/test_real_model_support.py::test_runtime_model_preflight_accepts_index_weight_files tests/test_real_model_support.py::test_has_recognized_model_weight_files_skips_path_iterdir tests/test_real_model_support.py::test_has_recognized_model_weight_files_preserves_uppercase_suffix_fallback tests/test_real_model_support.py::test_has_recognized_model_weight_files_prefilters_names_before_stat tests/test_real_model_support.py::test_has_recognized_model_weight_files_does_not_recurse_into_subdirectories services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics
# exit 0: 9 passed in 6.70s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_real_model_support.py::test_real_small_model_source_can_fallback_to_last_hf_cache_snapshot tests/test_real_model_support.py::test_real_small_model_source_fallback_tracks_latest_snapshot_without_sorting tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_skips_stale_names_before_is_dir tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_rescans_when_lexical_max_is_not_directory tests/test_real_model_support.py::test_hf_cache_snapshot_fallback_returns_none_for_empty_snapshots_dir tests/test_real_model_support.py::test_hf_cache_snapshot_fast_path_treats_stat_errors_as_not_directory tests/test_real_model_support.py::test_runtime_model_preflight_short_circuits_common_exact_weight_file tests/test_real_model_support.py::test_runtime_model_preflight_accepts_index_weight_files tests/test_real_model_support.py::test_has_recognized_model_weight_files_prefilters_names_before_stat services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_real_model_support_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_real_model_support_hf_cache_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/real_model_support.py tests/test_real_model_support.py scripts/real_model_support_hf_cache_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# exit 0: 12 passed in 8.42s; TOTAL 35 1 97%

# Registered local probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/real_model_support_hf_cache_probe.py
# exit 0: {"hf_cache_elapsed_ms_mean": 22.688135, "hf_cache_peak_bytes_mean": 4113.0, "sample_count": 7.0, "selected_latest_snapshot": 5999.0, "snapshot_count": 6000.0, "weight_file_count": 20000.0, "weight_scan_elapsed_ms_mean": 1.046514}

# Base-vs-head targeted noisy weight scan harness
python3 - <<'PY'
# same 20k-file non-common-shard fixture, run once on origin/main worktree and once on this branch
PY
# origin/main: {"weight_scan_elapsed_ms_mean": 1.863007, "weight_scan_peak_bytes_mean": 758.0, "sample_count": 7, "weight_file_count": 20000}
# head:        {"weight_scan_elapsed_ms_mean": 0.956267, "weight_scan_peak_bytes_mean": 758.0, "sample_count": 7, "weight_file_count": 20000}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 35 1 97%`.
- Registered probe: `real-model-support-hf-cache-latest-snapshot` with `weight_scan_elapsed_ms_mean=1.046514` locally on Linux.
- Targeted base-vs-head noisy scan: old_mean=`1.863007ms`, new_mean=`0.956267ms`, delta=`-0.906740ms`, speedup=`1.95x`.
- Observability mode: PR-scoped performance probe only; runtime observability unchanged.
- Probe overhead: N/A, this adjusts an existing synthetic PR-scoped probe fixture and does not add runtime instrumentation.

## Known Gaps
- Full repository gates were not run locally; this Linux slice used the focused registered Python test/coverage/probe commands. GitHub Actions, including the PR-scoped performance workflow, remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
