### PR TITLE
perf: guard LoRA auxiliary suffix checks

### DIFF
--- a/docs/plans/2026-07-18-lora-aux-py-last-char.md
+++ b/docs/plans/2026-07-18-lora-aux-py-last-char.md
@@ -1,0 +1,29 @@
+# LoRA Auxiliary Module `.py` Suffix Last-Character Guard
+
+## Context
+
+The registered PR-scoped probe `lora-aux-modules-scandir` covers LoRA runtime metadata auxiliary module detection in `worker.model_ops.lora_runtime_metadata`. The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries for the affected path.
+
+`_aux_modules_restored()` scans base-model directory entries and filters likely auxiliary Python sidecars by first-character prefix, `.py` suffix, and full auxiliary prefix. On noisy directories, most candidates are not Python files. This slice adds a cheap final-character guard before the full `.endswith(".py")` suffix check so non-`.py` entries can skip the full suffix comparison while preserving the existing prefix and suffix semantics.
+
+## Scope
+
+- Limit behavior change to `_aux_modules_restored()` in `services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py`.
+- Keep the single `os.scandir()` pass and existing `OSError` fallback behavior.
+- Do not change processor-resume or quantized-kind detection behavior covered by the same registered probe.
+
+## Measurement
+
+Registered probe: `lora-aux-modules-scandir`
+
+Required local Linux commands:
+
+- Focused registry test command for `lora-aux-modules-scandir`.
+- Changed-scope coverage command for the same registry entry.
+- Registered probe command from `infra/perf/pr_scoped_probes.json`.
+
+Success requires focused behavior tests to pass, changed-scope coverage to remain at or above 95%, and the local registered probe to show directional improvement or no regression for the auxiliary-module scandir metric. GitHub Actions PR-scoped performance remains the merge gate after push.
+
+## Linux Boundary
+
+This is a Python worker path and can be validated locally on Linux. CI remains the source of truth for the registered PR-scoped performance report after the PR is opened.

--- a/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
+++ b/services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py
@@ -344,6 +344,7 @@ def _aux_modules_restored(base_model_dir: Path) -> bool:
                 name = entry.name
                 if (
                     name[0] in auxiliary_prefix_chars
+                    and name[-1] == "y"
                     and name.endswith(".py")
                     and name.startswith(auxiliary_prefixes)
                 ):


### PR DESCRIPTION
## Summary
- Add a cheap final-character guard before the full `.py` suffix check in LoRA auxiliary module detection.
- Keep the existing single-`os.scandir()` scan and `OSError` fallback behavior unchanged.
- Add a focused plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-07-18-lora-aux-py-last-char.md`
- Registered probe: `lora-aux-modules-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_uses_single_scandir services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_aux_module_detection_returns_false_when_scandir_fails services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_json_mapping_uses_binary_read services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_uses_os_path_isfile_with_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_fallback_precedence services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_processor_resume_mode_returns_missing_without_resume_assets services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_uses_ascii_token_boundaries services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_quantized_kind_detection_skips_boundary_scan_without_substring services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_records_tokenizer_resume_and_drift_status services/mlx-worker-python/tests/test_lora_training_receipts.py::test_lora_canary_receipt_detects_missing_checkpoint_resume_assets services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_lora_aux_modules_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_sidecar_delta_metrics_are_informational services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_aux_modules_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_lora_processor_resume_probe_baseline_modes services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/lora_runtime_metadata.py services/mlx-worker-python/tests/test_lora_training_receipts.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/lora_aux_modules_scandir_probe.py`
- Registered probe command for `lora-aux-modules-scandir`.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 16 passed.
- Changed-scope coverage: 100.00% (`TOTAL 0 0 100%`; no measurable changed executable lines beyond the guarded condition line).
- Local Linux registered probe baseline on `origin/main`: `elapsed_ms_mean=1.326885340469224`, `peak_bytes_mean=815.0`, `scandir_calls_mean=1.0`.
- Local Linux registered probe after change: `elapsed_ms_mean=1.292876001181347`, `peak_bytes_mean=815.0`, `scandir_calls_mean=1.0`.
- Local delta: `elapsed_ms_mean` improved by `0.03400933928787708 ms` (`~2.56%` lower); `peak_bytes_mean` and `scandir_calls_mean` unchanged.
- CI PR-scoped performance is required as the registered probe merge gate.

## Known Gaps
- This is a Python worker path and was locally validated on Linux.
- Swift runtime effects are not involved in this slice.

## Evidence Checklist
- [x] Registered PR-scoped probe covers the affected path.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally.
- [x] Registered probe was run locally on Linux with baseline/head comparison.
- [ ] GitHub Actions PR-scoped performance completed successfully.
