### PR TITLE
perf: reuse native MTP weight key prefixes

### DIFF
--- a/docs/plans/2026-06-05-native-mtp-prefix-type-fastpath.md
+++ b/docs/plans/2026-06-05-native-mtp-prefix-type-fastpath.md
@@ -17,6 +17,10 @@ The registry entry includes focused `test_command`, `coverage_command`, and `pro
 3. Implement the exact-string fast path before the existing `isinstance` and `str(key)` fallback checks.
 4. Verify with the registered focused tests, changed-scope coverage, and the registered local Linux probe; use PR-scoped performance CI as the merge gate.
 
+## 2026-07-19 incremental slice: shared tuple prefix check
+
+This incremental Python-only slice keeps the `_is_mtp_weight_key` scope and the same registered probe. It reuses `_MTP_WEIGHT_KEY_PREFIXES` for exact strings instead of issuing two separate literal `startswith` calls, while preserving the `str` subclass and custom object fallback behavior described above.
+
 ## Metrics
 
 Success is measured by the registered probe's `key_new_mean_ms` / `key_old_mean_ms` and overall native-MTP loader metrics from `scripts/native_mtp_loader_safetensor_scandir_probe.py`; behavior parity is measured by focused native-MTP loader tests and changed-scope coverage for the touched module.

--- a/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
+++ b/services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
@@ -32,11 +32,12 @@ def _load_json_payload(path: Path) -> dict[str, Any]:
 
 
 def _is_mtp_weight_key(key: Any) -> bool:
+    prefixes = _MTP_WEIGHT_KEY_PREFIXES
     if type(key) is str:
-        return key.startswith("language_model.mtp.") or key.startswith("mtp.")
+        return key.startswith(prefixes)
     if isinstance(key, str):
-        return key.startswith(_MTP_WEIGHT_KEY_PREFIXES)
-    return str(key).startswith(_MTP_WEIGHT_KEY_PREFIXES)
+        return key.startswith(prefixes)
+    return str(key).startswith(prefixes)
 
 
 def _model_safetensor_files(model_path: Path) -> list[str]:


### PR DESCRIPTION
## Summary
- Reuse the shared `_MTP_WEIGHT_KEY_PREFIXES` tuple in `_is_mtp_weight_key` for exact `str` keys.
- Keep the existing `str` subclass and custom object fallback behavior unchanged.
- Document the incremental native-MTP prefix classifier slice in the governing plan.

## Plan or Spec
- `docs/plans/2026-06-05-native-mtp-prefix-type-fastpath.md`
- Registered probe: `native-mtp-loader-safetensor-scandir` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Rejected prior candidate (not included in this PR): hub-catalog Link-header method binding
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_next_cursor_probe_script_emits_metrics
# exit 0; 97 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_next_cursor_probe.py
# baseline elapsed_ms_mean=496.857739; attempted head elapsed_ms_mean=554.463698, regressed; reverted before this slice.

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
# exit 0 before implementation; key_old_mean_ms=5578.627494, key_new_mean_ms=5474.497431, key_speedup=1.019021

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_native_mtp_loader_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_loader_safetensor_scandir_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_weight_load_probe_tolerates_loader_timer_noise_without_weakening_counts services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_native_mtp_model_listing_probe_tolerates_loader_timer_noise_without_weakening_counts
# exit 0; 13 passed

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run --source=worker.runtime.native_mtp.mlx_lm_loader -m pytest -q services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_index_payload_loads_from_bytes services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_weight_key_detection_preserves_string_and_custom_keys services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_preserves_custom_file_names services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_inlines_key_prefix_filter services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_model_safetensor_listing_uses_scandir_without_glob services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_extra_safetensor_files_filters_names_before_path_join services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_load_weight_shards_streams_base_and_extra_paths services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_preload_patch_detects_qwen36_mtp_weights services/mlx-worker-python/tests/test_mlx_vlm_runtime.py::test_native_mtp_patched_loader_uses_scandir_model_weight_listing
# exit 0; 9 passed
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# exit 0; Wrote JSON report to coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py
# exit 0; TOTAL 4 0 100%
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/native_mtp_loader_safetensor_scandir_probe.py
# exit 0; key_old_mean_ms=5559.318068, key_new_mean_ms=4800.485505, key_speedup=1.158074

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 4 0 100%` for `services/mlx-worker-python/worker/runtime/native_mtp/mlx_lm_loader.py`.
- Local registered probe after implementation: `key_old_mean_ms=5559.318068`, `key_new_mean_ms=4800.485505`, `key_delta_ms=-758.832563`, `key_speedup=1.158074`; overall `old_mean_ms=11.454454`, `new_mean_ms=11.248278`, `speedup=1.018330`.
- CI PR-scoped performance is required as final registered probe validation before merge.

## Known Gaps
- Python-only Linux validation; no Swift runtime effect is claimed.
- Full repository gates were not run locally; CI remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
