### PR TITLE
perf: slice retrieval public source prefix check

### DIFF
--- a/docs/plans/2026-07-13-retrieval-context-kind-membership.md
+++ b/docs/plans/2026-07-13-retrieval-context-kind-membership.md
@@ -51,3 +51,18 @@ Success is accepted only if the focused retrieval context tests, changed-scope
 coverage, and the registered Linux probe pass locally with lower
 `optimized_elapsed_ms_mean`, and if the PR-scoped CI probe completes successfully
 before merge.
+
+## Follow-up Slice: Public Source Prefix Slice Comparison
+
+The 2026-07-19 follow-up keeps the same registered probe and narrows to the
+`source:` public-id fast path used by exact `RetrievalContextEntry` objects and
+exact dict store records. The previous implementation used
+`normalized_source_id.startswith(public_source_prefix)` before slicing the numeric
+suffix; this slice uses a fixed-length prefix slice comparison instead, reusing
+the already-bound prefix length and preserving the same fallback to
+`_is_public_source_id()` for non-numeric or non-prefixed public source ids.
+
+Success is accepted only if the focused retrieval context tests,
+changed-scope coverage, and the registered Linux probe pass locally with lower
+`optimized_elapsed_ms_mean`, and if the PR-scoped CI probe completes successfully
+before merge.

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -180,7 +180,7 @@ def project_retrieval_contexts(
                     and normalized_reason
                     and normalized_corrective_action
                 ):
-                    if normalized_source_id.startswith(public_source_prefix):
+                    if normalized_source_id[:public_source_prefix_length] == public_source_prefix:
                         source_suffix = normalized_source_id[public_source_prefix_length:]
                         source_is_public = (
                             source_suffix.isdigit() and len(normalized_source_id) <= 96
@@ -381,7 +381,7 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
                     and normalized_reason
                     and normalized_corrective_action
                 ):
-                    if normalized_source_id.startswith(public_source_prefix):
+                    if normalized_source_id[:public_source_prefix_length] == public_source_prefix:
                         source_suffix = normalized_source_id[public_source_prefix_length:]
                         source_is_public = (
                             source_suffix.isdigit() and len(normalized_source_id) <= 96


### PR DESCRIPTION
## Summary
- Optimize the retrieval context public `source:` fast path by replacing two `startswith(...)` checks with fixed-length prefix slice comparisons.
- Keep exact `RetrievalContextEntry` and exact dict store-record behavior unchanged, including fallback validation for non-numeric public source ids.

## Plan or Spec
- `docs/plans/2026-07-13-retrieval-context-kind-membership.md` (follow-up slice: Public Source Prefix Slice Comparison)

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py
# baseline before change: optimized_elapsed_ms_mean=0.1019052933302841; store_optimized_elapsed_ms_mean=0.11740278851773057; exit 0

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_admits_multiple_entries_with_redacted_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_isolates_refusals_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_malformed_entry_objects_without_dropping_valid_entries services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_payload_fields_before_overwrite services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_preserves_multi_field_admission_duplicate_scan services/mlx-worker-python/tests/test_retrieval_context.py::test_retrieval_lookup_payload_copy_preserves_scalar_and_none_values services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_fast_paths_complete_entries_without_admission_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_inlines_public_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_inlines_source_numeric_ids_without_regex services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_falls_back_for_source_prefixed_public_text_ids services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_refuses_duplicate_with_defensive_receipt_fallbacks services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_redacts_nonpublic_source_ids_with_fast_check services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_copies_multi_receipt_admissions services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_projects_records_without_entry_reentry services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_fast_paths_complete_dict_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_complete_dict_fast_path_avoids_isinstance services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_falls_back_for_source_prefixed_public_text_ids services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_redacts_nonpublic_source_ids_with_fast_check services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_store_projection_outputs services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_refusals services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_uses_wrapper_metadata_for_malformed_records services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_reads_records_once_for_metadata_refusal services/mlx-worker-python/tests/test_retrieval_context.py::test_lookup_result_metadata_refusal_skips_default_normalization_for_valid_metadata services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_normalizes_valid_metadata_once services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_copies_tuple_payloads_without_type_drift services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_lookup_result_refuses_malformed_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_retrieval_context_projection_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_prefers_head_script_for_comparable_inputs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_retrieval_context_projection_probe_covers_lookup_wrapper_metadata services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 38 passed in 1.36s; exit 0

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <same focused registry tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/retrieval_context.py services/mlx-worker-python/worker/runtime/untrusted_context.py services/mlx-worker-python/tests/test_retrieval_context.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/retrieval_context_projection_probe.py
# 38 passed in 0.41s; TOTAL 2 0 100%; exit 0

$ for i in 1 2 3; do PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py; done
# optimized_elapsed_ms_mean samples: 0.096781708416529, 0.0967630442963647, 0.0981229858007282; exit 0

$ git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 2 0 100%`.
- Registered probe: `retrieval-context-projection-fastpath`.
- Local Linux probe delta: old optimized mean `0.1019052933302841 ms`; new 3-run mean `0.097222579505 ms`; delta `-0.004682713826 ms`; speedup `1.048165x` (`4.60%`).
- The registered PR-scoped performance workflow is required as the CI validation source before merge.

## Known Gaps
- Full repository test gates were not run locally; this PR ran the focused registered test, changed-scope coverage, and registered probe for this Python slice.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; runtime observability unchanged.
- [x] Deferred work and known gaps are stated explicitly.
