### PR TITLE
perf: cache PR scope changed path normalization

### DIFF
--- a/docs/plans/2026-07-19-pr-scope-force-wildcard-inline-loop.md
+++ b/docs/plans/2026-07-19-pr-scope-force-wildcard-inline-loop.md
@@ -1,0 +1,40 @@
+# PR-scoped force-all wildcard inline loop slice
+
+## Scope
+
+This slice keeps the PR-scoped performance scope matcher behavior unchanged and
+only tightens the force-all wildcard check used by
+`worker.productization.pr_scoped_performance.build_scope_report`.
+
+## Optimization
+
+`build_scope_report` should normalize the changed-file list through a small LRU
+cache keyed by the incoming changed-file tuple. Repeated scope builds in local
+pre-commit and PR-scoped probe runs often reuse the same changed-file payload,
+so the cache avoids rebuilding the de-duplicated sorted path tuple each time.
+
+`_changed_paths_match_force_all_wildcards` should also iterate cached compiled
+force-all wildcard matchers directly instead of calling the generic
+`_matches_any_compiled_glob` helper for every changed path. When the caller
+already has the sorted changed-path tuple produced by `build_scope_report`, the
+function uses the literal prefix with `bisect_left` to skip unrelated path ranges
+before checking the regex. The generic helper remains the canonical matcher for
+external callers; this hot path can reuse the same prefix and regex checks
+without per-path helper-call overhead.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe
+`pr-scoped-performance-scope-matcher` in `infra/perf/pr_scoped_probes.json`.
+That entry defines focused `test_command`, `coverage_command`, and
+`probe_command` coverage for `pr_scoped_performance.py` and the matching tests.
+
+## Verification plan
+
+- Run the registered focused test command for
+  `pr-scoped-performance-scope-matcher`.
+- Run the registered coverage command and require at least 95 percent changed
+  scope coverage.
+- Run the registered probe locally on Linux and compare repeated samples against
+  the pre-change baseline.
+- Use GitHub Actions PR-scoped performance output as the merge gate.

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -3161,25 +3161,42 @@ def test_changed_paths_force_all_wildcards_short_circuits_on_match(
 ) -> None:
     match_calls: list[str] = []
 
+    class TrackingPattern:
+        def match(self, path: str) -> object | None:
+            match_calls.append(path)
+            return object() if path.startswith("scripts/pr_scoped_performance_") or path.endswith("report.py") else None
+
     monkeypatch.setattr(
         pr_scoped_performance_module,
         "_force_all_wildcard_matchers",
-        lambda: (("scripts/", re.compile(r"scripts/pr_scoped_performance_.*\.py")),),
+        lambda: (("scripts/", TrackingPattern()),),
     )
-
-    def tracked_match(path: str, matchers: tuple[tuple[str, re.Pattern[str]], ...]) -> bool:
-        match_calls.append(path)
-        return path.startswith("scripts/pr_scoped_performance_")
-
-    monkeypatch.setattr(pr_scoped_performance_module, "_matches_any_compiled_glob", tracked_match)
 
     assert (
         pr_scoped_performance_module._changed_paths_match_force_all_wildcards(
-            ["scripts/pr_scoped_performance_report.py", "docs/late.md"]  # type: ignore[arg-type]
+            ["docs/early.md", "scripts/other.py", "services/late.py"]
+        )
+        is False
+    )
+    assert match_calls == ["scripts/other.py"]
+    match_calls.clear()
+
+    assert (
+        pr_scoped_performance_module._changed_paths_match_force_all_wildcards(
+            ("docs/early.md", "scripts/pr_scoped_performance_report.py", "services/late.py")
         )
         is True
     )
     assert match_calls == ["scripts/pr_scoped_performance_report.py"]
+    match_calls.clear()
+
+    monkeypatch.setattr(
+        pr_scoped_performance_module,
+        "_force_all_wildcard_matchers",
+        lambda: (("", TrackingPattern()),),
+    )
+    assert pr_scoped_performance_module._changed_paths_match_force_all_wildcards(("docs/report.py",)) is True
+    assert match_calls == ["docs/report.py"]
 
 
 def test_matches_any_glob_uses_explicit_short_circuit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
+++ b/services/mlx-worker-python/worker/productization/pr_scoped_performance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from functools import lru_cache
+import bisect
 import fnmatch
 import gc
 import os
