### PR TITLE
perf: reuse cached worker tool schemas

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -232,6 +232,25 @@ Expected effect:
 - leave policy-aware selection, registry selection, OpenAI schema generation,
   and protobuf config materialization unchanged.
 
+## Follow-up Slice: Worker Tool Definition Cached Schema
+
+The 2026-07-20 follow-up keeps worker `ToolConfig` materialization behavior
+unchanged, but `ToolDescriptor.as_worker_tool_definition()` now reads the cached
+schema string directly instead of calling the public `json_schema()` accessor for
+each descriptor. The accessor still returns the same cached string for external
+callers; the protobuf materialization hot path only avoids per-tool Python method
+dispatch while preserving fresh `ToolConfig` copies and schema bytes.
+
+Expected effect:
+
+- reduce `tool-registry-schema-bytes-cache`
+  `built_in_tool_config_elapsed_ms_mean` for first materialization of registry
+  worker configs;
+- preserve `json_schema()` public API behavior and returned protobuf config
+  isolation;
+- leave registry selection, OpenAI schema generation, and schema payload copying
+  unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -360,6 +360,22 @@ def test_tool_registry_worker_config_reuses_isolated_template_copy() -> None:
     assert second_config.schema_version == tool_registry_module.TOOL_REGISTRY_SCHEMA_VERSION
 
 
+def test_tool_registry_worker_config_reuses_cached_descriptor_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = ToolRegistry(built_in_tool_registry().tools)
+    expected_schema = built_in_tool_registry().tools[0].json_schema()
+
+    def fail_json_schema(self: ToolDescriptor) -> str:  # pragma: no cover - regression sentinel
+        raise AssertionError("worker ToolConfig should use cached descriptor schema strings")
+
+    monkeypatch.setattr(ToolDescriptor, "json_schema", fail_json_schema)
+
+    config = registry.as_worker_tool_config()
+
+    assert config.tools[0].json_schema == expected_schema
+
+
 def test_built_in_tool_config_full_tuple_selection_returns_full_template_copy() -> None:
     selected_config = built_in_tool_config(tuple(list(BUILTIN_AGENTIC_TOOL_NAMES)))
     selected_config.tools.pop()

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -210,7 +210,7 @@ class ToolDescriptor:
         return common_pb2.ToolDefinition(
             name=self.name,
             description=self.description,
-            json_schema=self.json_schema(),
+            json_schema=self._cached_schema,
         )
 
 


### PR DESCRIPTION
## Summary
- Reuse the cached `ToolDescriptor` schema string directly when building worker `ToolDefinition` protobuf messages.
- Add a regression test proving worker `ToolConfig` materialization does not re-enter the public `json_schema()` accessor.
- Document the tool-registry performance slice in the governing plan.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# 126 passed in 0.45s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_schema_bytes_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_schema_bytes_probe.py
# 126 passed in 0.58s; changed-scope TOTAL 6 0 100%

# Local base/head registered probe comparison for tool-registry-schema-bytes-cache (origin/main vs HEAD):
# BASE: {"built_in_tool_config_elapsed_ms_mean": 56.50852406397462, "full_selection_tool_config_elapsed_ms_mean": 56.24193139374256, "partial_selection_tool_config_elapsed_ms_mean": 53.656027372926474, "schema_payload_elapsed_ms_mean": 148.22429814375937}
# HEAD: {"built_in_tool_config_elapsed_ms_mean": 55.585583206266165, "full_selection_tool_config_elapsed_ms_mean": 55.63813992775977, "partial_selection_tool_config_elapsed_ms_mean": 49.464132357388735, "schema_payload_elapsed_ms_mean": 147.62101080268621}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (6 measurable changed lines, 0 missed).
- Registered probe: `tool-registry-schema-bytes-cache`.
- Local probe deltas:
  - `built_in_tool_config_elapsed_ms_mean`: 56.5085 ms -> 55.5856 ms (delta -0.9229 ms, ~1.6% faster).
  - `full_selection_tool_config_elapsed_ms_mean`: 56.2419 ms -> 55.6381 ms (delta -0.6038 ms, ~1.1% faster).
  - `partial_selection_tool_config_elapsed_ms_mean`: 53.6560 ms -> 49.4641 ms (delta -4.1919 ms, ~7.8% faster).
  - `schema_payload_elapsed_ms_mean`: 148.2243 ms -> 147.6210 ms (delta -0.6033 ms, neutral/slightly faster).
- GitHub Actions PR-scoped performance is required as the merge gate for final registered probe validation.

## Known Gaps
- None. This is Python-only and was locally verified on Linux; CI remains the final registered probe validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. N/A: no observability-mode change; existing registered PR-scoped probe is reused.
- [x] Deferred work and known gaps are stated explicitly.
