### PR TITLE
perf: inline LoRA quantized boundary checks

### DIFF
--- a/docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md
+++ b/docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md
@@ -23,9 +23,15 @@ The behavior remains unchanged for whitespace-padded values and embedded suffix 
 
 This follow-up keeps the same Python-only boundary and registered `lora-aux-modules-scandir` probe. The quantized-kind parser only needs the existing `(?<![a-z0-9])... (?![a-z0-9])` delimiter semantics, so it now uses direct `str.find()` plus ASCII lower-alphanumeric boundary checks instead of dispatching through compiled regex searches for each candidate kind. Behavior remains unchanged for lowercase, uppercase, whitespace-padded, hyphen-delimited, and non-ASCII-delimited markers, while substring false positives such as `not-a-q4suffix` remain rejected.
 
+### 2026-07-18 boundary inline-ASCII follow-up
+
+This follow-up stays inside the same parser and registered probe. `_quantized_kind_from_text()` keeps the fixed quantized-kind priority order but unrolls the tiny candidate set to avoid tuple iteration overhead on every LoRA metadata parse. `_contains_quantized_kind_token()` now evaluates the ASCII alphanumeric boundary checks inline after each `str.find()` hit, avoiding helper dispatch in the inner scan loop while preserving the existing direct-substring gate and delimiter semantics. The change keeps the case where an early embedded false-positive token such as `badq4` is skipped and a later delimited `q4` token is accepted.
+
 ## Verification plan
 
 Run the registered focused tests, changed-scope coverage command, and the registered local probe on Linux before opening the PR. For the ASCII boundary follow-up, compare the registered probe against `origin/main` locally; the PR-scoped performance workflow remains the merge gate for the registered probe result in CI.
+
+For the 2026-07-18 follow-up, use the same `lora-aux-modules-scandir` registered probe locally on Linux and in PR-scoped performance CI. No registry change is required because the entry already watches the parser, focused tests, probe script, and this plan.
 
 ## Expected metrics
 

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5656,6 +5656,7 @@
       "services/mlx-worker-python/tests/test_lora_training_receipts.py",
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/lora_aux_modules_scandir_probe.py",
+      "docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md",
       "docs/plans/2026-07-12-lora-processor-resume-direct-checks.md",
       "docs/plans/2026-07-12-lora-aux-prefix-char-membership.md"
     ],

