### PR TITLE
perf: fast-path hub card mlx library names

### DIFF
--- a/docs/plans/2026-07-21-hub-card-library-exact-fastpath.md
+++ b/docs/plans/2026-07-21-hub-card-library-exact-fastpath.md
@@ -1,0 +1,38 @@
+# Hub catalog card library-name exact MLX fast path
+
+## Scope
+
+This Python-only performance slice is limited to the Hub catalog MLX compatibility helpers in
+`worker.model_ops.hub_catalog`. It preserves exact and mixed-case MLX library-name detection while
+replacing the remaining exact-name frozenset membership checks with direct string comparisons.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`hub-catalog-size-hint-regex-precompile` in `infra/perf/pr_scoped_probes.json`. The probe has focused
+`test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/model_ops/hub_catalog.py`
+- `services/mlx-worker-python/tests/test_hub_catalog.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/hub_catalog_size_hint_probe.py`
+
+This slice extends that probe's compatibility workload with an exact `cardData.library_name == "mlx"`
+case so the registered metrics cover the changed card-data branch.
+
+## Implementation plan
+
+1. Remove the exact MLX library-name frozenset constant from the Hub catalog hot path.
+2. Use direct `"mlx"`/`"MLX"` equality checks before the existing mixed-case `_is_mlx_atom()` fallback.
+3. Add focused regression coverage proving exact card-data library names bypass `_is_mlx_atom()` while
+   mixed-case names still fall back to the atom check.
+4. Run the registered focused tests, changed-scope coverage, and registered probe locally on Linux.
+5. Use GitHub Actions PR-scoped performance as the merge gate.
+
+## Success criteria
+
+- Focused Hub catalog tests pass.
+- Changed-scope coverage for touched Python paths remains at least 95%.
+- The registered local probe reports directionally lower `payload_compatibility_elapsed_ms_mean` with
+  unchanged compatibility call count and expected match count for the updated workload.
+- GitHub Actions and the registered PR-scoped performance report complete successfully before merge.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -4483,7 +4483,8 @@
       "services/mlx-worker-python/tests/test_hub_catalog.py",
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/hub_catalog_size_hint_probe.py",
-      "docs/plans/2026-07-21-hub-library-name-exact-fastpath.md"
+      "docs/plans/2026-07-21-hub-library-name-exact-fastpath.md",
+      "docs/plans/2026-07-21-hub-card-library-exact-fastpath.md"
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics",
     "coverage_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py",

--- a/scripts/hub_catalog_size_hint_probe.py
+++ b/scripts/hub_catalog_size_hint_probe.py
@@ -35,7 +35,7 @@ def _payload(index: int) -> tuple[dict[str, Any], int]:
 
 
 def _compatibility_payload(index: int) -> tuple[dict[str, Any], bool]:
-    mode = index % 5
+    mode = index % 6
     if mode == 0:
         return {
             "id": "plain/model",
@@ -63,6 +63,12 @@ def _compatibility_payload(index: int) -> tuple[dict[str, Any], bool]:
             "tags": ["Text-Generation", object()],
             "library_name": "transformers",
             "cardData": {"tags": ["MLX", object()]},
+        }, True
+    if mode == 4:
+        return {
+            "id": "plain/model",
+            "tags": ["Text-Generation", object()],
+            "cardData": {"library_name": "mlx", "tags": ["audio", object()]},
         }, True
     return {
         "id": "plain/model",

--- a/services/mlx-worker-python/tests/test_hub_catalog.py
+++ b/services/mlx-worker-python/tests/test_hub_catalog.py
@@ -152,6 +152,24 @@ def test_mlx_library_exact_detection_skips_atom_helper(monkeypatch: pytest.Monke
     ) is True
     assert calls == 1
 
+    assert hub_catalog._payload_is_mlx_compatible(
+        {
+            "id": "plain/model",
+            "tags": ["Text-Generation"],
+            "cardData": {"library_name": "mlx"},
+        }
+    ) is True
+    assert calls == 1
+
+    assert hub_catalog._payload_is_mlx_compatible(
+        {
+            "id": "plain/model",
+            "tags": ["Text-Generation"],
+            "cardData": {"library_name": "MLX"},
+        }
+    ) is True
+    assert calls == 1
+
 
 def test_mlx_repo_id_detection_preserves_case_insensitive_matches() -> None:
     assert _repo_id_contains_mlx("plain/model") is False

--- a/services/mlx-worker-python/worker/model_ops/hub_catalog.py
+++ b/services/mlx-worker-python/worker/model_ops/hub_catalog.py
@@ -77,9 +77,6 @@ _COMMON_4BIT_OPTIQ_EXCLUDED_TAGS = {
     "float16",
     "qat",
 }
-_EXACT_MLX_LIBRARY_NAMES = frozenset({"MLX", "mlx"})
-
-
 @dataclass(frozen=True, slots=True)
 class HubModelSummaryRecord:
     repo_id: str
@@ -591,7 +588,8 @@ def _payload_is_mlx_compatible(payload: dict[str, Any]) -> bool:
         not library_name
         and isinstance(raw_card_library_name, str)
         and (
-            raw_card_library_name in _EXACT_MLX_LIBRARY_NAMES
+            raw_card_library_name == "mlx"
+            or raw_card_library_name == "MLX"
             or _is_mlx_atom(raw_card_library_name)
         )
     ):