@@ -69,6 +70,13 @@ _SCOPE_SELECTED_PROBES_WITH_COVERAGE_CACHE: dict[
     tuple[int, int, tuple[str, ...]],
     tuple[dict[str, object], ...],
 ] = {}
+
+
+@lru_cache(maxsize=32)
+def _normalized_changed_paths(changed_files: tuple[str, ...]) -> tuple[str, ...]:
+    changed_path_set = set(changed_files)
+    changed_path_set.discard("")
+    return tuple(sorted(changed_path_set))
 
 
 def _log_progress(message: str) -> None:
@@ -261,9 +269,7 @@ def build_scope_report(
     changed_files: list[str],
 ) -> dict[str, object]:
     probes = load_probe_registry_for_scope(registry_path)
-    changed_path_set = set(changed_files)
-    changed_path_set.discard("")
-    changed_paths = tuple(sorted(changed_path_set))
+    changed_paths = _normalized_changed_paths(tuple(changed_files))
     force_all, matched_probe_ids, selected_probes = _scope_selection(
         probes=probes,
         changed_paths=changed_paths,
@@ -2426,7 +2432,7 @@ def _scope_selection_uncached(
 ) -> tuple[bool, tuple[str, ...], tuple[dict[str, object], ...]]:
     changed_path_set = frozenset(changed_paths)
     force_all = bool(_FORCE_ALL_EXACT_PATHS & changed_path_set) or _changed_paths_match_force_all_wildcards(
-        changed_path_set
+        changed_paths
     )
     if _FORCE_ALL_CONTEXT_ONLY_PATHS.isdisjoint(changed_path_set):
         direct_changed_paths = changed_paths
@@ -2761,14 +2767,26 @@ def _path_matches_force_all(path: str) -> bool:
     )
 
 
-def _changed_paths_match_force_all_wildcards(changed_paths: set[str]) -> bool:
+def _changed_paths_match_force_all_wildcards(changed_paths: set[str] | tuple[str, ...] | list[str]) -> bool:
     matchers = _force_all_wildcard_matchers()
     if not matchers:
         return False
-    matches_any_compiled_glob = _matches_any_compiled_glob
-    for path in changed_paths:
-        if matches_any_compiled_glob(path, matchers):
-            return True
+    if not isinstance(changed_paths, tuple):
+        changed_paths = tuple(sorted(changed_paths))
+    for prefix, pattern in matchers:
+        if prefix:
+            index = bisect.bisect_left(changed_paths, prefix)
+            while index < len(changed_paths):
+                path = changed_paths[index]
+                if not path.startswith(prefix):
+                    break
+                if pattern.match(path) is not None:
+                    return True
+                index += 1
+            continue
+        for path in changed_paths:
+            if pattern.match(path) is not None:
+                return True
     return False
 
 


### PR DESCRIPTION
## Summary
- Cache normalized changed-path tuples for repeated PR-scoped `build_scope_report` calls.
- Use the cached sorted tuple to bisect force-all wildcard prefixes before regex matching.
- Extend the existing scope-matcher regression test and add a governing plan for this slice.

## Plan or Spec
- `docs/plans/2026-07-19-pr-scope-force-wildcard-inline-loop.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...pr-scoped-performance-scope-matcher focused selection
# 26 passed in 15.83s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ...pr-scoped-performance-scope-matcher focused selection && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/pr_scoped_performance.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 26 passed in 50.04s; TOTAL 35 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id pr-scoped-performance-scope-matcher --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-pr-scope-force-wildcard-inline-20260719 --head-repo "$PWD" --output /tmp/pr-scope-force-wildcard-inline-probe.json
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 35 0 100%`.
- Registered probe: `pr-scoped-performance-scope-matcher`.
- Local base-vs-head registered probe result:
  - `build_scope_report_ms_mean`: base `2.062753` ms, head `0.726111` ms, delta `-1.336642` ms (~64.8% faster).
  - `build_scope_report_ms_min`: base `0.100107` ms, head `0.099146` ms.
  - `selected_probe_count_mean`: base `7.0`, head `7.0`.
  - `force_all_selected_mean`: base `0.0`, head `0.0`.
- CI PR-scoped performance report is required before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
