### PR TITLE
perf: fast-path PR report JSON suffix check

### DIFF
--- a/docs/plans/2026-07-12-pr-scoped-performance-report-suffix-check.md
+++ b/docs/plans/2026-07-12-pr-scoped-performance-report-suffix-check.md
@@ -28,3 +28,22 @@ The probe creates 2,000 JSON result files plus a non-JSON file and measures `_lo
 ## Expected Impact
 
 The registered probe should report lower or stable `elapsed_ms_mean` / `elapsed_ms_min` for report result loading by avoiding one short-lived string allocation per scanned directory entry.
+
+## Follow-up Slice: Fixed-Length JSON Suffix Slice
+
+The 2026-07-20 follow-up keeps the same registered probe and narrows to the
+same result-directory filter. The result loader only accepts the literal
+five-character `.json` suffix, so this slice uses a fixed-width tail comparison
+(`entry.name[-5:] == ".json"`) instead of the generic `str.endswith()` helper in
+the per-entry scan loop.
+
+This preserves accepted filenames, `os.scandir()` traversal, deterministic path
+sorting, binary JSON reads, non-dict filtering, and missing-directory behavior.
+The decision is measurement-gated because this reverses the earlier allocation
+hypothesis: on the registered Linux probe, the fixed-width slice comparison was
+faster than the current `endswith()` path for the synthetic 2,000-result report
+workload.
+
+Success is accepted only if the focused registered tests, changed-scope coverage,
+and registered local Linux probe pass, and if the PR-scoped performance CI probe
+completes successfully before merge.

--- a/scripts/pr_scoped_performance_report.py
+++ b/scripts/pr_scoped_performance_report.py
@@ -29,7 +29,7 @@ def _load_results(results_dir: Path) -> list[dict[str, object]]:
             result_paths: list[str] = []
             append_path = result_paths.append
             for entry in entries:
-                if entry.name.endswith(".json"):
+                if entry.name[-5:] == ".json":
                     append_path(entry.path)
     except OSError:
         return []


### PR DESCRIPTION
## Summary
- Fast-path the PR-scoped performance report result filter by comparing the fixed `.json` tail directly.
- Keep `os.scandir()` traversal, deterministic sorting, binary JSON reads, non-dict filtering, and missing-directory behavior unchanged.

## Plan or Spec
- `docs/plans/2026-07-12-pr-scoped-performance-report-suffix-check.md`

## Commands Run
```text
# Baseline on origin/main (b5d5105d), exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report_results_probe.py
{"elapsed_ms_mean": 24.886483, "elapsed_ms_min": 23.065888, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}

# Head local focused tests, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke
6 passed in 7.67s

# Head changed-scope coverage, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_performance_report_results_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_scandir_and_binary_json_reads services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_report_results_loader_uses_module_open_binding services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_performance_report_results_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_cli_scripts_smoke && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/pr_scoped_performance_report.py scripts/pr_scoped_performance_report_results_probe.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
6 passed in 42.48s
TOTAL 1 0 100%

# Head registered local probe, exit 0
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_report_results_probe.py
{"elapsed_ms_mean": 22.946611, "elapsed_ms_min": 20.76535, "file_count": 2000.0, "result_count": 2000.0, "sample_count": 5.0}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Registered probe: `pr-scoped-performance-report-results-scandir`.
- Local Linux probe delta: `elapsed_ms_mean` 24.886483 ms -> 22.946611 ms (`-1.939872 ms`, ~7.79% faster); `elapsed_ms_min` 23.065888 ms -> 20.76535 ms (`-2.300538 ms`).
- CI PR-scoped performance report is required before merge.

## Known Gaps
- This is a Python tooling path validated locally on Linux; CI remains the source of truth for the registered PR-scoped performance workflow report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
