### PR TITLE
perf: fast-path agentic token metric aliases

### DIFF
--- a/docs/plans/2026-06-25-trajectory-copy-list-literal.md
+++ b/docs/plans/2026-06-25-trajectory-copy-list-literal.md
@@ -146,3 +146,16 @@ fast path. Nested mutable component labels remain isolated, and non-standard
 quality metric payloads still fall back through the generic recursive copier. The
 registered `trajectory-provenance-copy-elision` probe remains the local Linux and
 CI validation gate for this small Python-only slice.
+
+## 2026-07-19 follow-up: clean token estimator alias fast path
+
+This follow-up remains limited to `_agentic_sft_token_metric_aliases(...)` inside
+`worker.trajectory_provenance`. The common exact `agentic_sft_token_metrics` dict
+shape now reads the six expected fields directly and, when the estimator is an
+already-clean string, returns the alias payload without calling the generic string
+coercion/strip path; `adapter_manifest_trajectory_provenance(...)` also bypasses
+the generic `Mapping` check for exact dict token metrics. Whitespace trimming,
+blank-estimator omission, integer coercion, fallback behavior for partial/custom
+mappings, and alias key order stay unchanged. The registered
+`trajectory-provenance-copy-elision` probe remains the local Linux and CI
+validation gate for this small Python-only slice.

--- a/services/mlx-worker-python/tests/test_trajectory_provenance.py
+++ b/services/mlx-worker-python/tests/test_trajectory_provenance.py
@@ -1085,6 +1085,79 @@ def test_adapter_manifest_trajectory_provenance_omits_blank_token_estimator() ->
     assert payload["training.agentic_sft.tool_call_tokens"] == 0
 
 
+def test_agentic_token_metric_aliases_fast_path_keeps_clean_estimator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metrics = {
+        "estimator": "fixture-tokenizer",
+        "source_trace_count": 64,
+        "trace_tokens": 2368,
+        "tool_call_tokens": 704,
+        "observation_tokens": 832,
+        "final_answer_tokens": 320,
+    }
+
+    def fail_string_coerce(value: object) -> str:  # pragma: no cover - regression guard
+        raise AssertionError(f"unexpected estimator coercion for {value!r}")
+
+    monkeypatch.setattr(trajectory_provenance_module, "_STR", fail_string_coerce)
+
+    aliases = trajectory_provenance_module._agentic_sft_token_metric_aliases(metrics)
+
+    assert aliases == {
+        "training.agentic_sft.token_estimator": "fixture-tokenizer",
+        "training.agentic_sft.source_trace_count": 64,
+        "training.agentic_sft.trace_tokens": 2368,
+        "training.agentic_sft.tool_call_tokens": 704,
+        "training.agentic_sft.observation_tokens": 832,
+        "training.agentic_sft.final_answer_tokens": 320,
+    }
+
+
+def test_agentic_token_metric_aliases_fast_path_trims_and_omits_estimators() -> None:
+    metrics = {
+        "estimator": " fixture-tokenizer ",
+        "source_trace_count": 64,
+        "trace_tokens": 2368,
+        "tool_call_tokens": 704,
+        "observation_tokens": 832,
+        "final_answer_tokens": 320,
+    }
+
+    aliases = trajectory_provenance_module._agentic_sft_token_metric_aliases(metrics)
+
+    assert aliases["training.agentic_sft.token_estimator"] == "fixture-tokenizer"
+    metrics["estimator"] = "   "
+    blank_aliases = trajectory_provenance_module._agentic_sft_token_metric_aliases(metrics)
+    assert "training.agentic_sft.token_estimator" not in blank_aliases
+    assert blank_aliases["training.agentic_sft.trace_tokens"] == 2368
+
+
+def test_agentic_token_metric_aliases_falls_back_for_partial_exact_dict() -> None:
+    metrics = {
+        "estimator": 123,
+        "source_trace_count": 64,
+        "trace_tokens": 2368,
+        "tool_call_tokens": 704,
+        "observation_tokens": 832,
+        "final_answer_tokens": 320,
+    }
+
+    aliases = trajectory_provenance_module._agentic_sft_token_metric_aliases(metrics)
+
+    assert aliases["training.agentic_sft.token_estimator"] == "123"
+    assert aliases["training.agentic_sft.final_answer_tokens"] == 320
+
+    partial_metrics: dict[str, object] = dict(metrics)
+    partial_metrics.pop("final_answer_tokens")
+    partial_metrics["extra"] = "forces-key-error-fallback"
+    fallback_aliases = trajectory_provenance_module._agentic_sft_token_metric_aliases(
+        partial_metrics
+    )
+    assert fallback_aliases["training.agentic_sft.token_estimator"] == "123"
+    assert fallback_aliases["training.agentic_sft.final_answer_tokens"] == 0
+
+
 def test_copy_json_dict_still_copies_nested_mutable_items() -> None:
     source = {"reward_coverage_count": 1, "components": [{"name": "format"}]}
 

--- a/services/mlx-worker-python/worker/trajectory_provenance.py
+++ b/services/mlx-worker-python/worker/trajectory_provenance.py
@@ -597,7 +597,9 @@ def adapter_manifest_trajectory_provenance(
         normalized.get("trajectory_reward_policy_id")
     )
     token_metrics = normalized.get("agentic_sft_token_metrics")
-    if isinstance(token_metrics, Mapping):
+    if type(token_metrics) is dict:
+        payload.update(_agentic_sft_token_metric_aliases(token_metrics))
+    elif isinstance(token_metrics, Mapping):
         payload.update(_agentic_sft_token_metric_aliases(token_metrics))
     return payload
 
