### PR TITLE
perf: speed stream channel name parsing

### DIFF
--- a/docs/plans/2026-05-20-stream-assembler-channel-name-probe-coverage.md
+++ b/docs/plans/2026-05-20-stream-assembler-channel-name-probe-coverage.md
@@ -10,7 +10,20 @@ The affected stream assembler path was selected by the registered PR-scoped prob
 
 ## Probe-only decision
 
-A candidate implementation that replaced `split(maxsplit=1)` with a Python-level single-pass whitespace scan was rejected locally because the direct microprobe regressed (`old_mean=26.863ms`, `new_mean=58.407ms`, `speedup=0.46x`). A bounded positional split variant was also rejected because the stream-assembler workload regressed (`old_mean=3.741ms`, `new_mean=4.001ms`, `speedup=0.93x`). No runtime behavior optimization is included in this PR.
+The original probe-registration slice did not include a runtime behavior optimization. A candidate implementation that replaced `split(maxsplit=1)` with a Python-level single-pass whitespace scan was rejected locally because the direct microprobe regressed (`old_mean=26.863ms`, `new_mean=58.407ms`, `speedup=0.46x`). A bounded positional split variant was also rejected because the stream-assembler workload regressed (`old_mean=3.741ms`, `new_mean=4.001ms`, `speedup=0.93x`).
+
+## 2026-07-18 split fast path follow-up
+
+`origin/main` now uses a Python-level `enumerate(...).isspace()` scan for `_pipe_channel_name(...)`. This follow-up returns the hot path to `header.strip().split(None, 1)[0].lower()` so whitespace tokenization runs in CPython's string split implementation while preserving behavior for empty headers, mixed-case channel names, tab-separated metadata, and headers without metadata.
+
+The registered `stream-assembler-parser-mode-cache` probe remains the governing PR-scoped performance probe. It watches `stream_assembler.py`, `test_stream_assembler.py`, `test_pr_scoped_performance.py`, and `scripts/stream_assembler_parser_mode_probe.py`, and includes focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+Local Linux registered probe samples on this host:
+
+- baseline `origin/main`: `4.8284132462868`, `3.7157699662202504`, `3.8718708565284032` ms; mean `4.1386846896784845` ms.
+- split fast path: `4.1309146108687855`, `3.958180532208644`, `3.952636387111852` ms; mean `4.013910510063094` ms.
+- delta: `-0.1247741796153905` ms, `3.014826555637104%` faster.
+- `channel_name_calls_mean`: unchanged at `13.0`.
 
 ## Verification plan
 

--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -21,11 +21,13 @@ def test_pipe_channel_name_caches_repeated_headers() -> None:
     assert RequestStreamAssembler._pipe_channel_name(" analysis metadata\n") == "analysis"
     assert RequestStreamAssembler._pipe_channel_name(" analysis metadata\n") == "analysis"
     assert RequestStreamAssembler._pipe_channel_name("FINAL metadata") == "final"
+    assert RequestStreamAssembler._pipe_channel_name("commentary\tmetadata") == "commentary"
+    assert RequestStreamAssembler._pipe_channel_name("analysis") == "analysis"
     assert RequestStreamAssembler._pipe_channel_name("   ") == ""
 
     cache_info = RequestStreamAssembler._pipe_channel_name.cache_info()
     assert cache_info.hits == 1
-    assert cache_info.misses == 3
+    assert cache_info.misses == 5
 
     RequestStreamAssembler._pipe_channel_name.cache_clear()
 

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1454,13 +1454,8 @@ class RequestStreamAssembler:
     @staticmethod
     @lru_cache(maxsize=16)
     def _pipe_channel_name(header: str) -> str:
-        stripped = header.strip()
-        if not stripped:
-            return ""
-        for index, character in enumerate(stripped):
-            if character.isspace():
-                return stripped[:index].lower()
-        return stripped.lower()
+        parts = header.strip().split(None, 1)
+        return parts[0].lower() if parts else ""
 
     @classmethod
     def _legacy_pipe_channel_header_body(cls, header: str, channel_name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Replace the Harmony pipe channel-name Python whitespace scan with CPython `split(None, 1)` parsing in `RequestStreamAssembler._pipe_channel_name(...)`.
- Extend the focused cache test to cover tab-separated metadata and metadata-free headers.
- Update the governing stream assembler channel-name probe plan with local baseline/head probe evidence.

## Plan or Spec
- `docs/plans/2026-05-20-stream-assembler-channel-name-probe-coverage.md`
- Registered PR-scoped probe: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
git fetch origin main --prune && git worktree add -b perf/stream-assembler-channel-split-fastpath-20260718 ... origin/main -> exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py::test_pipe_channel_name_caches_repeated_headers services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics -> 95 passed, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics && coverage json && python3 scripts/changed_scope_coverage.py ... -> TOTAL 5 0 100%, exit 0
for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py; done -> exit 0
Baseline probe was run from an origin/main worktree with the same script -> exit 0

git diff --check -> exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Registered local probe (`stream_assembler_parser_mode_probe.py`) on Linux:
  - Baseline `origin/main` elapsed samples: `4.8284132462868`, `3.7157699662202504`, `3.8718708565284032` ms; mean `4.1386846896784845` ms.
  - Head elapsed samples: `4.1309146108687855`, `3.958180532208644`, `3.952636387111852` ms; mean `4.013910510063094` ms.
  - Delta: `-0.1247741796153905` ms (`3.014826555637104%` faster).
  - `channel_name_calls_mean`: unchanged at `13.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- Remote GitHub Actions and the registered PR-scoped performance workflow must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, no observability behavior change; probe overhead is represented by the registered PR-scoped performance probe.
- [x] Deferred work and known gaps are stated explicitly.
