### PR TITLE
perf: cache retrieval store record type check

### DIFF
--- a/docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md
+++ b/docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md
@@ -27,3 +27,18 @@ Run on Linux before opening the PR:
 3. The registered probe command locally with repeated samples.
 
 GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.
+
+## Follow-up Slice: Record Type Cache
+
+The 2026-07-18 follow-up keeps the same `project_retrieval_store_records`
+boundary and registered `retrieval-context-projection-fastpath` probe. The
+valid dict-record hot path now computes the exact `dict` type check once per
+record and reuses that result for both Mapping validation and the direct
+subscript fast path. Behavior remains unchanged for plain dict records,
+Mapping subclasses, invalid record objects, projection refusals, and duplicate
+field handling; the slice only removes a repeated `type(record)` call from the
+common valid-record loop.
+
+Success is accepted only if focused tests, changed-scope coverage, and the
+local registered Linux probe pass with lower elapsed time, and if the PR-scoped
+CI probe completes successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -301,8 +301,10 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
     bool_type = bool
     type_of = type
 
+    mapping_type = Mapping
     for record in records:
-        if type_of(record) is not dict_type and not isinstance(record, Mapping):
+        record_is_dict = type_of(record) is dict_type
+        if not record_is_dict and not isinstance(record, mapping_type):
             store_refusal_receipts_append(
                 store_record_refusal(
                     source_field="record",
@@ -326,7 +328,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
             )
             continue
 
-        if type_of(record) is dict_type:
+        if record_is_dict:
             try:
                 source_id = record["source_id"]
                 payload = record["payload"]


### PR DESCRIPTION
## Summary
- Cache the exact `dict` type check once per record in `project_retrieval_store_records`.
- Reuse that cached result for Mapping validation and the direct dict subscript fast path.
- Keep Mapping subclass fallback, invalid-record refusals, duplicate handling, and receipt behavior unchanged.

## Plan or Spec
- `docs/plans/2026-06-14-retrieval-store-refusal-list-elision.md` (updated with the Record Type Cache follow-up slice).
- Registered PR-scoped probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline local registered probe on origin/main before the slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit=0
store_baseline_elapsed_ms_mean=0.30449645427454797
store_optimized_elapsed_ms_mean=0.12364717100613884
store_delta_ms=-0.18084928326840913
store_speedup=2.4626237041802623

# Focused tests from the registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...retrieval-context registered tests...
exit=0; 36 passed in 0.33s

# Changed-scope coverage from the registered probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...retrieval-context registered tests...
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
exit=0; TOTAL 4 0 100%

# Registered probe locally after the slice
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
exit=0
store_baseline_elapsed_ms_mean=0.3092481991708545
store_optimized_elapsed_ms_mean=0.13965254383427755
store_delta_ms=-0.16959565533657694
store_speedup=2.2144115007158924
optimized_elapsed_ms_mean=0.10817366569036883
speedup=9.6329451831281

# Whitespace check
git diff --check
exit=0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%`.
- Local Linux registered probe (`retrieval-context-projection-fastpath`): store path improved by `-0.16959565533657694 ms` mean (`2.2144115007158924x`) in the post-slice run.
- Full probe output: `baseline_elapsed_ms_mean=1.042030991853348`, `optimized_elapsed_ms_mean=0.10817366569036883`, `delta_ms=-0.9338573261629791`, `speedup=9.6329451831281`, `sample_count=7`, `iteration_count=400`, `entry_count=96`.
- CI PR-scoped performance remains the final registered probe validation source before merge.

## Known Gaps
- Full repository gates (`make swift-test`, `make py-test`, `make integration-test`) were not run locally; this Linux slice ran the registered focused test, coverage, and probe commands only.
- No Swift runtime effect is claimed; this is a Python worker path validated locally on Linux plus CI.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
