### PR TITLE
perf: skip dense coverage range scans

### DIFF
--- a/docs/plans/2026-07-20-changed-scope-dense-range-skip.md
+++ b/docs/plans/2026-07-20-changed-scope-dense-range-skip.md
@@ -27,7 +27,9 @@ For dense `set`/`frozenset` inputs and sorted measured coverage lists, this slic
 intersects the measured lists first and skips the separate range-bounds scan.
 If the intersections are empty, the function returns without reading source; if
 not, the existing measurable-line filtering and covered/missed partitioning stay
-unchanged.
+unchanged. The singleton changed-line path keeps its own direct measured-bounds
+fast path so the dense guard does not add overhead to the registered singleton
+range probe.
 
 ## Validation plan
 

--- a/docs/plans/2026-07-20-changed-scope-dense-range-skip.md
+++ b/docs/plans/2026-07-20-changed-scope-dense-range-skip.md
@@ -1,0 +1,46 @@
+# Changed-scope dense range-skip performance slice
+
+## Scope
+
+This Python-only performance slice is limited to
+`scripts/changed_scope_coverage.py` and the dense measured-line path in
+`_measurable_changed_lines(...)`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`changed-scope-coverage-measured-set-filter` in
+`infra/perf/pr_scoped_probes.json`. The registry entry already includes focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `scripts/changed_scope_coverage.py`
+- `scripts/changed_scope_coverage_measured_probe.py`
+- `tests/test_changed_scope_coverage.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+
+## Optimization
+
+The dense changed-line path already intersects changed lines with measured
+coverage lines. Before that intersection, it still ran `_line_ranges_may_overlap(...)`,
+which computes changed-set bounds with `min(changed)` and `max(changed)`.
+For dense `set`/`frozenset` inputs and sorted measured coverage lists, this slice
+intersects the measured lists first and skips the separate range-bounds scan.
+If the intersections are empty, the function returns without reading source; if
+not, the existing measurable-line filtering and covered/missed partitioning stay
+unchanged.
+
+## Validation plan
+
+1. Add regression coverage proving dense set inputs do not call the range-overlap
+   helper before intersecting measured lines.
+2. Run the registered focused test command for
+   `changed-scope-coverage-measured-set-filter` locally on Linux.
+3. Run the registered changed-scope coverage command locally on Linux.
+4. Run the registered probe locally on Linux and compare against the pre-change
+   baseline.
+5. Use the GitHub Actions PR-scoped performance report as the merge gate.
+
+## Boundary
+
+No Swift/macOS runtime effect is claimed for this slice. Local Linux validation
+covers the Python script behavior, changed-scope coverage, and registered probe.

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -317,17 +317,44 @@ def _measurable_changed_lines(
         executed_lookup = (executed_line,)
         missing_lookup = (missing_line,)
     else:
-        if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
-            return [], [], []
+        executed_lookup = executed_lines
+        missing_lookup = missing_lines
+        changed_count = len(changed)
+        dense_sorted_measured = (
+            changed_count >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
+            and executed_lines
+            and missing_lines
+            and executed_lines[0] <= executed_lines[-1]
+            and missing_lines[0] <= missing_lines[-1]
+        )
+        measured_line_count = len(executed_lines) + len(missing_lines) if dense_sorted_measured else 0
+        if (
+            dense_sorted_measured
+            and measured_line_count
+            and changed_count * 4 >= measured_line_count
+            and isinstance(changed, (set, frozenset))
+        ):
+            executed_lookup = changed.intersection(executed_lines)
+            missing_lookup = changed.intersection(missing_lines)
+            measured_changed = list(executed_lookup)
+            measured_changed.extend(missing_lookup)
+        else:
+            if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
+                return [], [], []
+            measured_changed = None
         if executed_lines and executed_lines[0] > executed_lines[-1]:
             executed_lookup = set(executed_lines)
         else:
-            executed_lookup = executed_lines
+            if measured_changed is None:
+                executed_lookup = executed_lines
         if missing_lines and missing_lines[0] > missing_lines[-1]:
             missing_lookup = set(missing_lines)
         else:
-            missing_lookup = missing_lines
-        if isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
+            if measured_changed is None:
+                missing_lookup = missing_lines
+        if measured_changed is not None:
+            pass
+        elif isinstance(executed_lookup, list) and isinstance(missing_lookup, list):
             measured_line_count = len(executed_lookup) + len(missing_lookup)
             sorted_line_list_contains = _sorted_line_list_contains
             if (

--- a/scripts/changed_scope_coverage.py
+++ b/scripts/changed_scope_coverage.py
@@ -320,13 +320,35 @@ def _measurable_changed_lines(
         executed_lookup = executed_lines
         missing_lookup = missing_lines
         changed_count = len(changed)
-        dense_sorted_measured = (
-            changed_count >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
-            and executed_lines
-            and missing_lines
-            and executed_lines[0] <= executed_lines[-1]
-            and missing_lines[0] <= missing_lines[-1]
-        )
+        measured_changed = None
+        dense_sorted_measured = False
+        if changed_count == 1:
+            changed_line = next(iter(changed))
+            singleton_may_overlap = False
+            if executed_lines:
+                first_line = executed_lines[0]
+                last_line = executed_lines[-1]
+                if first_line > last_line:
+                    first_line = min(executed_lines)
+                    last_line = max(executed_lines)
+                singleton_may_overlap = first_line <= changed_line <= last_line
+            if not singleton_may_overlap and missing_lines:
+                first_line = missing_lines[0]
+                last_line = missing_lines[-1]
+                if first_line > last_line:
+                    first_line = min(missing_lines)
+                    last_line = max(missing_lines)
+                singleton_may_overlap = first_line <= changed_line <= last_line
+            if not singleton_may_overlap:
+                return [], [], []
+        else:
+            dense_sorted_measured = (
+                changed_count >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
+                and executed_lines
+                and missing_lines
+                and executed_lines[0] <= executed_lines[-1]
+                and missing_lines[0] <= missing_lines[-1]
+            )
         measured_line_count = len(executed_lines) + len(missing_lines) if dense_sorted_measured else 0
         if (
             dense_sorted_measured
@@ -338,7 +360,7 @@ def _measurable_changed_lines(
             missing_lookup = changed.intersection(missing_lines)
             measured_changed = list(executed_lookup)
             measured_changed.extend(missing_lookup)
-        else:
+        elif changed_count != 1:
             if not _line_ranges_may_overlap(changed, executed_lines, missing_lines):
                 return [], [], []
             measured_changed = None
@@ -359,8 +381,8 @@ def _measurable_changed_lines(
             sorted_line_list_contains = _sorted_line_list_contains
             if (
                 measured_line_count
-                and len(changed) >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
-                and len(changed) * 4 >= measured_line_count
+                and changed_count >= _DENSE_CHANGED_LINE_SCAN_THRESHOLD
+                and changed_count * 4 >= measured_line_count
             ):
                 if isinstance(changed, (set, frozenset)):
                     executed_lookup = changed.intersection(executed_lines)

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -818,6 +818,38 @@ def test_measurable_changed_lines_uses_dense_membership_scan(
     assert missed == list(range(2, 81, 2))
 
 
+def test_measurable_changed_lines_dense_sets_skip_range_bounds_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 81)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 80, 2)),
+                "missing_lines": list(range(2, 81, 2)),
+            }
+        }
+    }
+
+    def fail_range_overlap(*args: object, **kwargs: object) -> bool:  # pragma: no cover
+        raise AssertionError("dense changed sets should intersect measured lines before range bounds scans")
+
+    monkeypatch.setattr(changed_scope_coverage, "_line_ranges_may_overlap", fail_range_overlap)
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        set(range(1, 81)),
+    )
+
+    assert measurable == list(range(1, 81))
+    assert covered == list(range(1, 80, 2))
+    assert missed == list(range(2, 81, 2))
+
+
 def test_measurable_changed_lines_keeps_reversed_coverage_fallback(tmp_path: Path) -> None:
     source_path = tmp_path / "foo.py"
     source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 6)), encoding="utf-8")

--- a/tests/test_changed_scope_coverage.py
+++ b/tests/test_changed_scope_coverage.py
@@ -613,6 +613,92 @@ def test_measurable_changed_lines_checks_singletons_before_range_overlap(
     assert missed == []
 
 
+def test_measurable_changed_lines_singleton_skips_range_helper_for_measured_lists(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": list(range(1, 100, 2)),
+                "missing_lines": list(range(2, 101, 2)),
+            }
+        }
+    }
+
+    def fail_range_overlap(*args: object, **kwargs: object) -> bool:  # pragma: no cover
+        raise AssertionError("singleton changed sets should check measured bounds directly")
+
+    def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:  # pragma: no cover
+        raise AssertionError("out-of-range singleton changed line should not read source")
+
+    monkeypatch.setattr(changed_scope_coverage, "_line_ranges_may_overlap", fail_range_overlap)
+    monkeypatch.setattr(changed_scope_coverage.Path, "read_text", fail_read_text)
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {101},
+    )
+
+    assert measurable == []
+    assert covered == []
+    assert missed == []
+
+
+def test_measurable_changed_lines_singleton_handles_reversed_executed_bounds(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 7)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": [5, 3, 1],
+                "missing_lines": [],
+            }
+        }
+    }
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {3},
+    )
+
+    assert measurable == [3]
+    assert covered == [3]
+    assert missed == []
+
+
+def test_measurable_changed_lines_singleton_handles_reversed_missing_bounds(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "foo.py"
+    source_path.write_text("\n".join(f"line_{line_no}" for line_no in range(1, 7)), encoding="utf-8")
+    coverage_payload = {
+        "files": {
+            "foo.py": {
+                "executed_lines": [],
+                "missing_lines": [6, 4, 2],
+            }
+        }
+    }
+
+    measurable, covered, missed = changed_scope_coverage._measurable_changed_lines(
+        tmp_path,
+        coverage_payload,
+        "foo.py",
+        {4},
+    )
+
+    assert measurable == [4]
+    assert covered == []
+    assert missed == [4]
+
+
 def test_line_ranges_may_overlap_single_changed_line_avoids_changed_minmax(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Skip the separate range-overlap bounds scan for dense changed-scope coverage sets when measured coverage lines are already sorted.
- Keep singleton changed-line inputs on a direct measured-bounds fast path so they avoid the generic range helper as well.
- Add regression coverage for dense measured-line intersection and singleton measured-bounds behavior, and document the Python-only performance slice boundary.

## Plan or Spec
- `docs/plans/2026-07-20-changed-scope-dense-range-skip.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 58 passed in 0.33s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_changed_scope_coverage_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/changed_scope_coverage.py --coverage-json coverage.json scripts/changed_scope_coverage.py scripts/changed_scope_coverage_measured_probe.py tests/test_changed_scope_coverage.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
# 58 passed in 0.71s; TOTAL 47 0 100%

