### PR TITLE
perf: seed slowest probe phase heap once

### DIFF
--- a/docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md
+++ b/docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md
@@ -26,3 +26,9 @@ The probe includes focused `test_command`, `coverage_command`, and `probe_comman
 3. Run the registered probe locally on Linux and compare the pre/post metrics, especially `matrix_roles_elapsed_ms_mean` and `elapsed_ms_mean`.
 
 GitHub Actions PR-scoped performance remains the final registered probe validation and merge gate.
+
+## Follow-up: slowest probe phase heap initialization
+
+The 2026-07-19 follow-up remains inside `worker.productization.report_evidence_gate` and keeps the same registered `report-evidence-gate-run-kind-set-membership` probe. `_slowest_probe_phases()` now appends the first five candidate rows directly and heapifies once before replacement comparisons, instead of calling `heapq.heappush()` for each seed row. The top-five ordering, side labels, typed duration handling, and tie ordering remain unchanged.
+
+Expected effect: lower `slowest_probe_phase_elapsed_ms_mean` in the registered probe, with the broader gate metrics non-regressive.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -587,7 +587,8 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
     rows: list[tuple[float, int, str, dict[str, object]]] = []
     row_index = 0
     row_count = 0
-    rows_push = heapq.heappush
+    heap_ready = False
+    rows_append = rows.append
     rows_replace = heapq.heapreplace
     for side in ("baseline", "candidate"):
         side_summary = probe_summary.get(side)
@@ -609,12 +610,16 @@ def _slowest_probe_phases(report: dict[str, object]) -> list[dict[str, object]]:
             else:
                 duration_ms = 0.0
             if row_count < 5:
-                rows_push(rows, (duration_ms, -row_index, side, row))
+                rows_append((duration_ms, -row_index, side, row))
                 row_count += 1
-            elif duration_ms >= rows[0][0]:
-                item = (duration_ms, -row_index, side, row)
-                if item > rows[0]:
-                    rows_replace(rows, item)
+            else:
+                if not heap_ready:
+                    heapq.heapify(rows)
+                    heap_ready = True
+                if duration_ms >= rows[0][0]:
+                    item = (duration_ms, -row_index, side, row)
+                    if item > rows[0]:
+                        rows_replace(rows, item)
             row_index += 1
     rows.sort(reverse=True)
     return [{"side": side, **row} for _duration_ms, _row_order, side, row in rows]


### PR DESCRIPTION
## Summary
- Seed `_slowest_probe_phases()` with direct list appends and heapify once before replacement comparisons instead of calling `heapq.heappush()` for each initial top-five row.
- Preserve top-five ordering, side labels, duration coercion, and tie ordering.

## Plan or Spec
- `docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md` follow-up section: slowest probe phase heap initialization.
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
```text
# Baseline probe before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_SAMPLES=5 MELIX_REPORT_EVIDENCE_GATE_ITERATIONS=50 uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py
# exit 0; elapsed_ms_mean=1007.4272114783525; slowest_probe_phase_elapsed_ms_mean=23.05698678828776

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_keeps_top_five_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_preserves_tie_order services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_slowest_probe_phases_accepts_typed_durations
# exit 0; 3 passed in 0.07s

# Registered focused test command for report-evidence-gate-run-kind-set-membership
bash /tmp/melix_report_probe_commands.sh
# exit 0; 34 passed in 0.18s

# Registered changed-scope coverage command for report-evidence-gate-run-kind-set-membership
bash /tmp/melix_report_probe_coverage.sh
# exit 0; TOTAL 10 0 100%

# Registered local Linux probe command for report-evidence-gate-run-kind-set-membership
bash /tmp/melix_report_probe.sh
# exit 0; elapsed_ms_mean=967.2503759153187; slowest_probe_phase_elapsed_ms_mean=22.491356590762734

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%` for `services/mlx-worker-python/worker/productization/report_evidence_gate.py` and registered probe/test scope.
- Local registered probe delta: `elapsed_ms_mean` 1007.4272114783525 -> 967.2503759153187 ms (`delta=-40.17683556303382 ms`, speedup `1.0415350989x`).
- Focus metric delta: `slowest_probe_phase_elapsed_ms_mean` 23.05698678828776 -> 22.491356590762734 ms (`delta=-0.5656301975250264 ms`, speedup `1.0251487868x`).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- None for the Python/Linux slice. macOS/Swift runtime validation is not applicable.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
