### PR TITLE
perf: reuse tool policy receipt lists

### DIFF
--- a/docs/plans/2026-07-20-tool-registry-policy-receipt-field-locals.md
+++ b/docs/plans/2026-07-20-tool-registry-policy-receipt-field-locals.md
@@ -1,0 +1,26 @@
+# Tool registry policy receipt field locals
+
+## Goal
+
+Reduce repeated list construction in policy-aware agentic tool-selection receipts while preserving receipt isolation and selection semantics.
+
+## Scope
+
+This Python-only slice is limited to `services/mlx-worker-python/worker/runtime/tool_registry.py` and the registered PR-scoped probe script `scripts/tool_registry_select_probe.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json`. The probe already includes focused `test_command`, `coverage_command`, and `probe_command` entries for the tool registry path, focused tests, and `scripts/tool_registry_select_probe.py`.
+
+This slice extends that probe with a policy-aware selection case so `allow_web=False` receipt assembly has an explicit machine-readable metric: `policy_planning_elapsed_ms_mean`.
+
+## Implementation
+
+`_agentic_tool_policy_receipt()` now reuses cached single-field list templates for the stable web policy fields and copies the already-deduplicated denied-tool accumulator directly. The common `allow_web=False` path also copies the cached network-capable tool list instead of scanning all selectable tool names for each receipt. Returned receipts still contain fresh mutable lists, so callers cannot mutate cached state.
+
+## Verification
+
+- Run the focused registered test command locally on Linux.
+- Run the changed-scope coverage command locally on Linux.
+- Run the registered probe locally on Linux and compare `policy_planning_elapsed_ms_mean` before/after the production change.
+- Let the PR-scoped performance workflow validate the registered probe in CI before merging.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5091,7 +5091,8 @@
       "services/mlx-worker-python/tests/test_tool_registry.py",
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/tool_registry_select_probe.py",
-      "infra/perf/pr_scoped_probes.json"
+      "infra/perf/pr_scoped_probes.json",
+      "docs/plans/2026-07-20-tool-registry-policy-receipt-field-locals.md"
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py",
@@ -5208,6 +5209,17 @@
       },
       {
         "key": "whitespace_turn_selected_schema_bytes_mean",
+        "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "policy_planning_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "policy_selected_schema_bytes_mean",
         "unit": "bytes",
         "direction": "informational"
       }

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -51,6 +51,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     no_keyword_fallback_selected_schema_bytes_samples: list[float] = []
     whitespace_turn_planning_elapsed_samples: list[float] = []
     whitespace_turn_selected_schema_bytes_samples: list[float] = []
+    policy_planning_elapsed_samples: list[float] = []
+    policy_selected_schema_bytes_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
@@ -233,6 +235,28 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         checksum += whitespace_turn_schema_bytes
 
+        policy_schema_bytes = 0
+        policy_started = time.perf_counter()
+        for _index in range(selector_iterations):
+            selection_result = select_agentic_tools_for_turn(
+                ToolSelectionInput(
+                    current_user_turn="Answer briefly without web access.",
+                    recent_user_turns=("Search local evidence from the fixture corpus.",),
+                    vector_selected_tool_ids=("visit", "text_search"),
+                    vector_available=False,
+                    max_selected_tools=4,
+                    allow_web=False,
+                )
+            )
+            policy_schema_bytes += int(selection_result.receipt["selected_schema_bytes"])
+        policy_planning_elapsed_samples.append(
+            (time.perf_counter() - policy_started) * 1000.0
+        )
+        policy_selected_schema_bytes_samples.append(
+            float(policy_schema_bytes / selector_iterations)
+        )
+        checksum += policy_schema_bytes
+
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
@@ -282,10 +306,14 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         "whitespace_turn_selected_schema_bytes_mean": statistics.fmean(
             whitespace_turn_selected_schema_bytes_samples
         ),
+        "policy_planning_elapsed_ms_mean": statistics.fmean(policy_planning_elapsed_samples),
+        "policy_selected_schema_bytes_mean": statistics.fmean(
+            policy_selected_schema_bytes_samples
+        ),
         "checksum": float(checksum),
         "iterations": float(iterations),
         "sample_count": float(sample_count),
