### PR TITLE
perf: skip lowercase for exact diagnostic lines

### DIFF
--- a/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
+++ b/docs/plans/2026-06-24-runtime-export-diagnostic-parser.md
@@ -254,6 +254,13 @@ directly when it is already non-whitespace, and only falls back to the existing
 left-strip behavior for indented or blank lines. Prompt/response labels,
 case-insensitive branches, and private-preview redaction semantics stay the same.
 
+A follow-up 2026-07-20 exact-source-text diagnosis slice keeps diagnosis
+semantics and matched pattern ids unchanged while checking a preserved exact
+source-text table before the lowercase exact table. Fixture-like common lines
+that already match the canonical source spelling now skip `str.lower()` entirely;
+case variants and non-exact lines continue through the same lowercase exact,
+marker, phrase, and regex fallbacks.
+
 Focused verification:
 
 ```bash

--- a/services/mlx-worker-python/tests/test_export_target_diagnostics.py
+++ b/services/mlx-worker-python/tests/test_export_target_diagnostics.py
@@ -77,6 +77,27 @@ def test_export_target_diagnostics_common_phrase_fast_path_skips_regex_table(
     assert diagnoses[0]["matched_pattern_id"] == "runtime-load-failed-v1"
 
 
+def test_export_target_diagnostics_exact_source_text_fast_path_skips_regex_table(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(export_target_diagnostics_module, "_DIAGNOSIS_PATTERNS", ())
+    source_lines = [
+        _SourceLine(
+            source_path="logs/ollama-create.log",
+            text="Metal out of memory during load",
+        ),
+    ]
+
+    diagnoses = _diagnoses_from_excerpt(
+        source_lines,
+        {0: 1},
+        "diagnostics/redacted-log-excerpt.txt",
+    )
+
+    assert [diagnosis["code"] for diagnosis in diagnoses] == [CODE_INSUFFICIENT_MEMORY]
+    assert diagnoses[0]["matched_pattern_id"] == "insufficient-memory-v1"
+
+
 def test_export_target_diagnostics_source_line_extension_matches_split_helper() -> None:
     lines: list[_SourceLine] = []
 

--- a/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
+++ b/services/mlx-worker-python/worker/productization/export_target_diagnostics.py
@@ -294,7 +294,7 @@ _DIAGNOSIS_FAST_PHRASE_PATTERNS = (
     ("runtime load failed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED]),
     ("model load failed", _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED]),
 )
-_DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS = {
+_DIAGNOSIS_EXACT_TEXT_PATTERNS = {
     "runtime load failed while opening model": _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_LOAD_FAILED],
     "unsupported architecture arm64 required": _DIAGNOSIS_PATTERN_BY_CODE[CODE_UNSUPPORTED_ARCHITECTURE],
     "duplicate tensor name decoder.layers.0": _DIAGNOSIS_PATTERN_BY_CODE[CODE_DUPLICATE_TENSOR_NAME],
@@ -303,7 +303,10 @@ _DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS = {
     "invalid runtime path /tmp/melix/bad-target": _DIAGNOSIS_PATTERN_BY_CODE[CODE_INVALID_RUNTIME_PATH],
     "generation smoke timed out after deadline exceeded": _DIAGNOSIS_PATTERN_BY_CODE[CODE_RUNTIME_TIMEOUT],
     "permission denied opening model weights": _DIAGNOSIS_PATTERN_BY_CODE[CODE_PERMISSION_DENIED],
-    "metal out of memory during load": _DIAGNOSIS_PATTERN_BY_CODE[CODE_INSUFFICIENT_MEMORY],
+    "Metal out of memory during load": _DIAGNOSIS_PATTERN_BY_CODE[CODE_INSUFFICIENT_MEMORY],
+}
+_DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS = {
+    text.lower(): pattern for text, pattern in _DIAGNOSIS_EXACT_TEXT_PATTERNS.items()
 }
 
 
@@ -851,6 +854,7 @@ def _diagnoses_from_excerpt(
     seen_codes_add = seen_codes.add
     patterns = _DIAGNOSIS_PATTERNS
     fast_phrase_patterns = _DIAGNOSIS_FAST_PHRASE_PATTERNS
+    exact_text_patterns = _DIAGNOSIS_EXACT_TEXT_PATTERNS
     exact_fast_text_patterns = _DIAGNOSIS_EXACT_FAST_TEXT_PATTERNS
     source_lines_local = source_lines
     has_diagnosis_marker = _has_diagnosis_marker
@@ -861,8 +865,12 @@ def _diagnoses_from_excerpt(
         if remaining_known_code_count == 0:
             break
         text = source_lines_local[index].text
-        lowered_text = text.lower()
-        fast_pattern = exact_fast_text_patterns.get(lowered_text)
+        fast_pattern = exact_text_patterns.get(text)
+        if fast_pattern is None:
+            lowered_text = text.lower()
+            fast_pattern = exact_fast_text_patterns.get(lowered_text)
+        else:
+            lowered_text = ""
         if fast_pattern is not None:
             pattern_code = fast_pattern.code
             if pattern_code in seen_codes:


### PR DESCRIPTION
## Summary
- Optimizes the runtime export diagnostic parser exact-text hot path by checking preserved source spellings before falling back to lowercase exact matching.
- Keeps diagnosis semantics, matched pattern ids, evidence anchors, and case-variant fallback behavior unchanged.
- Adds a regression test proving the mixed-case exact source-text path still works without the regex table.

## Plan or Spec
- Updated `docs/plans/2026-06-24-runtime-export-diagnostic-parser.md` with the 2026-07-20 exact-source-text diagnosis slice.
- Registered PR-scoped probe: `runtime-export-diagnostic-parser` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_exact_source_text_fast_path_skips_regex_table services/mlx-worker-python/tests/test_export_target_diagnostics.py::test_export_target_diagnostics_parser_matches_common_runtime_failures`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_blocks_report_when_required_file_is_missing services/mlx-worker-python/tests/test_export_target_smoke_policy.py::test_export_target_smoke_failure_boundaries services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_runtime_export_diagnostic_parser_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_runtime_export_diagnostic_parser_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/export_target_diagnostics.py services/mlx-worker-python/worker/productization/export_target_smoke.py services/mlx-worker-python/tests/test_export_target_diagnostics.py services/mlx-worker-python/tests/test_export_target_smoke_policy.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/runtime_export_diagnostic_parser_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py`
- `MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=120 MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_SAMPLES=5 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/runtime_export_diagnostic_parser_probe.py` (3 runs on `origin/main`, 3 runs on this branch)
- `git diff --check`

## Coverage and Metrics
- Focused regression subset: 10 passed in 0.32s.
- Registered focused tests: 85 passed in 1.81s.
- Changed-scope coverage: 100% (14/14 measurable changed lines).
- Default local registered probe on this branch: `diagnosis_matching_elapsed_ms_mean=0.15807454474270344`, `elapsed_ms_mean=2628.4143368247896`, `diagnostic_parser_coverage=1.0`.
- Repeated local metric comparison (`MELIX_RUNTIME_EXPORT_DIAGNOSTIC_PROBE_ITERATIONS=120`, `SAMPLES=5`, 3 runs each):
  - `origin/main` diagnosis matching mean: 0.7034671337654194 ms.
  - Branch diagnosis matching mean: 0.6350548937916756 ms.
  - Delta: -0.0684122399737438 ms (-9.725%).
  - Overall probe elapsed was effectively noise-bound: 10604.72534329941 ms baseline vs 10621.57017076388 ms branch (+0.159%), dominated by tempdir/report setup outside this slice.

## Known Gaps
- This is a Python-only Linux-local slice; no Swift runtime effect is claimed.
- GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped performance probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally on Linux with repeated old/new comparison.
- [ ] GitHub Actions PR-scoped performance completed successfully.
