### PR TITLE
perf: bind chunker output loop helpers

### DIFF
--- a/docs/plans/2026-05-09-training-dataset-chunker-segment-join-binding.md
+++ b/docs/plans/2026-05-09-training-dataset-chunker-segment-join-binding.md
@@ -23,3 +23,12 @@ Bind the whitespace join callable once per `_iter_word_segments` invocation befo
 - Run changed-scope coverage for the touched source, test, and probe files.
 - Run the registered local probe on Linux and compare against an `origin/main` base worktree.
 - Let GitHub Actions run the PR-scoped performance workflow before merge.
+
+## 2026-07-20 output chunk loop local bindings
+
+This follow-up Python-only slice keeps the same registered probe and narrows to
+`_chunk_sample(...)` after chunk message groups have already been selected. Bind
+`_copy_messages`, `chunks.append`, and the optional chunk-id prefix once before
+the output materialization loop so every emitted chunk preserves the same shallow
+source fields and independent message containers while avoiding repeated global
+lookups and repeated prefix formatting setup.

--- a/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
+++ b/services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py
@@ -404,14 +404,17 @@ def _chunk_sample(
     # the same key scan and metadata reference assignments unnecessarily.
     output_base = {k: v for k, v in sample.items() if k != "messages"}
     copy_dict = _COPY_DICT
+    copy_messages = _copy_messages
+    append_chunk = chunks.append
+    chunk_id_prefix = f"{sample_id}#chunk-" if sample_id else ""
     for idx, chunk in enumerate(chunked_messages):
         # Copy only the message dict containers so each chunk has an independent
         # message list without re-copying immutable string payloads.
         out = copy_dict(output_base)
-        out["messages"] = _copy_messages(chunk)
-        if sample_id:
-            out["id"] = f"{sample_id}#chunk-{idx}"
-        chunks.append(out)
+        out["messages"] = copy_messages(chunk)
+        if chunk_id_prefix:
+            out["id"] = f"{chunk_id_prefix}{idx}"
+        append_chunk(out)
     return chunks
 
 


### PR DESCRIPTION
## Summary
- Bind `_copy_messages`, `chunks.append`, and the optional chunk id prefix once before the training dataset chunker output materialization loop.
- Preserve the same shallow top-level field sharing, independent chunk message containers, and chunk id values.

## Plan or Spec
- `docs/plans/2026-05-09-training-dataset-chunker-segment-join-binding.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_copy_message_dicts_without_deepcopying_string_payloads services/mlx-worker-python/tests/test_training_dataset_chunker.py::test_chunked_outputs_filter_top_level_keys_once_per_source_sample services/mlx-worker-python/tests/test_single_turn_chunking_streams_candidate_segments_without_list_helper ...
# 11 passed in 1.29s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q <registered training-dataset-chunker-top-level-base-copy tests> && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py services/mlx-worker-python/tests/test_training_dataset_chunker.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/training_dataset_chunker_top_level_copy_probe.py
# TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/training_dataset_chunker_top_level_copy_probe.py
# {"chunk_count": 174.0, "elapsed_ms_mean": 22.812333, "peak_bytes_mean": 771822.714, "sample_count": 7.0, "top_level_key_count": 123.0}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `services/mlx-worker-python/worker/model_ops/training_dataset_chunker.py`.
- Local registered probe (`training-dataset-chunker-top-level-base-copy`, Linux):
  - `origin/main` baseline: `elapsed_ms_mean=25.007893`, `peak_bytes_mean=771689.714`, `chunk_count=174.0`.
  - PR head: `elapsed_ms_mean=22.812333`, `peak_bytes_mean=771822.714`, `chunk_count=174.0`.
  - Delta: `-2.195560 ms` mean elapsed, about `8.78%` faster; peak bytes `+133.0` bytes (noise-scale, same chunk count).
- CI PR-scoped performance is required as the registered probe validation source before merge.

## Known Gaps
- Full repository gates were not run locally; this Python-only slice used the registered focused test, coverage, and probe commands. GitHub Actions remains the merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability mode change.
- [x] Deferred work and known gaps are stated explicitly.
