### PR TITLE
perf: cache dataset record source ids

### DIFF
--- a/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
+++ b/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
@@ -68,3 +68,16 @@ The registered `dataset-source-records-scandir` probe fixture now includes all
 structured ingest suffixes (`.jsonl`, `.json`, `.csv`, `.tsv`) so local Linux
 and PR-scoped CI probe classification timing covers the optimized path before
 the slice is merged.
+
+## 2026-07-20 follow-up: source-id digest cache
+
+This Python-only follow-up keeps the same registered `dataset-source-records-scandir`
+probe and narrows to `_record(...)` source-id construction. Repeated source record
+materialization for stable paths previously encoded and hashed the path text on
+every pass even though the source-id is deterministic for a path. This slice adds
+a bounded LRU cache for the path-text-to-source-id digest while keeping content
+digest caching, metadata copying, normalized text handling, and the public source-id
+value unchanged.
+
+Success remains gated by the registered focused tests, changed-scope coverage,
+local Linux probe output for `record_elapsed_ms_*`, and PR-scoped performance CI.

--- a/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
+++ b/docs/plans/2026-06-20-dataset-source-empty-check-isspace.md
@@ -81,3 +81,7 @@ value unchanged.
 
 Success remains gated by the registered focused tests, changed-scope coverage,
 local Linux probe output for `record_elapsed_ms_*`, and PR-scoped performance CI.
+A 2026-07-20 review follow-up switches cached source-id hashing to `os.fsencode(...)`
+so arbitrary filesystem path strings with surrogate escapes use Python's filesystem
+encoding/error policy rather than hard-coded UTF-8 strict encoding; normal path IDs
+remain unchanged.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -254,8 +254,16 @@ def test_dataset_ingest_record_reuses_source_id_cache() -> None:
     assert cache_info.hits == 1
     assert cache_info.misses == 1
     assert first_record["source_id"] == second_record["source_id"]
-    assert first_record["source_id"] == hashlib.sha256(b"same.txt").hexdigest()[:16]
+    assert first_record["source_id"] == hashlib.sha256(os.fsencode("same.txt")).hexdigest()[:16]
     assert first_record["content_sha256"] != second_record["content_sha256"]
