### PR TITLE
perf: fast-path dataset quality completion rows

### DIFF
--- a/docs/plans/2026-07-21-dataset-quality-completion-dict-fastpath.md
+++ b/docs/plans/2026-07-21-dataset-quality-completion-dict-fastpath.md
@@ -1,0 +1,41 @@
+# Dataset Quality Completion Dict Fast Path
+
+## Goal
+
+Reduce Python overhead in `worker.productization.dataset_preparation._append_rows_output_lengths(...)` for the common dataset quality path where generated prompt/completion rows are plain `dict` objects with a direct `completion` field.
+
+## Scope
+
+- Python-only performance slice.
+- Affected implementation: `services/mlx-worker-python/worker/productization/dataset_preparation.py`.
+- Existing behavior is preserved for message rows, non-string completions, mixed rows, and dict subclasses.
+- No dataset schema, output artifact, partitioning, quality score, or CLI behavior changes.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped probe `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json`. The registry entry includes focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `services/mlx-worker-python/worker/productization/dataset_preparation.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_versioning.py`
+- `services/mlx-worker-python/tests/test_dataset_preparation_ingest.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/dataset_quality_lengths_probe.py`
+
+## Plan
+
+1. Confirm the registered probe and run the baseline probe locally on Linux.
+2. Add one exact-`dict` completion-row fast path that avoids the sentinel `get()` branch for plain prompt/completion rows.
+3. Keep the existing generic loop for dict subclasses and message/mixed fallback rows.
+4. Run the registered focused tests, changed-scope coverage, and local registered probe.
+5. Accept only if the local registered probe shows a clear non-regressive direction and CI registered probe completes successfully.
+
+## Metrics
+
+Primary metrics are emitted by `scripts/dataset_quality_lengths_probe.py`:
+
+- `elapsed_ms_mean`
+- `elapsed_ms_min`
+- `elapsed_ms_p95`
+- row counts and output-length statistics as parity guards
+
+The failed-partition metrics emitted by the same probe are informational for this slice because the implementation change only targets output-length aggregation.

--- a/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
+++ b/services/mlx-worker-python/tests/test_dataset_preparation_versioning.py
@@ -233,6 +233,16 @@ def test_dataset_quality_completion_rows_use_get_sentinel_fast_path() -> None:
     assert _sample_output_lengths([row], []) == [5]
 
 
+def test_dataset_quality_exact_dict_completion_fast_path_preserves_subclass_fallback() -> None:
+    class CompletionRow(dict[str, object]):
+        pass
+
+    assert _sample_output_lengths(
+        [{"completion": "abc"}, CompletionRow({"completion": "hello"})],
+        [],
+    ) == [3, 5]
+
+
 def test_dataset_quality_message_rows_skip_completion_key_lookup() -> None:
     class MessageRow(dict[str, object]):
         def __getitem__(self, key: str) -> object:  # pragma: no cover - regression tripwire

--- a/services/mlx-worker-python/worker/productization/dataset_preparation.py
+++ b/services/mlx-worker-python/worker/productization/dataset_preparation.py
@@ -1879,6 +1879,12 @@ def _append_rows_output_lengths(
     lengths: list[int],
     rows: list[dict[str, Any]],
 ) -> int:
+    try:
+        first_row = rows[0]
+    except IndexError:
+        return 0
+    if type(first_row) is dict and "completion" in first_row:
+        return _append_exact_dict_completion_output_lengths(lengths, rows)
     append = lengths.append
     len_ = len
     str_ = str
@@ -1924,6 +1930,32 @@ def _append_rows_output_lengths(
                 length = len_(str_(completion))
             append(length)
             output_length_total += length
+    return output_length_total
+
+
+def _append_exact_dict_completion_output_lengths(
+    lengths: list[int],
+    rows: list[dict[str, Any]],
+) -> int:
+    append = lengths.append
+    len_ = len
+    str_ = str
+    output_length_total = 0
+    for row in rows:
+        if type(row) is not dict:
+            output_length_total += _append_rows_output_lengths(lengths, [row])
+            continue
+        try:
+            completion = row["completion"]
+        except KeyError:
+            output_length_total += _append_rows_output_lengths(lengths, [row])
+            continue
+        if type(completion) is str_:
+            length = len_(completion)
+        else:
+            length = len_(str_(completion))
+        append(length)
+        output_length_total += length
     return output_length_total
 
 


### PR DESCRIPTION
## Summary
- Adds a plain-`dict` completion-row fast path for dataset quality output-length aggregation.
- Preserves the existing generic path for message rows, mixed rows, non-string completions, and dict subclasses.
- Adds a focused regression guard for subclass fallback behavior.

## Plan or Spec
- `docs/plans/2026-07-21-dataset-quality-completion-dict-fastpath.md`
- Registered probe: `dataset-quality-lengths-chain` in `infra/perf/pr_scoped_probes.json` (existing focused test, coverage, and probe commands cover this path).

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_dataset_version_listing_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_preparation_probes_cover_privacy_and_workspace_path_ingest_tests services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_dataset_quality_lengths_probe_script_emits_metrics` → `64 passed in 0.72s`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q ... && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/dataset_preparation.py services/mlx-worker-python/tests/test_dataset_preparation_versioning.py services/mlx-worker-python/tests/test_dataset_preparation_ingest.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/dataset_quality_lengths_probe.py` → `64 passed in 1.49s`; `TOTAL 30 0 100%`
- Baseline local probe on `origin/main`: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=101 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py`
- Head local probe: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_DATASET_QUALITY_LENGTHS_SAMPLES=101 uv run --project services/mlx-worker-python python3 scripts/dataset_quality_lengths_probe.py`
- `git diff --check`

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 30 0 100%`.
- Local Linux registered probe comparison (`dataset-quality-lengths-chain`, 101 samples):
  - baseline `elapsed_ms_mean=2.606785`, `elapsed_ms_p95=2.951269`
  - head `elapsed_ms_mean=2.485682`, `elapsed_ms_p95=2.559344`
  - mean delta `-0.121103 ms` (~4.65% faster), p95 delta `-0.391925 ms`
- Parity metrics unchanged: `row_count=15000`, `mean_output_length=51.999`, `p95_output_length=100.0`.
- Failed-partition metrics are informational for this slice because only output-length aggregation changed.

## Known Gaps
- Swift runtime effects are not relevant to this Python-only slice.
- Final registered probe validation must come from GitHub Actions PR-scoped performance workflow before merge.

## Evidence Checklist
- [x] Branch created from current `origin/main`.
- [x] Affected path has a registered PR-scoped performance probe with focused commands.
- [x] Focused tests passed locally on Linux.
- [x] Changed-scope coverage is at least 95%.
- [x] Registered probe ran locally on Linux and showed a positive direction.
- [ ] GitHub Actions and registered PR-scoped performance report are green.