-        "selection_case_count": float(len(_SELECTIONS) + 1),
+        "selection_case_count": float(len(_SELECTIONS) + 2),
     }
 
 

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1099,7 +1099,7 @@ def test_tool_registry_select_probe_script_emits_metrics(
     metrics = json.loads(capsys.readouterr().out)
     assert metrics["elapsed_ms_mean"] >= 0.0
     assert metrics["select_calls_mean"] == 20.0
-    assert metrics["selection_case_count"] == 5.0
+    assert metrics["selection_case_count"] == 6.0
     assert metrics["full_list_self_hits_mean"] == 4.0
     assert metrics["full_config_template_elapsed_ms_mean"] >= 0.0
     assert metrics["full_config_template_hits_mean"] == 4.0
@@ -1109,6 +1109,8 @@ def test_tool_registry_select_probe_script_emits_metrics(
     assert metrics["selector_selected_schema_bytes_mean"] > 0.0
     assert metrics["always_only_planning_elapsed_ms_mean"] >= 0.0
     assert metrics["always_only_selected_schema_bytes_mean"] > 0.0
+    assert metrics["policy_planning_elapsed_ms_mean"] >= 0.0
+    assert metrics["policy_selected_schema_bytes_mean"] > 0.0
 
 
 def test_tool_registry_names_probe_script_emits_metrics(

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -1416,6 +1416,25 @@ def test_agentic_tool_selection_explicit_web_deny_blocks_keyword_visit_with_poli
         "resolved_disabled_tools": ["visit"],
         "requested_tools": ["visit"],
     }
+    result.receipt["tool_policy_receipt"]["explicit_denies"].append("mutated")
+    result.receipt["tool_policy_receipt"]["resolved_disabled_tools"].append("mutated")
+    result.receipt["tool_policy_receipt"]["requested_tools"].append("mutated")
+    repeated = select_agentic_tools_for_turn(
+        ToolSelectionInput(
+            current_user_turn="Visit https://example.com/docs and summarize the page.",
+            vector_available=False,
+            max_selected_tools=4,
+            allow_web=False,
+        )
+    )
+    assert repeated.receipt["tool_policy_receipt"] == {
+        "schema_version": "melix.agentic_tool_policy.v1",
+        "allow_web": False,
+        "explicit_allows": [],
+        "explicit_denies": ["web"],
+        "resolved_disabled_tools": ["visit"],
+        "requested_tools": ["visit"],
+    }
     assert "https://example.com" not in json.dumps(result.receipt)
 
 

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -79,6 +79,9 @@ ALWAYS_AVAILABLE_AGENTIC_TOOL_NAMES = ("local_compute",)
 _EMPTY_AGENTIC_TOOL_NAME_SET: frozenset[str] = frozenset()
 NETWORK_CAPABLE_AGENTIC_TOOL_NAMES = ("visit",)
 _NETWORK_CAPABLE_AGENTIC_TOOL_NAME_SET = frozenset(NETWORK_CAPABLE_AGENTIC_TOOL_NAMES)
+_NETWORK_CAPABLE_AGENTIC_TOOL_NAME_LIST = list(NETWORK_CAPABLE_AGENTIC_TOOL_NAMES)
+_WEB_POLICY_EXPLICIT_ALLOW_LIST = ["web"]
+_WEB_POLICY_EXPLICIT_DENY_LIST = ["web"]
 _KEYWORD_MATCHABLE_TOOL_NAMES = tuple(
     tool_name
     for tool_name in SELECTABLE_AGENTIC_TOOL_NAMES
@@ -1126,15 +1129,23 @@ def _agentic_tool_policy_receipt(
     if selection_input.allow_web is None and not disabled_tool_names and not denied_tool_names:
         return None
     disabled_tool_names = disabled_tool_names or _EMPTY_AGENTIC_TOOL_NAME_SET
-    disabled = [
-        tool_name for tool_name in SELECTABLE_AGENTIC_TOOL_NAMES if tool_name in disabled_tool_names
-    ]
-    requested = list(dict.fromkeys(denied_tool_names or ()))
+    copy_list = _COPY_LIST
+    if disabled_tool_names is _NETWORK_CAPABLE_AGENTIC_TOOL_NAME_SET:
+        disabled = copy_list(_NETWORK_CAPABLE_AGENTIC_TOOL_NAME_LIST)
+    else:
+        disabled = [
+            tool_name for tool_name in SELECTABLE_AGENTIC_TOOL_NAMES if tool_name in disabled_tool_names
+        ]
+    requested = copy_list(denied_tool_names) if denied_tool_names else []
     return {
         "schema_version": "melix.agentic_tool_policy.v1",
         "allow_web": selection_input.allow_web,
-        "explicit_allows": ["web"] if selection_input.allow_web is True else [],
-        "explicit_denies": ["web"] if selection_input.allow_web is False else [],
+        "explicit_allows": copy_list(_WEB_POLICY_EXPLICIT_ALLOW_LIST)
+        if selection_input.allow_web is True
+        else [],
+        "explicit_denies": copy_list(_WEB_POLICY_EXPLICIT_DENY_LIST)
+        if selection_input.allow_web is False
+        else [],
         "resolved_disabled_tools": disabled,
         "requested_tools": requested,
     }


### PR DESCRIPTION
## Summary
- Reuses cached list templates for stable web-policy receipt fields in the tool registry selector.
- Copies the already-deduplicated denied-tool accumulator directly while preserving fresh mutable receipt lists.
- Extends the registered tool-registry select probe with an `allow_web=False` policy receipt case and metric.

## Plan or Spec
- `docs/plans/2026-07-20-tool-registry-policy-receipt-field-locals.md`

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`
- Baseline comparison from `origin/main` with the updated probe script copied into a detached baseline worktree.
- `git diff --check`

## Coverage and Metrics
- Focused tests: `125 passed`.
- Changed-scope coverage: `TOTAL 26 0 100%`.
- Baseline probe (`origin/main` code + updated probe): `policy_planning_elapsed_ms_mean=43.29715892672539`.
- Head probe: `policy_planning_elapsed_ms_mean=38.88607658445835`.
- Delta: `-4.41108234226704 ms` (`10.19%` faster) for the registered policy receipt case.
- Registered metric added: `policy_planning_elapsed_ms_mean` on `tool-registry-select-name-index-cache`.

## Known Gaps
- Local validation is Linux/Python only; GitHub Actions PR-scoped performance is required for registered CI probe validation before merge.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Focused local tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe shows an improvement.
- [ ] PR-scoped performance workflow completed successfully in CI.
