### PR TITLE
perf: hoist startup update stat tuple

### DIFF
--- a/docs/plans/2026-06-28-startup-update-result-cache.md
+++ b/docs/plans/2026-06-28-startup-update-result-cache.md
@@ -73,3 +73,20 @@ Local 2026-07-03 probe decision for this pyproject path-cache slice:
 Decision: accepted because the targeted registered product-version submetric
 improved substantially across the local Linux probe triplet, memory moved lower,
 and unrelated registered metrics stayed within the warning boundary.
+
+## 2026-07-20 follow-up: update channel stat tuple locals
+
+This Python-only follow-up keeps the same registered probe and narrows to
+`check_for_updates(...)` and its `_read_update_channel_version(...)` helper.
+Repeated update checks already stat the channel file once per call and use the
+mtime/size tuple as the freshness source, but the hot path repeatedly loaded
+`stat_result.st_mtime_ns` and `stat_result.st_size` while checking both the final
+result cache and the channel decode cache.
+
+This slice hoists the stat tuple into local integers immediately after the
+single `Path.stat()` call and passes those integers into the channel helper. The
+behavior remains unchanged: cache validity is still driven only by the channel
+file mtime and size, channel JSON is still decoded after a cache miss, and
+result construction/version comparison semantics are untouched. Verification
+remains the registered focused tests, changed-scope coverage command, local
+Linux probe, and PR-scoped performance workflow as the merge gate.

--- a/services/mlx-worker-python/worker/productization/startup_signals.py
+++ b/services/mlx-worker-python/worker/productization/startup_signals.py
@@ -179,19 +179,19 @@ def check_for_updates(installed_version: str, channel_path: str | Path) -> Updat
         else Path(channel_path).expanduser().resolve()
     )
     stat_result = resolved_channel_path.stat()
+    stat_mtime_ns = stat_result.st_mtime_ns
+    stat_size = stat_result.st_size
     channel_path_text = str(resolved_channel_path)
     stat_cache_key = (channel_path_text, installed_version)
     stat_cached = _UPDATE_CHECK_RESULT_STAT_CACHE.get(stat_cache_key)
     if stat_cached is not None:
         cached_mtime_ns, cached_size, cached_result = stat_cached
-        if (
-            cached_mtime_ns == stat_result.st_mtime_ns
-            and cached_size == stat_result.st_size
-        ):
+        if cached_mtime_ns == stat_mtime_ns and cached_size == stat_size:
             return cached_result
     latest_version, channel = _read_update_channel_version(
         resolved_channel_path,
-        stat_result=stat_result,
+        stat_mtime_ns=stat_mtime_ns,
+        stat_size=stat_size,
         cache_key=channel_path_text,
     )
     cache_key = (channel_path_text, installed_version, latest_version, channel)
@@ -209,8 +209,8 @@ def check_for_updates(installed_version: str, channel_path: str | Path) -> Updat
             )
             _UPDATE_CHECK_RESULT_CACHE[cache_key] = result
             _UPDATE_CHECK_RESULT_STAT_CACHE[stat_cache_key] = (
-                stat_result.st_mtime_ns,
-                stat_result.st_size,
+                stat_mtime_ns,
+                stat_size,
                 result,
             )
             return result
@@ -225,8 +225,8 @@ def check_for_updates(installed_version: str, channel_path: str | Path) -> Updat
         )
         _UPDATE_CHECK_RESULT_CACHE[cache_key] = result
         _UPDATE_CHECK_RESULT_STAT_CACHE[stat_cache_key] = (
-            stat_result.st_mtime_ns,
-            stat_result.st_size,
+            stat_mtime_ns,
+            stat_size,
             result,
         )
         return result
@@ -241,8 +241,8 @@ def check_for_updates(installed_version: str, channel_path: str | Path) -> Updat
     )
     _UPDATE_CHECK_RESULT_CACHE[cache_key] = result
     _UPDATE_CHECK_RESULT_STAT_CACHE[stat_cache_key] = (
-        stat_result.st_mtime_ns,
-        stat_result.st_size,
+        stat_mtime_ns,
+        stat_size,
         result,
     )
     return result
@@ -251,20 +251,21 @@ def check_for_updates(installed_version: str, channel_path: str | Path) -> Updat
 def _read_update_channel_version(
     channel_path: Path,
     *,
-    stat_result: Any,
+    stat_mtime_ns: int,
+    stat_size: int,
     cache_key: str,
 ) -> tuple[str, str]:
     cached = _UPDATE_CHANNEL_CACHE.get(cache_key)
     if cached is not None:
         cached_mtime_ns, cached_size, cached_latest_version, cached_channel = cached
-        if cached_mtime_ns == stat_result.st_mtime_ns and cached_size == stat_result.st_size:
+        if cached_mtime_ns == stat_mtime_ns and cached_size == stat_size:
             return cached_latest_version, cached_channel
     payload = json.loads(channel_path.read_bytes())
     latest_version = str(payload.get("latest_version", "")).strip()
     channel = str(payload.get("channel", "stable")).strip() or "stable"
     _UPDATE_CHANNEL_CACHE[cache_key] = (
-        stat_result.st_mtime_ns,
-        stat_result.st_size,
+        stat_mtime_ns,
+        stat_size,
         latest_version,
         channel,
     )


### PR DESCRIPTION
## Summary
- Hoists the startup update channel stat freshness tuple into local integers after the single `Path.stat()` call.
- Passes the cached mtime/size values into `_read_update_channel_version(...)` so the result cache and channel cache use the same freshness tuple without repeated stat attribute loads.

## Plan or Spec
- Updated `docs/plans/2026-06-28-startup-update-result-cache.md` with the 2026-07-20 follow-up slice and validation boundary.
- Registered probe: `startup-signals-version-compare-single-pass` in `infra/perf/pr_scoped_probes.json` already covers the affected path with focused test, coverage, and probe commands.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_startup_signals.py::test_check_for_updates_reports_newer_available_version ... services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_startup_signals_version_probe_script_emits_metrics` → 29 passed
- Registered coverage command for `startup-signals-version-compare-single-pass` → 29 passed; TOTAL 4/4 changed lines covered, 100%
- Baseline probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py` (3 runs)
- Post-change probe on this branch: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/startup_signals_version_probe.py` (3 runs)
- `git diff --check`

## Coverage and Metrics
- Changed-line coverage: 100% (`aggregate_measurable_changed_lines=4`, `aggregate_covered_changed_lines=4`).
- Local Linux registered probe triplet:
  - `elapsed_ms_mean`: baseline `11.447309394411386` ms → new `11.320538863184906` ms (`-0.1267705312264802` ms, `1.0112x`).
  - `update_channel_elapsed_ms_mean`: baseline `77.44431452426527` ms → new `75.55061619773153` ms (`-1.8936983265337375` ms, `1.0251x`).
  - `update_result_elapsed_ms_mean`: baseline `77.68014641035171` ms → new `78.74675256954062` ms (`+1.0666061591889076` ms, within the 5% warn boundary/noise band).
- CI PR-scoped performance is required for registered probe validation before merge.

## Known Gaps
- This is a Python-only Linux-verifiable slice; no Swift runtime effect is claimed.
- The update-result submetric moved slightly slower locally, but stayed within the registered warning boundary while the targeted channel-cache and overall probe metrics improved.

## Evidence Checklist
- [x] Synced from `origin/main` before branch creation.
- [x] Affected path has a registered PR-scoped performance probe with `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage measured at or above 95%.
- [x] Local registered probe run with baseline and post-change samples.
- [ ] GitHub Actions / PR-scoped performance completed successfully.
