### PR TITLE
perf: use local str checks in dataset quality lengths

### DIFF
--- a/docs/plans/2026-07-20-dataset-quality-str-type-local.md
+++ b/docs/plans/2026-07-20-dataset-quality-str-type-local.md
@@ -1,0 +1,47 @@
+# Dataset quality local string type checks
+
+## Scope
+
+This Python-only performance slice is limited to output-length accounting in
+`worker.productization.dataset_preparation._append_rows_output_lengths()`.
+
+The previous dataset quality slice already binds `str` as `str_` for coercion in
+this hot loop, but the exact-type checks still read the global `str` name. This
+slice keeps completion rows, chat message rows, malformed messages,
+non-string-content fallback, mean, p95, and failed-partition behavior unchanged
+while using the existing local `str_` binding for exact string type checks.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe
+`dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The probe
+has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Plan
+
+1. Reuse the existing local `str_` binding for all exact `type(...) is str`
+   checks inside `_append_rows_output_lengths()`.
+2. Preserve the existing generic fallback for malformed, non-list, non-dict, and
+   non-string-content rows.
+3. Run the registered focused tests, changed-scope coverage, and local registered
+   probe on Linux before opening the PR.
+4. Use GitHub Actions PR-scoped performance as the final registered probe and
+   merge gate.
+
+## Expected metrics
+
+The registered probe should report a lower `elapsed_ms_mean` for the dataset
+quality output-length workload. Failed-partition metrics are reported by the
+same probe but should remain neutral because this slice does not alter
+`_partition_failed_segments()`.
+
+## Linux boundary
+
+This is a Python-only slice and is locally verifiable on Linux. No Swift runtime
+behavior is changed.

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1897,7 +1897,7 @@ def _append_rows_output_lengths(
                 if type(message_0) is dict_ and type(message_1) is dict_:
                     content_0 = message_0.get("content", "")
                     content_1 = message_1.get("content", "")
-                    if type(content_0) is str and type(content_1) is str:
+                    if type(content_0) is str_ and type(content_1) is str_:
                         total = len_(content_0) + len_(content_1)
                         append(total)
                         output_length_total += total
@@ -1911,14 +1911,14 @@ def _append_rows_output_lengths(
                         content = item.get("content", "")
                     except AttributeError:
                         continue
-                if type(content) is str:
+                if type(content) is str_:
                     total += len_(content)
                 else:
                     total += len_(str_(content))
             append(total)
             output_length_total += total
         else:
-            if type(completion) is str:
+            if type(completion) is str_:
                 length = len_(completion)
             else:
                 length = len_(str_(completion))


### PR DESCRIPTION
## Summary
- Uses the existing local `str_` binding for exact string type checks in `dataset_preparation._append_rows_output_lengths()`.
- Keeps dataset quality length semantics unchanged while shaving global-name lookup overhead from the registered output-length hot loop.

## Plan or Spec
- `docs/plans/2026-07-20-dataset-quality-str-type-local.md`

## Commands Run
```text
# Baseline sync
cd /root/.hermes/profiles/coder/workspace/melix
git fetch origin
git reset --hard origin/main

# Focused pre-change smoke for the initial response-boundary candidate, rejected after probe regression
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_handles_empty_and_full services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_marks_truncated_labels services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_without_limit_updates_running_bounds services/mlx-worker-python/tests/test_response_only_boundary.py::test_aggregate_response_only_boundaries_consumes_single_pass_iterator
# 3 passed, 1 skipped
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/response_only_boundary_slots_probe.py
# baseline aggregation_no_limit_elapsed_ms_mean=243.185028; candidate=272.665633; rejected and reverted

# Registered dataset-quality tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics
# 63 passed in 2.13s

# Registered dataset-quality changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py
# TOTAL 3 0 100%

# Registered dataset-quality probe
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python bash -c 'SCRIPT="scripts/dataset_quality_lengths_probe.py"; for CANDIDATE in "${MELIX_PR_SCOPED_PERFORMANCE_HEAD_REPO:-}/$SCRIPT" "../head/$SCRIPT" "${GITHUB_WORKSPACE:-}/head/$SCRIPT" "$SCRIPT"; do if [ -f "$CANDIDATE" ]; then python3 "$CANDIDATE"; exit $?; fi; done; echo "missing probe script fallback for $SCRIPT" >&2; exit 2'
# elapsed_ms_mean=3.024542, failed_partition_elapsed_ms_mean=1.082661, exit 0

# Stable local baseline-vs-head probe with 100 samples
MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=100 ... python3 scripts/dataset_quality_lengths_probe.py
# baseline elapsed_ms_mean=2.694013; head elapsed_ms_mean=2.509559; delta=-0.184454 ms (-6.85%)
# baseline elapsed_ms_p95=2.839419; head elapsed_ms_p95=2.638602; delta=-0.200817 ms (-7.07%)
# baseline failed_partition_elapsed_ms_mean=1.030448; head=1.034984; delta=+0.004536 ms (+0.44%, neutral)

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%` from the registered `dataset-quality-lengths-chain` coverage command.
- Local registered probe (default samples): `elapsed_ms_mean=3.024542`, `elapsed_ms_p95=3.76209`, `failed_partition_elapsed_ms_mean=1.082661`, exit 0.
- Stable local baseline-vs-head probe (100 samples): `elapsed_ms_mean` improved from `2.694013 ms` to `2.509559 ms` (`-0.184454 ms`, `-6.85%`); `elapsed_ms_p95` improved from `2.839419 ms` to `2.638602 ms` (`-7.07%`). Failed-partition metrics stayed neutral (`+0.44% mean`) because this slice does not alter that path.
- CI PR-scoped performance is required for the final registered probe validation before merge.

## Known Gaps
- Linux-only local verification for this Python slice; no Swift runtime behavior changed.
- Full repository gates (`make bootstrap`, `make proto`, `make swift-test`, `make py-test`, `make integration-test`) were not run locally; this PR uses the focused registered probe/test/coverage commands and GitHub Actions as the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no production observability change.
- [x] Deferred work and known gaps are stated explicitly.
