### PR TITLE
perf: fast-path statistical category string labels

### DIFF
--- a/docs/plans/2026-05-21-statistical-category-local-bindings.md
+++ b/docs/plans/2026-05-21-statistical-category-local-bindings.md
@@ -41,3 +41,26 @@ lookup overhead on every included row.
 - The local registered probe reports lower `elapsed_ms_mean` versus the
   pre-change baseline while preserving checksum, row count, and category count.
 - GitHub Actions PR-scoped performance completes successfully before merge.
+
+## 2026-07-20 follow-up: exact string category label check
+
+This follow-up keeps the same registered probe and narrows to the category-label
+normalization branch in `build_category_breakdown()`. The common row payload uses
+plain `str` category labels, so the hot loop now checks the locally bound
+`type(raw_category_label) is str` fast path before falling back to the original
+`isinstance(..., str)` behavior for string subclasses and to
+`str(raw_category_label).strip()` for non-string labels. This preserves
+missing-key handling, string-subclass labels with custom `__str__`, non-string
+label support, deterministic ordering, and rounded accuracy payloads while
+avoiding an `isinstance(...)` call for each included plain-string row.
+
+Local Linux probe quintet:
+
+- Baseline `elapsed_ms_mean`: `9.978312626481056`, `10.006940178573132`,
+  `11.492647929117084`, `10.83152424544096`, `11.737409373745322` ms; mean
+  `10.80936687067151` ms.
+- Post-change `elapsed_ms_mean`: `10.127129592001438`, `9.964018128812313`,
+  `10.066704591736197`, `9.91921592503786`, `10.359516181051731` ms; mean
+  `10.087316883727908` ms (`-0.7220499869436026` ms, `1.0716x` faster,
+  `-6.68%`).
+- `peak_bytes_mean` stayed `17040.0`; checksum stayed `250365.72`.

--- a/services/mlx-worker-python/tests/test_statistical_evidence.py
+++ b/services/mlx-worker-python/tests/test_statistical_evidence.py
@@ -425,6 +425,13 @@ def test_statistical_helper_edges_cover_percentiles_and_interval_sign_fallbacks(
 
 
 def test_build_category_breakdown_aggregates_supported_categories_only() -> None:
+    class CategoryLabel(str):
+        def __str__(self) -> str:
+            return "override-should-not-relabel-str-subclasses"
+
+    subclass_label = CategoryLabel(" subclass ")
+    assert str(subclass_label) == "override-should-not-relabel-str-subclasses"
+
     breakdown = build_category_breakdown(
         rows=(
             {"category_label": "math", "base_correct": False, "target_correct": True},
@@ -432,6 +439,7 @@ def test_build_category_breakdown_aggregates_supported_categories_only() -> None
             {"category_label": "history", "base_correct": True, "target_correct": False},
             {"category_label": "history"},
             {"category_label": 7, "base_correct": False, "target_correct": True},
+            {"category_label": subclass_label, "base_correct": True, "target_correct": True},
             {"category_label": "", "base_correct": True, "target_correct": True},
         )
     )
@@ -442,6 +450,12 @@ def test_build_category_breakdown_aggregates_supported_categories_only() -> None
             "base_accuracy": 0.0,
             "target_accuracy": 1.0,
             "delta_accuracy": 1.0,
+        },
+        "subclass": {
+            "sample_size": 1,
+            "base_accuracy": 1.0,
+            "target_accuracy": 1.0,
+            "delta_accuracy": 0.0,
         },
         "history": {
             "sample_size": 2,

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -83,14 +83,17 @@ def build_category_breakdown(
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
     category_totals_get = category_totals.get
-    is_instance = isinstance
     string_type = str
+    value_type = type
+    is_instance = isinstance
     for row in rows:
         try:
             raw_category_label = row["category_label"]
         except KeyError:
             continue
-        if is_instance(raw_category_label, string_type):
+        if value_type(raw_category_label) is string_type:
+            category_label = raw_category_label.strip()
+        elif is_instance(raw_category_label, string_type):
             category_label = raw_category_label.strip()
         else:
             category_label = string_type(raw_category_label).strip()


### PR DESCRIPTION
## Summary
- Fast-path plain `str` category labels in `build_category_breakdown()` with a locally bound exact-type check.
- Preserve the original `isinstance(..., str)` behavior for string subclasses and non-string label fallback semantics.
- Extend the focused statistical evidence test to cover string subclasses with custom `__str__`.

## Plan or Spec
- Updated `docs/plans/2026-05-21-statistical-category-local-bindings.md` with this follow-up slice, validation boundary, and local probe metrics.
- Affected path is already covered by registered PR-scoped probe `statistical-evidence-category-breakdown-single-pass` in `infra/perf/pr_scoped_probes.json`, including `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `git fetch origin && git rev-parse origin/main && git rev-parse HEAD && git status --short --branch`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_category_breakdown_probe.py`
- Baseline probe x5 from detached `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py`
- Post-change probe x5: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 6 passed in 0.15s; focused coverage replay: 6 passed in 0.27s.
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Baseline `elapsed_ms_mean` samples: `9.978312626481056`, `10.006940178573132`, `11.492647929117084`, `10.83152424544096`, `11.737409373745322` ms; mean `10.80936687067151` ms.
- Post-change `elapsed_ms_mean` samples: `10.127129592001438`, `9.964018128812313`, `10.066704591736197`, `9.91921592503786`, `10.359516181051731` ms; mean `10.087316883727908` ms.
- Delta: `-0.7220499869436026` ms, `1.0716x` faster, `-6.68%`; `peak_bytes_mean` stayed `17040.0`, checksum stayed `250365.72`.
- CI PR-scoped performance is required for final registered-probe validation before merge.

## Known Gaps
- Local validation is Linux-only Python worker validation. No Swift runtime effect is claimed for this Python-only slice.
- Probe timings are small and noisy; acceptance relies on the registered PR-scoped CI probe also completing successfully.

## Evidence Checklist
- [x] Branch created from current `origin/main` (`268456c87f48a6bea7bb16ef15f80dda88a56ae2`).
- [x] Affected path has registered PR-scoped probe with focused commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally with preserved checksum and improved elapsed mean.
- [ ] GitHub Actions and PR-scoped performance completed successfully.
