### PR TITLE
perf: cache exact invalid probe policy strings

### DIFF
--- a/docs/plans/2026-05-23-probe-policy-invalid-string-cache.md
+++ b/docs/plans/2026-05-23-probe-policy-invalid-string-cache.md
@@ -26,3 +26,13 @@ normalization so repeated absent-value parsing returns the cached default policy
 without allocating and normalizing `str(None or "")`. The registered probe now
 also reports `mode_parse_none_call_ms_mean` alongside the existing empty, valid,
 and invalid parse metrics.
+
+## 2026-07-20 follow-up: exact invalid minimal cache
+
+The registered `probe-policy-noop-overhead` probe repeatedly parses the same
+exact unsupported lowercase mode string to measure invalid-mode fallback cost.
+Keep non-exact string normalization on the existing bounded helper, but add a
+small exact-value cache for default-minimal invalid strings after their first
+normalization. Repeated exact invalid values can then return the immutable
+fallback policy by direct dictionary lookup while preserving the same
+`source_value`, fallback mode, and subclass/whitespace normalization behavior.

--- a/services/mlx-worker-python/tests/test_probe_policy.py
+++ b/services/mlx-worker-python/tests/test_probe_policy.py
@@ -98,6 +98,19 @@ def test_probe_policy_reuses_normalized_string_cache_for_invalid_values() -> Non
     assert ProbePolicy.from_value("   ") is ProbePolicy.from_value("")
 
 
+def test_probe_policy_exact_invalid_minimal_strings_skip_cached_normalization() -> None:
+    _probe_policy_from_uncached_string.cache_clear()
+    invalid_policy = ProbePolicy.from_value("unsupported-mode")
+
+    assert invalid_policy.mode is ProbeMode.MINIMAL
+    assert invalid_policy.source_value == "unsupported-mode"
+    assert invalid_policy.fallback_applied is True
+    assert ProbePolicy.from_value("unsupported-mode") is invalid_policy
+    assert _probe_policy_from_uncached_string.cache_info().hits == 0
+    for index in range(65):
+        assert ProbePolicy.from_value(f"unsupported-mode-{index}").fallback_applied is True
+
+
 def test_probe_policy_empty_values_reuse_default_policy_cache() -> None:
     minimal_policy = ProbePolicy.from_value("")
 

--- a/services/mlx-worker-python/worker/productization/probe_policy.py
+++ b/services/mlx-worker-python/worker/productization/probe_policy.py
@@ -75,6 +75,16 @@ class ProbePolicy:
             policy = _PROBE_POLICY_BY_VALUE_GET(value)
             if policy is not None:
                 return policy
+            if default_mode is ProbeMode.MINIMAL:
+                policy = _MINIMAL_INVALID_EXACT_POLICY_BY_VALUE_GET(value)
+                if policy is not None:
+                    return policy
+                policy = _probe_policy_from_uncached_string(value, default_mode)
+                if policy.fallback_applied and policy.source_value == value:
+                    if len(_MINIMAL_INVALID_EXACT_POLICY_BY_VALUE) >= 64:
+                        _MINIMAL_INVALID_EXACT_POLICY_BY_VALUE.clear()
+                    _MINIMAL_INVALID_EXACT_POLICY_BY_VALUE[value] = policy
+                return policy
             return _probe_policy_from_uncached_string(value, default_mode)
         elif isinstance(value, ProbeMode):
             return _PROBE_POLICY_BY_MODE[value]
@@ -112,6 +122,8 @@ _PROBE_POLICY_BY_DEFAULT_MODE: dict[ProbeMode, ProbePolicy] = {
     mode: ProbePolicy(mode=mode) for mode in ProbeMode
 }
 _MINIMAL_DEFAULT_PROBE_POLICY = _PROBE_POLICY_BY_DEFAULT_MODE[ProbeMode.MINIMAL]
+_MINIMAL_INVALID_EXACT_POLICY_BY_VALUE: dict[str, ProbePolicy] = {}
+_MINIMAL_INVALID_EXACT_POLICY_BY_VALUE_GET = _MINIMAL_INVALID_EXACT_POLICY_BY_VALUE.get
 _EVIDENCE_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.EVIDENCE]
 _DEBUG_PROBE_POLICY = _PROBE_POLICY_BY_MODE[ProbeMode.DEBUG]
 


### PR DESCRIPTION
## Summary
- Cache exact unsupported lowercase `ProbePolicy.from_value(...)` strings on the default-minimal path after the first normalization.
- Add a regression test proving repeated exact invalid strings skip the normalized cached helper while preserving fallback semantics.
- Update the probe-policy invalid-string plan with the 2026-07-20 exact invalid minimal cache follow-up.

## Plan or Spec
- `docs/plans/2026-05-23-probe-policy-invalid-string-cache.md`
- Registered probe: `probe-policy-noop-overhead` in `infra/perf/pr_scoped_probes.json` already covers `probe_policy.py`, focused tests, changed-scope coverage, and `scripts/probe_policy_noop_overhead_probe.py`.

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 19 passed in 1.32s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_probe_policy_overhead_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_probe_policy_noop_overhead_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/probe_policy.py services/mlx-worker-python/worker/productization/probe_policy_overhead.py services/mlx-worker-python/tests/test_probe_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/probe_policy_noop_overhead_probe.py
# 19 passed in 0.45s; TOTAL 22 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/probe_policy_noop_overhead_probe.py
# mode_parse_invalid_call_ms_mean=0.000190945, threshold_passed=1.0

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id probe-policy-noop-overhead --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output /tmp/probe_policy_pr_scoped_final.json
# head verification ok; base/head probe ok

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 22 0 100%`.
- Registered local PR-scoped probe `probe-policy-noop-overhead`:
  - `mode_parse_invalid_call_ms_mean`: base `0.000213906`, head `0.000193739`, delta `-0.000020167` ms, speedup `9.43%`.
  - `threshold_passed`: base `1.0`, head `1.0`.
- Direct same-worktree local baseline/head spot check:
  - baseline before change `mode_parse_invalid_call_ms_mean=0.000227121`
  - head after change `mode_parse_invalid_call_ms_mean=0.000190945`
- GitHub Actions PR-scoped performance report is still required as the merge gate.

## Known Gaps
- None. This is a Python-only slice validated locally on Linux; CI remains the authoritative registered probe validation before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
