### PR TITLE
perf: use direct stat category totals lookup

### DIFF
--- a/docs/plans/2026-07-20-stat-category-dict-lookup.md
+++ b/docs/plans/2026-07-20-stat-category-dict-lookup.md
@@ -1,0 +1,19 @@
+# Statistical evidence category dict lookup slice
+
+## Context
+
+`worker.productization.statistical_evidence.build_category_breakdown()` is used by evaluation report evidence assembly to aggregate many per-sample category rows into sorted category summaries. The hot loop receives repeated category labels, so most row visits update an existing totals bucket.
+
+## Slice
+
+This Python-only performance slice is limited to the category totals lookup in `build_category_breakdown()`. It keeps row parsing and output semantics unchanged while replacing the existing `dict.get()` plus `None` branch with a direct dictionary lookup and `KeyError` miss path. In the registered probe shape, category buckets are created once and then reused for tens of thousands of rows, so the direct lookup avoids the per-row sentinel comparison on the hot hit path.
+
+## Registered probe
+
+The affected path is already covered by the registered PR-scoped probe `statistical-evidence-category-breakdown-single-pass` in `infra/perf/pr_scoped_probes.json`. The same file also selects `statistical-evidence-bootstrap-single-sort`, so both registered statistical-evidence probes remain part of the local and CI evidence for this slice.
+
+Expected direction for `statistical-evidence-category-breakdown-single-pass`: lower `elapsed_ms_mean`; `peak_bytes_mean` should stay within the existing threshold.
+
+## Verification
+
+Run the registered focused test command, changed-scope coverage command, and registered probe command locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the final merge gate.

--- a/services/mlx-worker-python/worker/productization/statistical_evidence.py
+++ b/services/mlx-worker-python/worker/productization/statistical_evidence.py
@@ -82,7 +82,6 @@ def build_category_breakdown(
     rows: tuple[dict[str, object], ...],
 ) -> dict[str, dict[str, object]]:
     category_totals: dict[str, list[int]] = {}
-    category_totals_get = category_totals.get
     string_type = str
     value_type = type
     is_instance = isinstance
@@ -99,8 +98,9 @@ def build_category_breakdown(
             category_label = string_type(raw_category_label).strip()
         if not category_label:
             continue
-        totals = category_totals_get(category_label)
-        if totals is None:
+        try:
+            totals = category_totals[category_label]
+        except KeyError:
             totals = [0, 0, 0]
             category_totals[category_label] = totals
         totals[0] += 1


### PR DESCRIPTION
## Summary
- Optimize `build_category_breakdown()` by using direct dictionary lookup for the hot existing-category totals path.
- Keep category parsing, missing-key handling, output ordering, and rounding behavior unchanged.
- Add a focused plan for this statistical-evidence performance slice.

## Plan or Spec
- `docs/plans/2026-07-20-stat-category-dict-lookup.md`
- Registered PR-scoped probes: `statistical-evidence-category-breakdown-single-pass` and `statistical-evidence-bootstrap-single-sort`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_aggregates_supported_categories_only services/mlx-worker-python/tests/test_statistical_evidence.py::test_build_category_breakdown_preserves_ordering_and_rounded_totals services/mlx-worker-python/tests/test_statistical_evidence.py::test_bootstrap_interval_short_circuits_constant_outcomes_without_sampling services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_statistical_evidence_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_bootstrap_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_statistical_evidence_category_breakdown_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/statistical_evidence.py services/mlx-worker-python/tests/test_statistical_evidence.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/statistical_evidence_bootstrap_probe.py scripts/statistical_evidence_category_breakdown_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_category_breakdown_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/statistical_evidence_bootstrap_probe.py`
- `python3 <base-vs-head harness for statistical_evidence.py>`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 6 passed.
- Combined statistical-evidence coverage scope: 22 passed; changed-scope coverage `TOTAL 3 0 100%`.
- Local registered category probe: `elapsed_ms_mean=9.609006624668837`, `peak_bytes_mean=17304.0`, `row_count=50000.0`, `sample_count=5.0`.
- Local registered bootstrap probe: `elapsed_ms_mean=143.2184064295143`, `peak_bytes_mean=44531.2`, `sorted_calls_mean=0.0`.
- Local base-vs-head harness: `old_mean=11.12187664128012ms`, `new_mean=10.869655628792113ms`, `delta_ms=-0.25222101248800755`, `speedup=1.0232041401403658x`; head peak `15736.0` bytes vs base `15472.0` bytes (within threshold).

## Known Gaps
- Linux local validation covers the Python path only. GitHub Actions PR-scoped performance is still required as the registered CI validation and merge gate.

## Evidence Checklist
- [x] Affected path has registered PR-scoped probes with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage is at least 95% locally.
- [x] Registered Python probes ran locally on Linux.
- [ ] PR-scoped performance workflow completed successfully in CI.
