### PR TITLE
perf: fast-path hub library mlx names

### DIFF
--- a/docs/plans/2026-07-21-hub-library-name-exact-fastpath.md
+++ b/docs/plans/2026-07-21-hub-library-name-exact-fastpath.md
@@ -1,0 +1,40 @@
+# Hub catalog library-name exact MLX fast path
+
+## Scope
+
+This Python-only performance slice is limited to `worker.model_ops.hub_catalog._payload_is_mlx_compatible()`.
+It preserves Hub MLX compatibility detection while replacing a tiny exact-name frozenset lookup on
+the payload library name with direct string comparisons before the mixed-case atom fallback.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`.
+The probe has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+The probe records both size-hint parser metrics and the Hub payload compatibility workload;
+this slice targets `payload_compatibility_elapsed_ms_mean` while keeping size-hint counters
+unchanged.
+
+## Implementation plan
+
+1. Keep `_is_mlx_atom()` unchanged for mixed-case and scalar compatibility checks.
+2. Replace exact `MLX`/`mlx` library-name set membership with direct equality checks in
+   `_payload_is_mlx_compatible()`.
+3. Reuse the focused Hub catalog tests that cover exact, mixed-case, malformed, and nested
+   compatibility payloads.
+4. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Focused Hub catalog tests pass.
+- Changed-scope coverage for touched Python paths remains at least 95%.
+- The registered local probe reports directionally lower `payload_compatibility_elapsed_ms_mean`
+  without changing `size_hint_calls_mean` or compatibility match counts.
+- GitHub Actions and the registered PR-scoped performance report complete successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4482,7 +4482,8 @@
       "services/mlx-worker-python/worker/model_ops/hub_catalog.py",
       "services/mlx-worker-python/tests/test_hub_catalog.py",
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
-      "scripts/hub_catalog_size_hint_probe.py"
+      "scripts/hub_catalog_size_hint_probe.py",
+      "docs/plans/2026-07-21-hub-library-name-exact-fastpath.md"
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py",

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -573,7 +573,7 @@ def _repo_id_contains_mlx(repo_id: str) -> bool:
 def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
     raw_library_name = payload.get("library_name")
     library_name = raw_library_name if isinstance(raw_library_name, str) else ""
-    if library_name in _EXACT_MLX_LIBRARY_NAMES or (
+    if library_name == "mlx" or library_name == "MLX" or (
         library_name and _is_mlx_atom(library_name)
     ):
         return True


### PR DESCRIPTION
## Summary
- Fast-path exact `mlx`/`MLX` Hub payload library names before falling back to mixed-case atom parsing.
- Add a governing plan for this focused Python performance slice.

## Plan or Spec
- `docs/plans/2026-07-21-hub-library-name-exact-fastpath.md`

## Commands Run
```text
# Baseline registered probe on origin/main before implementation
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0: {"elapsed_ms_mean": 1269.0243222285062, "payload_compatibility_elapsed_ms_mean": 186.97735196910799, "payload_compatibility_matched_count": 160000.0, "size_hint_calls_mean": 0.0, ...}

# Focused registered tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
exit 0: 97 passed in 0.30s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
exit 0: TOTAL 1 0 100%

# Registered local probe on head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
exit 0: {"elapsed_ms_mean": 1296.6101851779968, "payload_compatibility_elapsed_ms_mean": 183.73059160076082, "payload_compatibility_matched_count": 160000.0, "size_hint_calls_mean": 0.0, ...}

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Registered probe target metric: `payload_compatibility_elapsed_ms_mean` improved from `186.97735196910799` ms to `183.73059160076082` ms (`-3.24676036834717` ms, ~`1.74%` faster).
- Guard counters stayed stable: `payload_compatibility_matched_count=160000.0`, `size_hint_calls_mean=0.0`.
- Overall size-hint workload `elapsed_ms_mean` changed from `1269.0243222285062` ms to `1296.6101851779968` ms; this slice targets the registered compatibility submetric, and CI PR-scoped performance is the merge gate.

## Known Gaps
- Linux local validation covers this Python helper and registered probe. GitHub Actions PR-scoped performance must complete successfully before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing registered PR-scoped performance probe; probe overhead unchanged.
- [x] Deferred work and known gaps are stated explicitly.