@@ -613,7 +611,7 @@ def _is_mlx_compatible(
     lowered_tags = _normalized_lowered_tags(tags, lowered_tags)
     if "mlx" in lowered_tags:
         return True
-    if library_name in _EXACT_MLX_LIBRARY_NAMES or _is_mlx_atom(library_name):
+    if library_name == "mlx" or library_name == "MLX" or _is_mlx_atom(library_name):
         return True
     if _repo_id_contains_mlx(repo_id):
         return True


### PR DESCRIPTION
## Summary
- Fast-path exact `mlx`/`MLX` Hub `cardData.library_name` checks with direct string comparisons before the mixed-case atom fallback.
- Remove the remaining exact MLX library-name frozenset from the Hub catalog compatibility hot path.
- Extend the registered Hub catalog probe workload so PR-scoped performance covers the exact card-data library branch.

## Plan or Spec
- `docs/plans/2026-07-21-hub-card-library-exact-fastpath.md`

## Commands Run
```text
# Baseline sync / branch setup
cd /root/.hermes/profiles/coder/workspace/melix-base && git fetch origin && git reset --hard origin/main
cd /root/.hermes/profiles/coder/workspace/melix-base && git worktree add -b perf/hub-card-library-exact-fastpath-20260721 /root/.hermes/profiles/coder/workspace/worktrees/melix-hub-card-library-exact-fastpath-20260721 origin/main

# Focused tests
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics
# 97 passed in 1.61s

# Changed-scope coverage
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_hub_catalog_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_hub_catalog_size_hint_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/model_ops/hub_catalog.py services/mlx-worker-python/tests/test_hub_catalog.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/hub_catalog_size_hint_probe.py
# 97 passed in 0.55s; TOTAL 8 0 100%

# Registered local probe (head)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_HUB_CATALOG_SIZE_HINT_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/hub_catalog_size_hint_probe.py
# {"payload_compatibility_elapsed_ms_mean": 208.58771316707134, "payload_compatibility_calls_mean": 200000.0, "payload_compatibility_matched_count": 166667.0, ...}

# Local base-vs-head probe, using the head probe script for both implementations, 3 runs each
# payload_compatibility_elapsed_ms_mean base=194.736514 head=192.649955 delta=-2.086559 pct=-1.071
# payload_compatibility_calls_mean base=200000.000000 head=200000.000000 delta=0.000000 pct=0.000
# payload_compatibility_matched_count base=166667.000000 head=166667.000000 delta=0.000000 pct=0.000
# elapsed_ms_mean base=1291.246696 head=1274.216899 delta=-17.029798 pct=-1.319

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 8 0 100%` for `hub_catalog.py`, `test_hub_catalog.py`, `test_pr_scoped_performance.py`, and `hub_catalog_size_hint_probe.py`.
- Registered local probe metric: `payload_compatibility_elapsed_ms_mean=208.58771316707134 ms`, `payload_compatibility_calls_mean=200000`, `payload_compatibility_matched_count=166667`.
- Local base-vs-head comparison with the updated registered probe workload: `payload_compatibility_elapsed_ms_mean` improved from `194.736514 ms` to `192.649955 ms` (`delta=-2.086559 ms`, `-1.071%`).
- GitHub Actions PR-scoped performance is required as the merge gate before merging.

## Known Gaps
- Linux local verification covers the Python slice. No Swift runtime behavior is touched.
- Final registered PR-scoped performance validation must come from GitHub Actions before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; runtime probe overhead N/A because no runtime observability path changed.
- [x] Deferred work and known gaps are stated explicitly.
