### PR TITLE
perf: fast-path dataset quality two-message rows

### DIFF
--- a/docs/plans/2026-07-20-dataset-quality-two-message-fastpath.md
+++ b/docs/plans/2026-07-20-dataset-quality-two-message-fastpath.md
@@ -1,0 +1,44 @@
+# Dataset quality two-message fast path
+
+## Scope
+
+This Python-only performance slice is limited to output-length accounting in
+`worker.productization.dataset_preparation._append_rows_output_lengths()`.
+
+The registered dataset quality probe uses chat-style validation rows with two
+exact-dict messages. The existing fallback loop handles that shape correctly but
+still pays per-message loop and branch overhead. This slice keeps completion-row,
+mixed-message, non-string-content, malformed-message, ordering, p95, and mean
+semantics unchanged while adding a narrow fast path for the common two exact-dict
+message shape where both `content` values are strings.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The probe
+has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Plan
+
+1. Preserve the existing generic message fallback for malformed, non-list,
+   non-dict, and non-string-content rows.
+2. Add a two-message exact-dict fast path for string `content` values.
+3. Add a focused regression test covering the fast-path shape and fallback for a
+   two-message row with non-string content.
+4. Run focused tests, changed-scope coverage, and the registered local probe on
+   Linux before opening the PR.
+5. Use GitHub Actions PR-scoped performance as the final registered probe and
+   merge gate.
+
+## Expected metrics
+
+The registered probe should report a lower `elapsed_ms_mean` for the dataset
+quality output-length workload. Failed-partition metrics are reported by the
+same probe but should remain neutral because this slice does not alter
+`_partition_failed_segments()`.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -245,6 +245,16 @@ def test_dataset_quality_message_rows_skip_completion_key_lookup() -> None:
     assert _sample_output_lengths([], [row]) == [8]
 
 
+def test_dataset_quality_two_message_rows_preserve_content_lengths() -> None:
+    assert _sample_output_lengths(
+        [],
+        [
+            {"messages": [{"content": "hello"}, {"content": "world"}]},
+            {"messages": [{"content": "hello"}, {"content": 678}]},
+        ],
+    ) == [10, 8]
+
+
 def test_dataset_quality_length_stats_accumulates_total_inline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1892,6 +1892,16 @@ def _append_rows_output_lengths(
             if not isinstance(messages, list):
                 append(0)
                 continue
+            if len_(messages) == 2:
+                message_0, message_1 = messages
+                if type(message_0) is dict_ and type(message_1) is dict_:
+                    content_0 = message_0.get("content", "")
+                    content_1 = message_1.get("content", "")
+                    if type(content_0) is str and type(content_1) is str:
+                        total = len_(content_0) + len_(content_1)
+                        append(total)
+                        output_length_total += total
+                        continue
             total = 0
             for item in messages:
                 if type(item) is dict_:


### PR DESCRIPTION
## Summary
- Add a narrow dataset-quality output-length fast path for common two-message exact-dict chat rows with string `content` fields.
- Preserve the existing generic fallback for mixed/non-string/malformed message rows.
- Add the governing performance-slice plan and focused regression coverage.

## Plan or Spec
- `docs/plans/2026-07-20-dataset-quality-two-message-fastpath.md`

## Commands Run
```text
# Baseline from origin/main, Linux local registered probe
MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=50 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
exit 0; elapsed_ms_mean=2.705345; failed_partition_elapsed_ms_mean=1.049571

# Focused regression tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_output_lengths_preserve_completion_and_message_semantics services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_completion_rows_use_get_sentinel_fast_path services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_message_rows_skip_completion_key_lookup services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_two_message_rows_preserve_content_lengths services/mlx-worker-python/tests/test_dataset_preparation_versioning.py::test_dataset_quality_length_stats_accumulates_total_inline
exit 0; 5 passed in 0.31s

# Registered focused test command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics
exit 0; 63 passed in 1.96s

# Registered changed-scope coverage command
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
exit 0; TOTAL 12 0 100%

# Head, Linux local registered probe
MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=50 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py
exit 0; elapsed_ms_mean=2.642343; failed_partition_elapsed_ms_mean=1.037461

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 12 0 100%`.
- Registered local probe (`dataset-quality-lengths-chain`, 50 samples): old_mean=2.705345 ms, new_mean=2.642343 ms, delta=-0.063002 ms, speedup=1.023843x (2.329% lower).
- Probe informational metrics preserved: `row_count=15000`, `mean_output_length=51.999`, `p95_output_length=100.0`.
- PR-scoped performance CI is required for final registered-probe validation before merge.

## Known Gaps
- Linux local validation covers this Python slice. GitHub Actions PR-scoped performance remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
