### PR TITLE
perf: streamline report evidence run-kind values

### DIFF
--- a/docs/plans/2026-07-19-report-evidence-run-kind-set-comprehension.md
+++ b/docs/plans/2026-07-19-report-evidence-run-kind-set-comprehension.md
@@ -1,0 +1,42 @@
+# Report evidence run-kind set comprehension
+
+## Scope
+
+This Python-only performance slice is limited to `worker.productization.report_evidence_gate._report_run_kind_values`, the helper used by `_report_matrix_roles(...)` when a release evidence matrix contains run-kind-only rules.
+
+## Optimization
+
+`_report_run_kind_values(...)` currently builds the run-kind set with an explicit Python loop and a locally bound `set.add`. This slice keeps the same normalization behavior while using a set comprehension so CPython can perform the simple collection build with less Python bytecode overhead.
+
+Behavior remains unchanged:
+
+- string `run_kind` values are included as-is;
+- non-string values are converted with `str(...)`;
+- missing run kinds still contribute the existing empty-string fallback.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_report_evidence_gate.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/report_evidence_gate_run_kind_probe.py`
+
+## Verification plan
+
+1. Run focused report evidence tests around run-kind role matching.
+2. Run the registered focused test command for `report-evidence-gate-run-kind-set-membership`.
+3. Run the registered changed-scope coverage command and require at least 95 percent coverage.
+4. Run the registered probe locally on Linux before and after the change and compare `matrix_roles_elapsed_ms_mean` plus the broader report-evidence guardrail metrics.
+5. Use GitHub Actions PR-scoped performance output as the final merge gate.
+
+## Baseline
+
+Initial local Linux baseline on `origin/main` with the registered probe command:
+
+```json
+{"dict_list_checksum": 10240000.0, "dict_list_elapsed_ms_mean": 38.20913536474109, "dict_list_identity_hits": 5000.0, "dict_list_rows_per_call": 2048.0, "elapsed_ms_mean": 1005.0677983555943, "iterations": 50000.0, "load_report_payload_bytes": 6247.0, "load_report_payload_checksum": 48000.0, "load_report_payload_elapsed_ms_mean": 7.150595122948289, "match_count": 250000.0, "matrix_roles_elapsed_ms_mean": 3.1098753679543734, "matrix_roles_emitted_roles": 40000.0, "matrix_roles_probe_phase_rows": 2048.0, "matrix_roles_report_count": 1.0, "matrix_roles_role_count": 32.0, "metric_prefix_count": 65.0, "metric_prefix_elapsed_ms_mean": 405.36599582992494, "metric_prefix_match_count": 250000.0, "metrics_per_call": 80.0, "probe_phases_checksum": 320000.0, "probe_phases_elapsed_ms_mean": 46.749754482880235, "probe_phases_rows_per_call": 2048.0, "release_matrix_elapsed_ms_mean": 28.913624864071608, "release_matrix_emitted_rows": 80000.0, "release_matrix_report_count": 96.0, "release_matrix_role_count": 32.0, "run_kind_count": 65.0, "run_kind_elapsed_ms_mean": 213.39659257791936, "runs_per_call": 80.0, "sample_count": 5.0, "slowest_probe_phase_checksum": 2488000.0, "slowest_probe_phase_elapsed_ms_mean": 25.466515589505434, "slowest_probe_phase_rows_per_call": 2000.0, "target_field_count": 65.0, "target_field_elapsed_ms_mean": 265.61933401972055, "target_field_match_count": 250000.0, "targets_per_call": 80.0}
+```

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -368,16 +368,11 @@ def _run_kind_rule_matches(run_kinds: object, run_kind_values: AbstractSet[str])
 
 def _report_run_kind_values(runs: list[dict[str, object]]) -> set[str]:
     run_kind_key = "run_kind"
-    values: set[str] = set()
-    values_add = values.add
     to_string = str
-    for run in runs:
-        run_kind = run.get(run_kind_key, "")
-        if type(run_kind) is str:
-            values_add(run_kind)
-        else:
-            values_add(to_string(run_kind))
-    return values
+    return {
+        run_kind if type(run_kind := run.get(run_kind_key, "")) is str else to_string(run_kind)
+        for run in runs
+    }
 
 
 def _rule_matches_report(


### PR DESCRIPTION
## Summary
- Streamline `report_evidence_gate._report_run_kind_values` by building normalized run-kind values with a set comprehension.
- Keep run-kind normalization behavior unchanged for strings, non-strings, and missing `run_kind` fields.
- Add a focused plan for the registered performance slice.

## Plan or Spec
- `docs/plans/2026-07-19-report-evidence-run-kind-set-comprehension.md`
- Registered probe: `report-evidence-gate-run-kind-set-membership`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_matrix_roles_lazily_loads_targets_and_metrics_for_run_kind_only_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_matrix_roles_select_multiple_run_kind_rules services/mlx-worker-python/tests/test_report_evidence_gate.py::test_report_evidence_gate_run_kind_list_rules_reflect_mutation`
- Registered focused test command for `report-evidence-gate-run-kind-set-membership` (`34 passed`)
- Registered changed-scope coverage command for `report-evidence-gate-run-kind-set-membership`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`
- Baseline registered probe on `origin/main`:
  - `elapsed_ms_mean=1005.0677983555943`
  - `matrix_roles_elapsed_ms_mean=3.1098753679543734`
  - `run_kind_elapsed_ms_mean=213.39659257791936`
- Candidate registered probe after change:
  - `elapsed_ms_mean=983.0933582503349`
  - `matrix_roles_elapsed_ms_mean=3.012266429141164`
  - `run_kind_elapsed_ms_mean=211.53674297966063`
- Local Linux delta:
  - overall `elapsed_ms_mean`: `-21.97444010525942 ms` (`~2.19%` faster)
  - `matrix_roles_elapsed_ms_mean`: `-0.0976089388132094 ms` (`~3.14%` faster)
  - `run_kind_elapsed_ms_mean`: `-1.85984959825873 ms` (`~0.87%` faster)

## Known Gaps
- Local validation is Linux-only. The PR-scoped performance GitHub Actions report is still required as the registered probe merge gate.
- Some unrelated guardrail timings move within probe noise; the targeted run-kind/matrix-role metrics improved locally.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe.
- [x] Registered probe has focused `test_command`, `coverage_command`, and `probe_command` entries.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at >=95%.
- [x] Registered local probe ran on Linux with an improving targeted metric.
- [ ] PR-scoped performance CI completed successfully.
