### PR TITLE
perf: bind event JSON parser helpers

### DIFF
--- a/docs/plans/2026-07-19-event-extraction-json-whitespace-fastpath.md
+++ b/docs/plans/2026-07-19-event-extraction-json-whitespace-fastpath.md
@@ -1,0 +1,29 @@
+# Event extraction JSON whitespace fast path
+
+This Python-only performance slice is limited to the event-extraction response JSON parser in `worker.productization.event_extraction`.
+
+## Scope
+
+The parser already avoids pre-trimming response strings and uses `JSONDecoder.raw_decode` for direct-object and fenced-object responses. This slice keeps the same parse and validation behavior while binding the raw decoder and trailing-validation helpers once per call so repeated hot-path branches avoid global lookups.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `event-extraction-response-json-fence-trim` in `infra/perf/pr_scoped_probes.json`.
+
+The probe has focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_response_json_probe.py`
+
+## Verification plan
+
+1. Run the registered focused tests from the probe.
+2. Run the registered changed-scope coverage command.
+3. Run the registered probe locally on Linux against `origin/main` and this branch with repeated samples.
+4. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Acceptance criteria
+
+Accept this slice only if focused tests and coverage pass, the local registered probe does not regress the JSON parser metrics, and the PR-scoped performance CI probe completes successfully.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2888,18 +2888,21 @@ def _coerce_string_list(value: object) -> list[str]:
 
 def _parse_response_json(response_text: str) -> dict[str, object]:
     response_length = len(response_text)
+    raw_decode = _JSON_RAW_DECODE
+    has_only_trailing_whitespace = _has_only_trailing_whitespace
+    has_only_optional_closing_fence = _has_only_optional_closing_fence
     if response_length and response_text[0] == "{":
-        parsed, end_index = _JSON_RAW_DECODE(response_text, 0)
-        if not _has_only_trailing_whitespace(response_text, end_index, response_length):
+        parsed, end_index = raw_decode(response_text, 0)
+        if not has_only_trailing_whitespace(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
     if response_length and response_text[0] == "`" and response_text.startswith(_JSON_FENCE_PREFIX):
-        parsed, end_index = _JSON_RAW_DECODE(
+        parsed, end_index = raw_decode(
             response_text,
             _JSON_FENCE_PREFIX_LENGTH,
         )
-        if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+        if not has_only_optional_closing_fence(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         if not isinstance(parsed, dict):
             raise ValueError("LLM response must be a JSON object")
@@ -2908,17 +2911,17 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
     response_start = _skip_json_whitespace(response_text, 0, response_length)
 
     if response_start < response_length and response_text[response_start] == "{":
-        parsed, end_index = _JSON_RAW_DECODE(response_text, response_start)
-        if not _has_only_trailing_whitespace(response_text, end_index, response_length):
+        parsed, end_index = raw_decode(response_text, response_start)
+        if not has_only_trailing_whitespace(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
     if response_text.startswith(_JSON_FENCE_PREFIX, response_start):
-        parsed, end_index = _JSON_RAW_DECODE(
+        parsed, end_index = raw_decode(
             response_text,
             response_start + _JSON_FENCE_PREFIX_LENGTH,
         )
-        if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+        if not has_only_optional_closing_fence(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         if not isinstance(parsed, dict):
             raise ValueError("LLM response must be a JSON object")
@@ -2927,14 +2930,14 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
     if response_text.startswith("```", response_start):
         newline_index = response_text.find("\n", response_start)
         if newline_index >= 0:
-            parsed, end_index = _JSON_RAW_DECODE(response_text, newline_index + 1)
-            if not _has_only_optional_closing_fence(response_text, end_index, response_length):
+            parsed, end_index = raw_decode(response_text, newline_index + 1)
+            if not has_only_optional_closing_fence(response_text, end_index, response_length):
                 raise json.JSONDecodeError("Extra data", response_text, end_index)
             if not isinstance(parsed, dict):
                 raise ValueError("LLM response must be a JSON object")
             return parsed
-    parsed, end_index = _JSON_RAW_DECODE(response_text, response_start)
-    if not _has_only_trailing_whitespace(response_text, end_index, response_length):
+    parsed, end_index = raw_decode(response_text, response_start)
+    if not has_only_trailing_whitespace(response_text, end_index, response_length):
         raise json.JSONDecodeError("Extra data", response_text, end_index)
     if not isinstance(parsed, dict):
         raise ValueError("LLM response must be a JSON object")


### PR DESCRIPTION
## Summary
- Bind the event-extraction JSON parser's raw decoder and trailing-validation helpers once per `_parse_response_json()` call.
- Keep parser behavior unchanged while reducing repeated global lookups on the registered response JSON parsing hot path.

## Plan or Spec
- `docs/plans/2026-07-19-event-extraction-json-whitespace-fastpath.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 17 passed in 0.34s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused tests>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
# TOTAL 15 0 100%

# Baseline origin/main vs this branch, registered probe with 9 samples and 200 iterations/sample:
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EVENT_RESPONSE_JSON_PROBE_SAMPLES=9 MELIX_EVENT_RESPONSE_JSON_PROBE_ITERATIONS=200 uv run --project services/mlx-worker-python python3 scripts/event_extraction_response_json_probe.py
# origin/main: elapsed_ms_mean=3703.2456275903514, direct_elapsed_ms_mean=3682.1281619163024, peak_bytes_mean=2999274.222222222
# branch:      elapsed_ms_mean=3488.9186496794637, direct_elapsed_ms_mean=3626.955824671313, peak_bytes_mean=2999274.222222222

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: 100% (15/15 changed measurable lines).
- Registered local Linux probe: `event-extraction-response-json-fence-trim`.
  - `elapsed_ms_mean`: 3703.2456 ms -> 3488.9186 ms (`-214.3270 ms`, ~5.79% faster).
  - `direct_elapsed_ms_mean`: 3682.1282 ms -> 3626.9558 ms (`-55.1723 ms`, ~1.50% faster).
  - `peak_bytes_mean`: unchanged at 2999274.2222 bytes.
- CI PR-scoped performance remains the merge gate for the registered probe.

## Known Gaps
- Local validation was Linux-only; no Swift/runtime effect is claimed.
- An initial ASCII-whitespace membership-table variant was rejected because repeated registered-probe runs showed unstable/regressing primary elapsed metrics; this PR keeps only the helper-binding change that improved the registered probe.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
