### PR TITLE
perf: bind download directory digest hot loop

### DIFF
--- a/docs/plans/2026-07-20-download-directory-digest-local-binds.md
+++ b/docs/plans/2026-07-20-download-directory-digest-local-binds.md
@@ -1,0 +1,23 @@
+# Download Directory Snapshot Digest Local Binds
+
+## Scope
+
+This Python-only performance slice is limited to `DownloadPipeline._sha256_directory_snapshot(...)` in `services/mlx-worker-python/worker/model_ops/download_pipeline.py`.
+
+The implementation keeps directory snapshot digest semantics unchanged while reducing repeated attribute/global lookups in the per-file digest loop by binding hot helpers (`digest.update`, `_directory_snapshot_files`, `open`, and the chunk size) once per digest call, emitting file sizes directly as ASCII bytes, and reusing each file object's bound `read` method inside the chunk loop.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `download-pipeline-directory-size-single-stat` in `infra/perf/pr_scoped_probes.json`. The registry entry already provides focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- download pipeline behavior tests,
+- changed-scope coverage for the download pipeline and probe-selection tests,
+- digest and companion directory scan metrics, including `digest_elapsed_ms_mean` and `digest_delta_ms`.
+
+## Validation Plan
+
+Run the registered focused tests, changed-scope coverage command, and local registered probe on Linux before opening the PR. Use GitHub Actions PR-scoped performance as the merge gate for the registered probe result.
+
+## Boundaries
+
+No Swift runtime path is changed. No generated protobuf outputs or dependency lockfiles are touched.

--- a/services/mlx-worker-python/worker/model_ops/download_pipeline.py
+++ b/services/mlx-worker-python/worker/model_ops/download_pipeline.py
@@ -1548,16 +1548,21 @@ class DownloadPipeline:
     @staticmethod
     def _sha256_directory_snapshot(path: Path) -> str:
         digest = hashlib.sha256()
-        for relative_path, file_path, file_size in DownloadPipeline._directory_snapshot_files(path):
-            digest.update(b"file\0")
-            digest.update(relative_path.encode("utf-8"))
-            digest.update(b"\0")
-            digest.update(str(file_size).encode("ascii"))
-            digest.update(b"\0")
-            with open(file_path, "rb") as file:
-                for chunk in iter(lambda: file.read(1024 * 1024), b""):
-                    digest.update(chunk)
-            digest.update(b"\0")
+        update_digest = digest.update
+        directory_snapshot_files = DownloadPipeline._directory_snapshot_files
+        open_file = open
+        chunk_size = 1024 * 1024
+        for relative_path, file_path, file_size in directory_snapshot_files(path):
+            update_digest(b"file\0")
+            update_digest(relative_path.encode("utf-8"))
+            update_digest(b"\0")
+            update_digest(b"%d" % file_size)
+            update_digest(b"\0")
+            with open_file(file_path, "rb") as file:
+                read_chunk = file.read
+                while chunk := read_chunk(chunk_size):
+                    update_digest(chunk)
+            update_digest(b"\0")
         return digest.hexdigest()
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Bind hot helpers in `DownloadPipeline._sha256_directory_snapshot(...)` so each file in a directory snapshot digest avoids repeated global/attribute lookup overhead.
- Keep digest ordering, file metadata framing, and chunked file reads unchanged; follow-up incorporated review feedback to emit file sizes directly as ASCII bytes.
- Add a focused plan for this Python performance slice.

## Plan or Spec
- `docs/plans/2026-07-20-download-directory-digest-local-binds.md`

## Commands Run
```text
# Baseline probe before the change on origin/main (exit 0)
bash /tmp/download_probe_cmd.sh
{"baseline_companion_receipt_elapsed_ms_mean": 3.278704, "baseline_digest_elapsed_ms_mean": 22.181657, "chunk_bytes": 1.0, "companion_receipt_delta_ms": -2.309747, "companion_receipt_elapsed_ms_mean": 0.968957, "companion_receipt_file_count": 300.0, "digest_delta_ms": -18.538239, "digest_elapsed_ms_mean": 3.643418, "digest_elapsed_ms_min": 3.384075, "digest_file_count": 300.0, "elapsed_ms_mean": 68.757363, "elapsed_ms_min": 60.231924, "snapshot_count": 4098.0, "source_size_bytes": 4096.0}

# Registered focused tests, initial local-bind change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_download_pipeline_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
61 passed, 1 skipped in 0.29s

# Registered changed-scope coverage, initial local-bind change (exit 0)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_download_pipeline_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/download_pipeline.py services/mlx-worker-python/tests/test_download_pipeline_unit.py services/mlx-worker-python/tests/test_pr_scoped_performance.py
TOTAL 15 0 100%

# Registered local probe, initial local-bind change (exit 0)
bash /tmp/download_probe_cmd.sh
{"baseline_companion_receipt_elapsed_ms_mean": 3.601244, "baseline_digest_elapsed_ms_mean": 22.008795, "chunk_bytes": 1.0, "companion_receipt_delta_ms": -2.599076, "companion_receipt_elapsed_ms_mean": 1.002168, "companion_receipt_file_count": 300.0, "digest_delta_ms": -18.414338, "digest_elapsed_ms_mean": 3.594457, "digest_elapsed_ms_min": 3.302582, "digest_file_count": 300.0, "elapsed_ms_mean": 65.649951, "elapsed_ms_min": 63.095563, "snapshot_count": 4098.0, "source_size_bytes": 4096.0}

# Registered focused tests after review follow-up (exit 0)
bash /tmp/download_test_cmd.sh
61 passed, 1 skipped in 0.28s

# Registered changed-scope coverage after review follow-up (exit 0)
bash /tmp/download_cov_cmd.sh
TOTAL 1 0 100%

# Registered local probe after review follow-up (exit 0)
bash /tmp/download_probe_cmd.sh
{"baseline_companion_receipt_elapsed_ms_mean": 3.671667, "baseline_digest_elapsed_ms_mean": 21.011577, "chunk_bytes": 1.0, "companion_receipt_delta_ms": -2.692645, "companion_receipt_elapsed_ms_mean": 0.979021, "companion_receipt_file_count": 300.0, "digest_delta_ms": -17.589089, "digest_elapsed_ms_mean": 3.422487, "digest_elapsed_ms_min": 3.230724, "digest_file_count": 300.0, "elapsed_ms_mean": 66.885777, "elapsed_ms_min": 62.859793, "snapshot_count": 4098.0, "source_size_bytes": 4096.0}

git diff --check
```

## Coverage and Metrics
- Changed-scope coverage: initial slice `TOTAL 15 0 100%`; review follow-up delta `TOTAL 1 0 100%`.
- Registered local probe after review follow-up: `digest_elapsed_ms_mean` improved from the pre-change baseline `3.643418 ms` to `3.422487 ms` (`-0.220931 ms`, about `6.06%` faster). Overall `elapsed_ms_mean` improved from `68.757363 ms` to `66.885777 ms` (`-1.871586 ms`, about `2.72%` faster).
- Registered PR-scoped performance CI is required as the merge gate for the authoritative base-vs-head probe report.

## Known Gaps
- Local validation is Linux/Python only. No Swift runtime path is changed.
- The registered GitHub Actions PR-scoped performance report is the authoritative merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no runtime observability overhead.
- [x] Deferred work and known gaps are stated explicitly.
