### PR TITLE
perf: open dataset source reads directly

### DIFF
--- a/docs/plans/2026-07-19-dataset-read-source-open-direct.md
+++ b/docs/plans/2026-07-19-dataset-read-source-open-direct.md
@@ -1,0 +1,36 @@
+# Dataset Source Reader Direct Binary Open
+
+## Scope
+
+This Python-only performance slice is limited to `_read_source_text(...)` in
+`services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+
+Dataset ingest reads every accepted source file before normalizing and segmenting
+records. The source path is already a `Path`, but the hot reader does not need
+`Path.open()` wrapper dispatch for either unbounded or capped reads. This slice
+converts the path once with `os.fspath(...)` and uses direct binary `open(...)`
+for both branches while preserving UTF-8 decoding, cap enforcement, and the
+single-read unbounded behavior.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`. The
+registry entry already includes focused `test_command`, `coverage_command`, and
+`probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_source_records_probe.py`
+
+This slice extends `scripts/dataset_source_records_probe.py` with
+`read_elapsed_ms_*` metrics so the registered probe directly measures the source
+reader in addition to traversal, classification, and record materialization.
+
+## Verification Plan
+
+Run the registered focused tests, changed-scope coverage command, `git diff --check`,
+and the registered `dataset-source-records-scandir` probe locally on Linux before
+opening the PR. GitHub Actions PR-scoped performance remains the merge gate for
+the registered probe report.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5619,6 +5619,23 @@
         "warn_pct": 5.0
       },
       {
+        "key": "read_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "read_elapsed_ms_min",
+        "unit": "ms",
+        "direction": "lower_is_better"
+      },
+      {
+        "key": "read_elapsed_ms_p95",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
         "direction": "lower_is_better",
         "key": "record_elapsed_ms_mean",
         "unit": "ms",

--- a/scripts/dataset_source_records_probe.py
+++ b/scripts/dataset_source_records_probe.py
@@ -63,6 +63,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
 def measure(*, directory_count: int, files_per_directory: int, samples: int) -> dict[str, float]:
     elapsed_ms: list[float] = []
     source_kind_elapsed_ms: list[float] = []
+    read_elapsed_ms: list[float] = []
     record_elapsed_ms: list[float] = []
     file_counts: list[float] = []
     with tempfile.TemporaryDirectory(prefix="melix-dataset-source-records-probe-") as tmp:
@@ -109,6 +110,11 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
                 if source_kinds != expected_kinds:
                     raise RuntimeError("source kind classification changed")
                 started = time.perf_counter()
+                source_texts = [dataset_preparation._read_source_text(path) for path in paths]
+                read_elapsed_ms.append((time.perf_counter() - started) * 1000.0)
+                if source_texts[0] != "Melix source row\n" or source_texts[-1] != "Melix source row\n":
+                    raise RuntimeError("source text reading changed")  # pragma: no cover - guard only.
+                started = time.perf_counter()
                 records = [
                     dataset_preparation._record(
                         path=path,
@@ -135,6 +141,9 @@ def measure(*, directory_count: int, files_per_directory: int, samples: int) -> 
         "source_kind_elapsed_ms_mean": statistics.fmean(source_kind_elapsed_ms),
         "source_kind_elapsed_ms_min": min(source_kind_elapsed_ms),
         "source_kind_elapsed_ms_p95": sorted(source_kind_elapsed_ms)[int((len(source_kind_elapsed_ms) - 1) * 0.95)],
+        "read_elapsed_ms_mean": statistics.fmean(read_elapsed_ms),
+        "read_elapsed_ms_min": min(read_elapsed_ms),
+        "read_elapsed_ms_p95": sorted(read_elapsed_ms)[int((len(read_elapsed_ms) - 1) * 0.95)],
         "record_elapsed_ms_mean": statistics.fmean(record_elapsed_ms),
         "record_elapsed_ms_min": min(record_elapsed_ms),
         "record_elapsed_ms_p95": sorted(record_elapsed_ms)[int((len(record_elapsed_ms) - 1) * 0.95)],

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -121,14 +121,14 @@ def test_dataset_ingest_unbounded_source_reader_uses_single_binary_read(
 
     counting_file = CountingBinaryFile()
 
-    def counted_open(path: Path, mode: str = "r", *args: object, **kwargs: object) -> CountingBinaryFile:
-        assert path == source_path
+    def counted_open(path: str | os.PathLike[str], mode: str = "r", *args: object, **kwargs: object) -> CountingBinaryFile:
+        assert os.fspath(path) == os.fspath(source_path)
         assert mode == "rb"
         assert args == ()
         assert kwargs == {}
         return counting_file
 
-    monkeypatch.setattr(Path, "open", counted_open)
+    monkeypatch.setattr(dataset_preparation_module, "open", counted_open, raising=False)
 
     assert _read_source_text(source_path) == "hello\nworld\n"
     assert counting_file.read_calls == 1

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1239,12 +1239,13 @@ def _source_read_cap_bytes(*, upload_cap_bytes: int, source_cap_bytes: int) -> i
 
 
 def _read_source_text(path: Path, *, cap_bytes: int = 0) -> str:
+    raw_path = os.fspath(path)
     if cap_bytes <= 0:
-        with path.open("rb") as handle:
+        with open(raw_path, "rb") as handle:
             return handle.read().decode("utf-8")
     chunks: list[bytes] = []
     observed = 0
-    with path.open("rb") as handle:
+    with open(raw_path, "rb") as handle:
         while True:
             chunk = handle.read(64 * 1024)
             if not chunk:


### PR DESCRIPTION
## Summary
- Optimize dataset ingest source reads by converting each `Path` with `os.fspath(...)` once and using direct binary `open(...)` in `_read_source_text(...)`.
- Extend the registered `dataset-source-records-scandir` probe with `read_elapsed_ms_*` metrics so the affected reader path is measured directly.
- Update the focused reader test and add the governing plan for this performance slice.

## Plan or Spec
- `docs/plans/2026-07-19-dataset-read-source-open-direct.md`
- Registered probe: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json` (existing registry entry with focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_unbounded_source_reader_uses_single_binary_read`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- Three-run baseline/head comparison using the updated registered probe script against `origin/main` and this branch.
- `git diff --check`

## Coverage and Metrics
- Focused reader test: `1 passed in 0.24s`.
- Registered focused tests: `47 passed in 1.95s`.
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Registered probe (head, default 11 samples): `read_elapsed_ms_mean=63.275123142044656`, `read_elapsed_ms_min=59.48973004706204`, `read_elapsed_ms_p95=70.17000508494675`.
- Three-run comparison for `read_elapsed_ms_mean` (9 samples/run): base mean `68.01633940388759` ms, head mean `65.17812628643932` ms, delta `-2.8382131174482623` ms, speedup `1.043545484952653x` (`4.172840147416166%`).

## Known Gaps
- Local verification was performed on Linux for this Python path. GitHub Actions PR-scoped performance is still required as the merge gate for the registered probe report.
- Non-reader metrics in the shared probe are expected to be noisy because this slice only targets `_read_source_text(...)`.

## Evidence Checklist
- [x] Worktree synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused behavior tests pass locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered probe ran locally with before/after metrics.
- [ ] GitHub Actions checks completed successfully.
- [ ] PR-scoped performance report completed successfully.