+
+
+def test_dataset_ingest_record_source_id_uses_filesystem_encoding_for_surrogates() -> None:
+    _record_source_id.cache_clear()
+
+    path_text = "surrogate-\udcff.txt"
+
+    assert _record_source_id(path_text) == hashlib.sha256(os.fsencode(path_text)).hexdigest()[:16]
 
 
 def test_dataset_ingest_record_accepts_pre_normalized_text(

--- a/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_ingest.py
@@ -21,6 +21,7 @@ from worker.productization.dataset_preparation import (
     _normalize_line_endings,
     _record,
     _record_content_digest_and_size,
+    _record_source_id,
     _read_source_text,
     _source_size_entries,
     _source_kind,
@@ -241,6 +242,20 @@ def test_dataset_ingest_record_reuses_normalized_text_digest_cache() -> None:
     assert first_record["source_id"] == hashlib.sha256(b"first.txt").hexdigest()[:16]
     assert second_record["source_id"] == hashlib.sha256(b"second.txt").hexdigest()[:16]
     assert first_record["source_id"] != second_record["source_id"]
+
+
+def test_dataset_ingest_record_reuses_source_id_cache() -> None:
+    _record_source_id.cache_clear()
+
+    first_record = _record(Path("same.txt"), "text", "first\n", {}, normalized=True)
+    second_record = _record(Path("same.txt"), "text", "second\n", {}, normalized=True)
+
+    cache_info = _record_source_id.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.misses == 1
+    assert first_record["source_id"] == second_record["source_id"]
+    assert first_record["source_id"] == hashlib.sha256(b"same.txt").hexdigest()[:16]
+    assert first_record["content_sha256"] != second_record["content_sha256"]
 
 
 def test_dataset_ingest_record_accepts_pre_normalized_text(

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1527,10 +1527,8 @@ def _record(
     normalized_text = text if normalized else _normalize_line_endings(text)
     content_sha256, byte_size = _record_content_digest_and_size(normalized_text)
     record_metadata = dict(metadata) if metadata else {}
-    sha256 = _SHA256
-    path_key = str(path).encode("utf-8")
     return {
-        "source_id": sha256(path_key).hexdigest()[:16],
+        "source_id": _record_source_id(os.fspath(path)),
         "source_uri": path.name,
         "source_kind": source_kind,
         "content_sha256": content_sha256,
@@ -1545,6 +1543,11 @@ def _record(
 def _record_content_digest_and_size(normalized_text: str) -> tuple[str, int]:
     normalized_bytes = normalized_text.encode("utf-8")
     return _SHA256(normalized_bytes).hexdigest(), len(normalized_bytes)
+
+
+@lru_cache(maxsize=8192)
+def _record_source_id(path_text: str) -> str:
+    return _SHA256(path_text.encode("utf-8")).hexdigest()[:16]
 
 
 def _failure_id(reason: str, name: str) -> str:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1547,7 +1547,7 @@ def _record_content_digest_and_size(normalized_text: str) -> tuple[str, int]:
 
 @lru_cache(maxsize=8192)
 def _record_source_id(path_text: str) -> str:
-    return _SHA256(path_text.encode("utf-8")).hexdigest()[:16]
+    return _SHA256(os.fsencode(path_text)).hexdigest()[:16]
 
 
 def _failure_id(reason: str, name: str) -> str:


### PR DESCRIPTION
## Summary
- Cache deterministic dataset source-id digests for repeated `_record(...)` materialization.
- Add focused regression coverage proving the source-id cache is reused without changing digest values.
- Follow up on review by hashing cached source IDs with `os.fsencode(...)` so filesystem-surrogate path strings use Python's filesystem encoding/error policy.
- Update the dataset source-record performance plan for this follow-up slice.

## Plan or Spec
- Updated `docs/plans/2026-06-20-dataset-source-empty-check-isspace.md` with the 2026-07-20 source-id digest cache slice and filesystem-encoding follow-up.
- Registered probe coverage: existing `dataset-source-records-scandir` entry in `infra/perf/pr_scoped_probes.json` covers `dataset_preparation.py`, focused ingest tests, PR-scoped performance tests, and the probe script with `test_command`, `coverage_command`, and `probe_command`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_record_reuses_source_id_cache services/mlx-worker-python/tests/test_dataset_preparation_ingest.py::test_dataset_ingest_record_reuses_normalized_text_digest_cache`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_restores_gc_state services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_supports_multiple_timed_samples services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_count services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_file_order services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_source_kind services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_source_records_probe_rejects_changed_record_byte_accounting` (49 passed after filesystem-encoding follow-up)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_source_records_probe.py` (100.00%, 6/6 changed lines after filesystem-encoding follow-up)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_SOURCE_RECORDS_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/dataset_source_records_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id dataset-source-records-scandir --base-repo /root/.hermes/profiles/coder/workspace/worktrees/melix-baseline-dataset-record-source-id-cache-20260720 --head-repo "$PWD" --output /tmp/dataset_source_records_followup_probe.json`
- `git diff --check`

## Coverage and Metrics
- Initial focused cache tests: 2 passed.
- Registered focused tests after review follow-up: 49 passed.
- Changed-scope coverage after review follow-up: 100.00% (6/6 measurable changed lines covered).
- Initial local PR-scoped probe (`dataset-source-records-scandir`) base vs head before review follow-up:
  - `record_elapsed_ms_mean`: 9.982802 -> 6.975042 ms (-3.007760 ms, ~30.13% faster).
  - `record_elapsed_ms_p95`: 10.562313 -> 6.857991 ms (-3.704322 ms, ~35.07% faster).
  - `read_elapsed_ms_mean`: 61.345235 -> 59.948875 ms (-1.396361 ms, ~2.28% faster).
  - `elapsed_ms_mean`: 11.147119 -> 11.507635 ms (+0.360516 ms, ~3.23% slower; within the registered 5% warning threshold and outside the targeted record slice).
- Follow-up local PR-scoped probe (`/tmp/dataset_source_records_followup_probe.json`) base vs head after `os.fsencode(...)`:
  - `record_elapsed_ms_mean`: 10.018814 -> 7.870029 ms (-2.148785 ms, ~21.45% faster).
  - `record_elapsed_ms_p95`: 10.261629 -> 10.456305 ms (+0.194676 ms, ~1.90% slower; within threshold).
  - `elapsed_ms_mean`: 11.074113 -> 11.247286 ms (+0.173172 ms, ~1.56% slower; within threshold).
  - `elapsed_ms_p95`: 11.085736 -> 11.881780 ms (+0.796044 ms, ~7.18% slower in this local sample; CI PR-scoped performance is the final gate and this PR must not merge unless the report is non-regressing/accepted).
- Final GitHub Actions PR-scoped performance report: `ok`, 3 selected probes, 0 regressions, 0 verification failures.
- Final CI `dataset-source-records-scandir` metrics:
  - `record_elapsed_ms_mean`: 11.543 -> 8.707 ms (-2.836 ms, ~24.57% faster).
  - `record_elapsed_ms_p95`: 12.142 -> 8.741 ms (-3.402 ms, ~28.01% faster).
  - `elapsed_ms_mean`: 15.163 -> 14.805 ms (-0.357 ms, ~2.36% faster/neutral).

## Known Gaps
- This is a Python-only slice and was locally validated on Linux. No Swift runtime effect is claimed.
- Earlier local/CI probe runs showed p95 noise on non-target/context metrics; the final registered CI report is non-regressing and accepted.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests pass.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered local Linux probe was run with base/head metrics.
- [x] PR-scoped performance CI completed successfully with an acceptable report.
- [x] All PR checks are green before merge.
