### PR TITLE
perf: reuse model load rejection policy template

### DIFF
--- a/docs/plans/2026-07-09-model-load-trust-text-route-fastpath.md
+++ b/docs/plans/2026-07-09-model-load-trust-text-route-fastpath.md
@@ -22,8 +22,8 @@ back exactly as before.
 
 The follow-up rejection-policy template slice keeps the same registered probe and
 moves repeated custom-loader rejection policy construction behind a cached
-serialized protobuf template keyed by the policy fields. Each rejection still
-receives a fresh mutable `ModelLoadTrustPolicy` parsed from the cached bytes, so
+protobuf template keyed by the policy fields. Each rejection still receives a
+fresh mutable `ModelLoadTrustPolicy` populated from the cached template, so
 callers cannot mutate the cached template while hot repeated rejection paths avoid
 rebuilding identical protobuf fields one by one.
 

--- a/services/mlx-worker-python/worker/model_load_trust.py
+++ b/services/mlx-worker-python/worker/model_load_trust.py
@@ -183,8 +183,9 @@ def _custom_loader_rejection_policy(
     loader_family: str,
     detection_source: str,
 ) -> common_pb2.ModelLoadTrustPolicy:
-    return MODEL_LOAD_TRUST_POLICY.FromString(
-        _custom_loader_rejection_policy_bytes(
+    policy = MODEL_LOAD_TRUST_POLICY()
+    policy.CopyFrom(
+        _custom_loader_rejection_policy_template(
             requested_mode,
             policy_source,
             route_class,
@@ -192,16 +193,17 @@ def _custom_loader_rejection_policy(
             detection_source,
         )
     )
+    return policy
 
 
 @lru_cache(maxsize=128)
-def _custom_loader_rejection_policy_bytes(
+def _custom_loader_rejection_policy_template(
     requested_mode: int,
     policy_source: str,
     route_class: int,
     loader_family: str,
     detection_source: str,
-) -> bytes:
+) -> common_pb2.ModelLoadTrustPolicy:
     return MODEL_LOAD_TRUST_POLICY(
         requested_mode=requested_mode,
         effective_mode=requested_mode,
@@ -211,7 +213,7 @@ def _custom_loader_rejection_policy_bytes(
         block_reason=BLOCK_REASON_CUSTOM_LOADER_REQUIRES_TRUST,
         route_class=route_class,
         loader_family=loader_family,
-    ).SerializeToString()
+    )
 
 
 def _requested_mode(


### PR DESCRIPTION
## Summary
- Reuses a cached `ModelLoadTrustPolicy` rejection template for repeated custom-loader trust rejections.
- Keeps each returned rejection policy isolated by copying from the cached template into a fresh protobuf object.
- Updates the model-load trust fast-path plan to reflect the protobuf-template implementation.

## Plan or Spec
- `docs/plans/2026-07-09-model-load-trust-text-route-fastpath.md`
- Registered probe: `model-load-config-json-bytes` in `infra/perf/pr_scoped_probes.json`

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_model_load_trust.py::test_custom_loader_rejection_policy_uses_isolated_cached_template services/mlx-worker-python/tests/test_model_load_trust.py::test_trust_policy_common_loader_fast_path_skips_normalized_membership services/mlx-worker-python/tests/test_model_load_trust.py::test_loader_family_text_default_bypasses_request_policy_lookup`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ... [registered model-load-config-json-bytes test_command]`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... [registered model-load-config-json-bytes coverage_command] && coverage json && python3 scripts/changed_scope_coverage.py ...`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/model_load_config_json_bytes_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused smoke: 3 passed in 0.52s.
- Registered focused tests: 37 passed in 0.59s.
- Changed-scope coverage: 100.00% (`TOTAL 4 0 100%`).
- Local Linux registered probe baseline before change: `elapsed_ms_mean=5.391936782481415`, `executable_elapsed_ms_mean=9.285298043063708`.
- Local Linux registered probe after change: `elapsed_ms_mean=5.2485583416585415`, `executable_elapsed_ms_mean=8.976725029892155`.
- Local delta: `elapsed_ms_mean -0.14337844082287356 ms` (~2.66% faster), `executable_elapsed_ms_mean -0.308573013171553 ms` (~3.32% faster).

## Known Gaps
- Local validation is Linux/Python only; CI must run the registered PR-scoped performance workflow for repository gating.
- Probe improvements are small and should be treated as a targeted hot-path allocation/construction reduction, not a broad model-load rewrite.

## Evidence Checklist
- [x] Started from synced `origin/main`.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally and showed directionally faster metrics.
- [ ] GitHub Actions and registered PR-scoped performance probe completed successfully.
