### PR TITLE
perf: bind export diagnostic redaction loop locals

### DIFF
--- a/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
+++ b/docs/plans/2026-06-28-export-diagnostics-source-line-extension.md
@@ -108,3 +108,28 @@ Local 2026-06-29 probe decision for this diagnosis-marker dispatch slice:
 - Post-change `peak_bytes_mean`: `204847.0`, `203285.2`, `203169.0` bytes; mean `203767.06666666665` bytes (`+819.5333333333256` bytes, within the registered 5% warning boundary).
 
 Decision: accepted because the targeted registered diagnosis-matching submetric improved over three local Linux probe runs, path redaction also improved, and the end-to-end elapsed/peak-memory movement stayed within the registered 5% warning boundary. `diagnostic_latency_ms` was noisy (`+0.5255787012477704` ms mean, `+5.96%`) and remains a CI-observed risk for this PR-scoped probe.
+
+## 2026-07-20 follow-up: redaction loop local bindings
+
+This Python-only follow-up stays inside the same
+`runtime-export-diagnostic-parser` registered probe and narrows to
+`_build_redacted_excerpt(...)`. The redaction loop now keeps the redaction helper
+and current `source_path` in local variables before prefix reuse. This preserves
+excerpt text, line-number mapping, truncation, and redaction counters while
+reducing repeated global lookup and slotted attribute access on the registered
+path-redaction submetric.
+
+Validation remains the registered focused pytest selection, changed-scope
+coverage, and the registered local/CI probe for runtime export diagnostic
+parsing.
+
+Local 2026-07-20 probe decision for this redaction-loop binding slice:
+
+- Baseline `elapsed_ms_mean`: `2629.5241069979966`, `2622.8228258434683`, `2585.4673861525953` ms; mean `2612.60477299802` ms.
+- Post-change `elapsed_ms_mean`: `2610.936465440318`, `2559.9187607411295`, `2643.1361829862` ms; mean `2604.6638030558825` ms (`-7.940969942137599` ms, `1.0030x` faster).
+- Baseline `path_redaction_elapsed_ms_mean`: `19.895885000005364`, `20.440040389075875`, `21.177809173241258` ms; mean `20.50457818744083` ms.
+- Post-change `path_redaction_elapsed_ms_mean`: `20.10074481368065`, `20.044437143951654`, `19.781076814979315` ms; mean `19.97541959087054` ms (`-0.5291585965702907` ms, `1.0265x` faster).
+- Baseline `peak_bytes_mean`: `196635.8`, `203640.8`, `202438.6` bytes; mean `200905.06666666665` bytes.
+- Post-change `peak_bytes_mean`: `203278.8`, `203712.0`, `204345.2` bytes; mean `203778.66666666666` bytes (`+2873.600000000006` bytes, within the registered 5% warning boundary).
+
+Decision: accepted because the registered end-to-end elapsed metric and the targeted path-redaction submetric improved over three local Linux probe runs, behavior is covered by 100% changed-scope coverage, and the peak-memory movement remains within the registered warning boundary.

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -590,6 +590,7 @@ def _build_redacted_excerpt(
     used_bytes = 0
     last_source_path = ""
     last_source_prefix = ""
+    redact_text = _redact_text
     try:
         resolved_target_root = layout.target_root.resolve(strict=False)
     except OSError:
@@ -599,12 +600,13 @@ def _build_redacted_excerpt(
         if output_line_count >= bounded_lines:
             summary.truncated = True
             break
-        redacted = _redact_text(source_line.text, resolved_target_root, resolved_target_root_text, summary)
-        if source_line.source_path == last_source_path:
+        source_path = source_line.source_path
+        redacted = redact_text(source_line.text, resolved_target_root, resolved_target_root_text, summary)
+        if source_path == last_source_path:
             source_prefix = last_source_prefix
         else:
-            last_source_path = source_line.source_path
-            source_prefix = f"[{source_line.source_path}] "
+            last_source_path = source_path
+            source_prefix = f"[{source_path}] "
             last_source_prefix = source_prefix
         rendered = source_prefix + redacted
         if rendered.isascii():


### PR DESCRIPTION
## Summary
- Bind `_build_redacted_excerpt()` loop helpers locally on the runtime export diagnostic redaction hot path.
- Keep excerpt rendering, line-number mapping, truncation, and redaction counters unchanged.
- Record the 2026-07-20 local Linux probe decision in the governing runtime export diagnostics plan.

## Plan or Spec
- `docs/plans/2026-06-28-export-diagnostics-source-line-extension.md`
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `git fetch origin && git reset --hard origin/main`
- Baseline probe x3: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- Focused tests: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- Changed-scope coverage: registered `runtime-export-diagnostic-parser` `coverage_command`
- Post-change registered probe x3: registered `runtime-export-diagnostic-parser` `probe_command`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `84 passed in 1.81s`.
- Changed-scope coverage: `TOTAL 6 0 100%`.
- Baseline `elapsed_ms_mean`: `2629.5241069979966`, `2622.8228258434683`, `2585.4673861525953` ms; mean `2612.60477299802` ms.
- Post-change `elapsed_ms_mean`: `2610.936465440318`, `2559.9187607411295`, `2643.1361829862` ms; mean `2604.6638030558825` ms (`-7.940969942137599` ms, `1.0030x` faster).
- Baseline `path_redaction_elapsed_ms_mean`: `19.895885000005364`, `20.440040389075875`, `21.177809173241258` ms; mean `20.50457818744083` ms.
- Post-change `path_redaction_elapsed_ms_mean`: `20.10074481368065`, `20.044437143951654`, `19.781076814979315` ms; mean `19.97541959087054` ms (`-0.5291585965702907` ms, `1.0265x` faster).
- Baseline `peak_bytes_mean`: mean `200905.06666666665` bytes.
- Post-change `peak_bytes_mean`: mean `203778.66666666666` bytes (`+2873.600000000006` bytes, within the registered 5% warning boundary).

## Known Gaps
- Local verification covers the Python runtime export diagnostic path on Linux only.
- CI must run the registered PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux with three post-change samples.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