--- a/services/mlx-worker-python/tests/test_lora_training_receipts.py
+++ b/services/mlx-worker-python/tests/test_lora_training_receipts.py
@@ -626,10 +626,15 @@ def test_lora_processor_resume_mode_returns_missing_without_resume_assets(
 def test_lora_quantized_kind_detection_uses_ascii_token_boundaries() -> None:
     assert lora_runtime_metadata_module._quantized_kind_from_text("mlx q4 adapter") == "q4"
     assert lora_runtime_metadata_module._quantized_kind_from_text(" \tq8\n") == "q8"
+    assert lora_runtime_metadata_module._quantized_kind_from_text("MLX 4BIT ADAPTER") == "4bit"
+    assert lora_runtime_metadata_module._quantized_kind_from_text("MLX 8BIT ADAPTER") == "8bit"
     assert lora_runtime_metadata_module._quantized_kind_from_text("MLX Q4 ADAPTER") == "q4"
+    assert lora_runtime_metadata_module._quantized_kind_from_text("MLX Q8 ADAPTER") == "q8"
+    assert lora_runtime_metadata_module._quantized_kind_from_text("MLX OPTIQ ADAPTER") == "optiq"
     assert lora_runtime_metadata_module._quantized_kind_from_text("not-a-q4suffix") == "unknown"
     assert lora_runtime_metadata_module._quantized_kind_from_text("q4-mlx") == "q4"
     assert lora_runtime_metadata_module._quantized_kind_from_text("模型q4版本") == "q4"
+    assert lora_runtime_metadata_module._quantized_kind_from_text("badq4 q4") == "q4"
 
 
 def test_lora_quantized_kind_detection_skips_boundary_scan_without_substring(

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -418,15 +418,30 @@ def _str_value(raw_value: Any) -> str:
 def _quantized_kind_from_text(raw_value: str) -> str:
     # The token boundary only needs ASCII [a-z0-9] checks; avoid regex dispatch
     # in this hot parser loop while preserving the same delimiter semantics.
-    for kind in _QUANTIZED_KIND_ORDER:
-        if kind in raw_value and _contains_quantized_kind_token(raw_value, kind):
-            return kind
+    contains_kind_token = _contains_quantized_kind_token
+    if "4bit" in raw_value and contains_kind_token(raw_value, "4bit"):
+        return "4bit"
+    if "8bit" in raw_value and contains_kind_token(raw_value, "8bit"):
+        return "8bit"
+    if "q4" in raw_value and contains_kind_token(raw_value, "q4"):
+        return "q4"
+    if "q8" in raw_value and contains_kind_token(raw_value, "q8"):
+        return "q8"
+    if "optiq" in raw_value and contains_kind_token(raw_value, "optiq"):
+        return "optiq"
     normalized = raw_value.lower()
     if normalized == raw_value:
         return "unknown"
-    for kind in _QUANTIZED_KIND_ORDER:
-        if kind in normalized and _contains_quantized_kind_token(normalized, kind):
-            return kind
+    if "4bit" in normalized and contains_kind_token(normalized, "4bit"):
+        return "4bit"
+    if "8bit" in normalized and contains_kind_token(normalized, "8bit"):
+        return "8bit"
+    if "q4" in normalized and contains_kind_token(normalized, "q4"):
+        return "q4"
+    if "q8" in normalized and contains_kind_token(normalized, "q8"):
+        return "q8"
+    if "optiq" in normalized and contains_kind_token(normalized, "optiq"):
+        return "optiq"
     return "unknown"
 
 
@@ -439,16 +454,18 @@ def _contains_quantized_kind_token(value: str, kind: str) -> bool:
         if index < 0:
             return False
         end = index + kind_length
-        if (
-            (index == 0 or not _is_lower_ascii_alnum(value[index - 1]))
-            and (end == value_length or not _is_lower_ascii_alnum(value[end]))
-        ):
-            return True
+        if index == 0:
+            left_boundary = True
+        else:
+            char = value[index - 1]
+            left_boundary = not ("a" <= char <= "z" or "0" <= char <= "9")
+        if left_boundary:
+            if end == value_length:
+                return True
+            char = value[end]
+            if not ("a" <= char <= "z" or "0" <= char <= "9"):
+                return True
         start = index + 1
-
-
-def _is_lower_ascii_alnum(char: str) -> bool:
-    return "a" <= char <= "z" or "0" <= char <= "9"
 
 
 def _quantized_target_module_guard_status(


### PR DESCRIPTION
## Summary
- Inline the fixed LoRA quantized-kind candidate checks to avoid tuple iteration in the hot parser path.
- Inline ASCII boundary checks inside `_contains_quantized_kind_token()` while preserving delimiter semantics.
- Extend focused regression coverage for uppercase markers and a later valid token after an embedded false positive.

## Plan or Spec
- `docs/plans/2026-06-03-lora-quantized-kind-strip-elision.md`
- Registered PR-scoped probe: `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...lora registered focused tests...
# 16 passed in 0.30s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...lora registered focused tests...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py
# TOTAL 36 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_aux_modules_scandir_probe.py
# head quantized_kind_optimized_elapsed_ms_mean=6.0699018982372115, iteration_count=12000

MELIX_LORA_AUX_MODULES_PROBE_SAMPLES=15 MELIX_LORA_QUANTIZED_KIND_PROBE_ITERATIONS=60000 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/lora_aux_modules_scandir_probe.py
# head quantized_kind_optimized_elapsed_ms_mean=29.68178374382357, iteration_count=60000

git diff --check
# pass
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 36 0 100%`.
- Local Linux registered probe (`lora-aux-modules-scandir`, default): origin/main `quantized_kind_optimized_elapsed_ms_mean=6.443522571186934`; head `6.0699018982372115`; delta `-0.3736206729497221 ms`; speedup `1.0616x`.
- Local Linux high-sample probe (`MELIX_LORA_AUX_MODULES_PROBE_SAMPLES=15`, `MELIX_LORA_QUANTIZED_KIND_PROBE_ITERATIONS=60000`): origin/main `31.8732481294622`; head `29.68178374382357`; delta `-2.191464385638628 ms`; speedup `1.0738x`.
- PR-scoped performance CI is still required as the merge gate for the registered probe report.

## Known Gaps
- Swift/macOS runtime effects: N/A, Python-only parser slice verified locally on Linux.
- Full repository `make py-test` / `make integration-test` not run locally; scoped registered tests, changed-scope coverage, and registered probe were run.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A, no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A, no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