python3 scripts/changed_scope_coverage_measured_probe.py
# New repeated local samples included dense_elapsed_ms_mean: 46.8220, 46.7752, 44.7742 ms.

python3 scripts/changed_scope_coverage_singleton_probe.py
# New repeated local samples included elapsed_ms_mean: 0.5679, 0.5822, 0.6051 ms.

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 47 0 100%` for `scripts/changed_scope_coverage.py`, `scripts/changed_scope_coverage_measured_probe.py`, `tests/test_changed_scope_coverage.py`, and `services/mlx-worker-python/tests/test_pr_scoped_performance.py`.
- Registered probe coverage: `changed-scope-coverage-measured-set-filter` is registered with focused `test_command`, `coverage_command`, and `probe_command`; the related singleton path is covered by the existing `changed-scope-coverage-singleton-range-fastpath` probe.
- Local measured-set probe comparison against pre-follow-up `HEAD` samples: `dense_elapsed_ms_mean` 47.0582 ms -> 46.1238 ms (`-1.99%`, `delta=-0.9345 ms`).
- Local singleton probe comparison against pre-follow-up `HEAD` samples: `elapsed_ms_mean` 0.6252 ms -> 0.5851 ms (`-6.42%`, `delta=-0.0401 ms`).
- CI PR-scoped performance remains the merge gate for the registered probe report.

## Known Gaps
- No Swift/macOS runtime effect is claimed; this is a Linux-verified Python script slice.
- CI is required for the registered PR-scoped performance validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
