### PR TITLE
perf: avoid native mtp nested basename slices

### DIFF
--- a/docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md
+++ b/docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md
@@ -39,3 +39,17 @@ JSON-emitting performance probe script.
 This slice changes Python worker code only. Linux local validation covers the
 Python regression tests, changed-scope coverage, and registered probe command.
 No Swift/macOS runtime effect is claimed for this slice.
+
+## Follow-up Slice: Nested Base Shard Prefix Check
+
+The 2026-07-19 follow-up keeps the same registered probe and narrows to nested
+base-shard filtering inside `_extra_mtp_safetensor_file_paths(...)`. The sidecar
+scanner already rejects top-level and nested `model*.safetensors` base shards
+before path existence checks. This slice preserves that behavior but checks the
+nested basename with `str.startswith(..., start)` instead of slicing the basename
+segment first, avoiding a short string allocation for repeated nested base-shard
+references in large native-MTP weight maps.
+
+Success is accepted only if focused tests, changed-scope coverage, and the local
+registered Linux probe pass with non-regressive or improved elapsed time, and if
+the PR-scoped CI probe completes successfully before merge.

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -108,7 +108,11 @@ def _extra_mtp_safetensor_file_paths(model_path: Path) -> list[str]:
             seen_add(file_name_text)
             continue
         separator_index = str_rfind(file_name_text, path_sep)
-        if separator_index >= 0 and str_startswith(file_name_text[separator_index + 1 :], model_prefix):
+        if separator_index >= 0 and str_startswith(
+            file_name_text,
+            model_prefix,
+            separator_index + 1,
+        ):
             seen_add(file_name_text)
             continue
         seen_add(file_name_text)


### PR DESCRIPTION
## Summary
- Avoid allocating a sliced nested basename while filtering native-MTP index entries that point at base `model*.safetensors` shards.
- Keep the sidecar shard result unchanged: top-level and nested base model shards are still skipped before existence checks, while true MTP sidecars are still returned.

## Plan or Spec
- `docs/plans/2026-07-01-native-mtp-loader-extra-path-local-bindings.md` (new 2026-07-19 follow-up slice).

## Commands Run
```text
$ git fetch origin && git reset --hard origin/main
HEAD is now at 5926b306 perf: open dataset source reads directly (#2915)

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_EXTRA_FILES=25000 MELIX_NATIVE_MTP_LOADER_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py  # baseline before edit
exit 0; new_mean_ms=13.511272380128503; old_mean_ms=12.569928169250488; speedup=0.9303289738823945

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_weight_load_probe_tolerates_loader_timer_noise_without_weakening_counts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_model_listing_probe_tolerates_loader_timer_noise_without_weakening_counts
exit 0; 13 passed in 2.60s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
exit 0; changed_line_coverage=100.00%; TOTAL 1 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_NATIVE_MTP_LOADER_REPO_ROOT="$PWD" MELIX_NATIVE_MTP_EXTRA_FILES=25000 MELIX_NATIVE_MTP_LOADER_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
exit 0; new_mean_ms=11.575377872213721; old_mean_ms=11.828198004513979; speedup=1.021841199059872; delta_ms=-0.2528201323002577; extra_new_mean_ms=45.12106780894101; extra_old_mean_ms=290.88752642273903; extra_speedup=6.4468227492856

$ git diff --check
exit 0
```

## Coverage and Metrics
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`; it already includes focused `test_command`, `coverage_command`, and `probe_command`.
- Changed-scope coverage: 100.00% for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py` changed line.
- Local Linux probe: `old_mean_ms=11.828198004513979`, `new_mean_ms=11.575377872213721`, `delta_ms=-0.2528201323002577`, `speedup=1.021841199059872`; extra-file submetric `extra_old_mean_ms=290.88752642273903`, `extra_new_mean_ms=45.12106780894101`, `extra_speedup=6.4468227492856`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python only. No Swift/macOS runtime effect is claimed for this slice.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