@@ -623,8 +625,70 @@ def alignment_metrics_trajectory_provenance(
 
 
 def _agentic_sft_token_metric_aliases(metrics: Mapping[str, Any]) -> dict[str, Any]:
-    metrics_get = metrics.get
     int_value = _INT
+    if type(metrics) is dict and len(metrics) == 6:
+        try:
+            estimator = metrics["estimator"]
+            source_trace_count = metrics["source_trace_count"]
+            trace_tokens = metrics["trace_tokens"]
+            tool_call_tokens = metrics["tool_call_tokens"]
+            observation_tokens = metrics["observation_tokens"]
+            final_answer_tokens = metrics["final_answer_tokens"]
+        except KeyError:
+            pass
+        else:
+            if type(estimator) is str:
+                if estimator and not estimator[0].isspace() and not estimator[-1].isspace():
+                    return {
+                        "training.agentic_sft.token_estimator": estimator,
+                        "training.agentic_sft.source_trace_count": int_value(
+                            source_trace_count or 0
+                        ),
+                        "training.agentic_sft.trace_tokens": int_value(trace_tokens or 0),
+                        "training.agentic_sft.tool_call_tokens": int_value(
+                            tool_call_tokens or 0
+                        ),
+                        "training.agentic_sft.observation_tokens": int_value(
+                            observation_tokens or 0
+                        ),
+                        "training.agentic_sft.final_answer_tokens": int_value(
+                            final_answer_tokens or 0
+                        ),
+                    }
+                estimator_text = estimator.strip()
+            else:
+                estimator_text = _STR(estimator).strip()
+            if estimator_text:
+                return {
+                    "training.agentic_sft.token_estimator": estimator_text,
+                    "training.agentic_sft.source_trace_count": int_value(
+                        source_trace_count or 0
+                    ),
+                    "training.agentic_sft.trace_tokens": int_value(trace_tokens or 0),
+                    "training.agentic_sft.tool_call_tokens": int_value(
+                        tool_call_tokens or 0
+                    ),
+                    "training.agentic_sft.observation_tokens": int_value(
+                        observation_tokens or 0
+                    ),
+                    "training.agentic_sft.final_answer_tokens": int_value(
+                        final_answer_tokens or 0
+                    ),
+                }
+            return {
+                "training.agentic_sft.source_trace_count": int_value(
+                    source_trace_count or 0
+                ),
+                "training.agentic_sft.trace_tokens": int_value(trace_tokens or 0),
+                "training.agentic_sft.tool_call_tokens": int_value(tool_call_tokens or 0),
+                "training.agentic_sft.observation_tokens": int_value(
+                    observation_tokens or 0
+                ),
+                "training.agentic_sft.final_answer_tokens": int_value(
+                    final_answer_tokens or 0
+                ),
+            }
+    metrics_get = metrics.get
     estimator = _STR(metrics_get("estimator", "")).strip()
     if estimator:
         return {


### PR DESCRIPTION
## Summary
- Fast-path exact `agentic_sft_token_metrics` alias materialization for clean estimator strings.
- Bypass the generic `Mapping` check for exact dict token metrics in `adapter_manifest_trajectory_provenance(...)`.
- Add regression coverage for clean, trimmed/blank, non-string, and partial metric dictionaries.

## Plan or Spec
- `docs/plans/2026-06-25-trajectory-copy-list-literal.md` (2026-07-19 follow-up: clean token estimator alias fast path)
- Registered PR-scoped probe: `trajectory-provenance-copy-elision` in `infra/perf/pr_scoped_probes.json`

## Commands Run
```text
# Branch/base setup
$ git fetch origin main && git reset --hard origin/main
HEAD is now at 872c02fd perf: fast-path event JSON probe trailer (#2921)

# Focused regression test added in this slice
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_trajectory_provenance.py::test_agentic_token_metric_aliases_fast_path_keeps_clean_estimator
1 passed in 1.31s

# Focused trajectory provenance + PR-scoped registry tests, with the new alias tests included
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <trajectory-provenance-copy-elision focused tests plus new alias tests>
41 passed in 0.53s

# Changed-scope coverage for the touched worker module, with new alias tests included
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.trajectory_provenance -m pytest -q <focused trajectory provenance tests plus new alias tests> && uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/trajectory_provenance.py
38 passed in 0.93s
changed_line_coverage=95.45%
TOTAL 22 1 95%

# Registered local Linux probe
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/trajectory_provenance_copy_elision_probe.py
adapter_manifest_elapsed_ms_mean=70.35323949530721
adapter_manifest_baseline_elapsed_ms_mean=469.12749321199954
adapter_manifest_delta_ms=-398.77425371669233
adapter_manifest_speedup=6.6681718791825055
elapsed_ms_mean=202.91287540458143
speedup=7.371076449698083
sample_count=5 iteration_count=2000 component_count=64

# Hygiene
$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `95.45%` for `services/mlx-worker-python/worker/trajectory_provenance.py` (`TOTAL 22 1 95%`).
- Registered probe: `trajectory-provenance-copy-elision` completed locally on Linux.
- Probe metrics from the final run:
  - `adapter_manifest_baseline_elapsed_ms_mean=469.12749321199954`
  - `adapter_manifest_elapsed_ms_mean=70.35323949530721`
  - `adapter_manifest_delta_ms=-398.77425371669233`
  - `adapter_manifest_speedup=6.6681718791825055`
  - `elapsed_ms_mean=202.91287540458143`
  - `speedup=7.371076449698083`
- CI PR-scoped performance must run the registered base-vs-head report before merge.

## Known Gaps
- Full repository gates were not run locally; this is a narrow Python-only slice.
- Swift runtime effects are not changed or claimed.
- Local probe numbers are Linux-only; the GitHub Actions PR-scoped performance report is the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability change.
- [x] Deferred work and known gaps are stated explicitly.
