### PR TITLE
perf: bind dict checks in report evidence lists

### DIFF
--- a/docs/plans/2026-07-19-report-evidence-dict-list-exact-dict.md
+++ b/docs/plans/2026-07-19-report-evidence-dict-list-exact-dict.md
@@ -1,0 +1,46 @@
+# Report evidence gate exact-dict list fast path
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.report_evidence_gate._dict_list(...)`, which normalizes
+report-evidence payload sections to `list[dict[str, object]]` while preserving
+identity for already-valid dictionary lists.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`report-evidence-gate-run-kind-set-membership` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/report_evidence_gate_run_kind_probe.py`
+
+The existing probe reports `dict_list_elapsed_ms_mean`,
+`dict_list_rows_per_call`, and `dict_list_identity_hits`; those metrics are the
+primary evidence for this exact-dict fast path.
+
+## Implementation plan
+
+1. Preserve `_dict_list(...)` semantics for exact `list`, list subclasses,
+   exact `dict` rows, dict subclasses, mixed rows, and non-list inputs.
+2. Bind the `dict` type and `isinstance` helper once per `_dict_list(...)` call so
+   exact-dict list scans and fallback filtering avoid repeated global lookups.
+3. Run the focused report-evidence tests, changed-scope coverage command,
+   `git diff --check`, and the registered local Linux probe before opening the
+   PR.
+4. Use GitHub Actions PR-scoped performance as the merge gate for the registered
+   probe result.
+
+## Success criteria
+
+- Focused behavior tests pass.
+- Changed-scope coverage for the touched report-evidence scope remains at or
+  above the repository threshold.
+- Local registered probe shows lower `dict_list_elapsed_ms_mean` versus the
+  pre-change baseline without changing `dict_list_identity_hits` or checksum.
+- PR-scoped performance CI selects and completes the registered probe for this
+  path before merge.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -996,6 +996,15 @@ def test_report_evidence_gate_covers_invalid_payload_and_edge_summaries(tmp_path
     subclass_rows: list[object] = [DictRow({"phase": "subclass"}), {"phase": "plain"}]
     assert report_evidence_gate_module._dict_list(subclass_rows) is subclass_rows
 
+    class RowList(list[object]):
+        pass
+
+    subclass_list = RowList([{"phase": "plain"}, DictRow({"phase": "subclass"})])
+    assert report_evidence_gate_module._dict_list(subclass_list) is subclass_list
+    assert report_evidence_gate_module._dict_list(RowList([subclass_list[0], "skip"])) == [
+        subclass_list[0]
+    ]
+
     markdown = render_pr_evidence_markdown(
         {
             **gate,

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -645,14 +645,16 @@ def _probe_phases(report: dict[str, object]) -> set[str]:
 
 
 def _dict_list(value: object) -> list[dict[str, object]]:
+    dict_type = dict
+    is_dict = isinstance
     if type(value) is list:
         for item in value:
-            if type(item) is not dict and not isinstance(item, dict):
-                return [item for item in value if isinstance(item, dict)]
+            if type(item) is not dict_type and not is_dict(item, dict_type):
+                return [item for item in value if is_dict(item, dict_type)]
         return cast(list[dict[str, object]], value)
     if not isinstance(value, list):
         return []
     for item in value:
-        if type(item) is not dict and not isinstance(item, dict):
-            return [item for item in value if isinstance(item, dict)]
+        if type(item) is not dict_type and not is_dict(item, dict_type):
+            return [item for item in value if is_dict(item, dict_type)]
     return cast(list[dict[str, object]], value)


### PR DESCRIPTION
## Summary
- Optimizes `report_evidence_gate._dict_list(...)` by binding the exact dict type and `isinstance` helper once per call.
- Adds regression coverage for list-subclass inputs so the fast path preserves dict subclass and mixed-row semantics.
- Documents the Python-only performance slice and registered probe boundary.

## Plan or Spec
- `docs/plans/2026-07-19-report-evidence-dict-list-exact-dict.md`
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Initial focused repro/baseline loop on origin/main-equivalent code
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_covers_invalid_payload_and_edge_summaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_evidence_gate_run_kind_probe_script_emits_metrics
# 2 passed in 1.31s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=20000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=3 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# baseline dict_list_elapsed_ms_mean=15.878455247730017, elapsed_ms_mean=387.5064807167898

# Focused registered tests after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q <registered report-evidence focused test list>
# 32 passed in 0.18s

# Changed-scope coverage after implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered report-evidence focused test list>
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/report_evidence_gate.py services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/report_evidence_gate_run_kind_probe.py
# TOTAL 11 0 100%

# Local registered probe, base vs head with default-sized sample
PYTHONPATH="$BASE:$BASE/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$BASE" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=50000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# base dict_list_elapsed_ms_mean=42.226399993523955, elapsed_ms_mean=970.7280453760177

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" MELIX_REPORT_EVIDENCE_RUN_KIND_ITERATIONS=50000 MELIX_REPORT_EVIDENCE_RUN_KIND_SAMPLES=5 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# head dict_list_elapsed_ms_mean=37.06272365525365, elapsed_ms_mean=957.4623592663556

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 11 0 100%`.
- Local Linux registered probe metric: `dict_list_elapsed_ms_mean` improved `42.226399993523955 ms -> 37.06272365525365 ms` (`-5.163676338270306 ms`, about `12.23%` faster).
- Overall local probe aggregate: `elapsed_ms_mean` improved `970.7280453760177 ms -> 957.4623592663556 ms` (`-13.265686109662056 ms`, about `1.37%` faster).
- Structural parity: `dict_list_checksum=10240000.0`, `dict_list_identity_hits=5000.0`, `dict_list_rows_per_call=2048.0` unchanged.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python slice. Swift runtime effects are not applicable.
- CI is still required to validate the registered PR-scoped performance workflow on GitHub Actions.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: off; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
