### PR TITLE
perf: map dataset source paths directly

### DIFF
--- a/docs/plans/2026-06-14-dataset-source-path-map-fastpath.md
+++ b/docs/plans/2026-06-14-dataset-source-path-map-fastpath.md
@@ -32,3 +32,18 @@ focused ingest tests, PR-scoped performance tests, and
 This slice is Python-only and locally verifiable on Linux. The PR-scoped GitHub
 Actions performance workflow remains the merge gate for the registered probe
 report.
+
+## 2026-07-19 execution note
+
+The slice remains limited to replacing the final Python-level path projection
+comprehension with `list(map(path_cls, file_paths))` after deterministic string
+sorting. Behavior is unchanged: traversal still uses non-following `os.scandir`,
+entry errors remain skipped, and the helper returns a sorted `list[Path]`.
+
+Local Linux probe result for `dataset-source-records-scandir` against
+`origin/main` showed a small primary traversal improvement:
+`elapsed_ms_mean 12.6049 -> 12.5383 ms` and
+`elapsed_ms_p95 15.9867 -> 14.2248 ms`. Secondary read/source-kind metrics also
+improved in that run, while record materialization noise stayed within the
+registered 5 percent warning threshold. CI PR-scoped performance remains the
+merge gate.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1280,7 +1280,7 @@ def _iter_source_file_paths(input_path: Path) -> list[Path]:
         except OSError:
             continue
     file_paths.sort()
-    return [path_cls(path) for path in file_paths]
+    return list(map(path_cls, file_paths))
 
 
 def _classify_source_kind_name(name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Replace the final Python-level dataset source path projection comprehension with `list(map(path_cls, file_paths))` after deterministic string sorting.
- Keep the scandir traversal, symlink policy, entry-error handling, and sorted `list[Path]` result unchanged.

## Plan or Spec
- Updated `docs/plans/2026-06-14-dataset-source-path-map-fastpath.md` with the 2026-07-19 execution note and local probe evidence.
- Registered probe coverage already exists: `dataset-source-records-scandir` in `infra/perf/pr_scoped_probes.json`, with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/melix-base --head-repo "$PWD" --output .runtime/perf/dataset-source-records-scandir.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `47 passed in 2.05s`.
- Changed-scope coverage: `TOTAL 1 0 100%` for the touched scope.
- Local registered probe (`dataset-source-records-scandir`, Linux):
  - `elapsed_ms_mean`: `12.604909737340428 -> 12.538328999653459` ms (`-0.06658073768696927` ms)
  - `elapsed_ms_p95`: `15.986676095053554 -> 14.224837068468332` ms (`-1.7618390265852213` ms)
  - `source_kind_elapsed_ms_mean`: `20.457545697519723 -> 19.372636960311368` ms
  - `read_elapsed_ms_mean`: `65.13373124074529 -> 63.270212383940816` ms
  - `record_elapsed_ms_mean`: `10.378916112875396 -> 10.859786236489361` ms (within the registered 5% warning threshold)

## Known Gaps
- This is a Python-only Linux-verified slice. No Swift runtime effect is claimed.
- The local primary improvement is small and should be treated as a narrow hot-path cleanup; the PR-scoped GitHub Actions performance report remains the merge gate.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe ran against base and head.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
