### PR TITLE
perf: scan stream assembler channel headers by index

### DIFF
--- a/docs/plans/2026-05-20-stream-assembler-channel-name-probe-coverage.md
+++ b/docs/plans/2026-05-20-stream-assembler-channel-name-probe-coverage.md
@@ -25,6 +25,19 @@ Local Linux registered probe samples on this host:
 - delta: `-0.1247741796153905` ms, `3.014826555637104%` faster.
 - `channel_name_calls_mean`: unchanged at `13.0`.
 
+## 2026-07-21 indexed channel-name scan follow-up
+
+`origin/main` still uses CPython `strip().split(None, 1)[0].lower()` for `_pipe_channel_name(...)`. This follow-up narrows the parser-mode slice to a direct index scan that skips leading whitespace, advances to the first trailing whitespace, and lowercases only the channel token. Behavior remains equivalent for empty headers, leading whitespace, mixed-case channel names, tab-separated metadata, and headers without metadata; the hot path avoids allocating the stripped header and split list for each uncached Harmony channel header.
+
+The registered `stream-assembler-parser-mode-cache` probe remains the governing PR-scoped performance probe. It already watches `stream_assembler.py`, `test_stream_assembler.py`, `test_pr_scoped_performance.py`, and `scripts/stream_assembler_parser_mode_probe.py`, with focused `test_command`, `coverage_command`, and `probe_command` entries.
+
+Local Linux registered probe samples on this host (`MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512`):
+
+- baseline `origin/main`: `3.8412028070524684`, `3.7652363143934053`, `3.956838053454703` ms; mean `3.8544257249668587` ms.
+- indexed channel-name scan: `3.64667875919622`, `3.702656364566792`, `3.761872156701429` ms; mean `3.7037357601548135` ms.
+- delta: `-0.1506899648120452` ms, `3.910830471295034%` faster.
+- `channel_name_calls_mean`: unchanged at `13.0`.
+
 ## Verification plan
 
 1. Run the registered focused test command for `stream-assembler-parser-mode-cache`.

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1459,8 +1459,16 @@ class RequestStreamAssembler:
     @staticmethod
     @lru_cache(maxsize=16)
     def _pipe_channel_name(header: str) -> str:
-        parts = header.strip().split(None, 1)
-        return parts[0].lower() if parts else ""
+        start = 0
+        header_len = len(header)
+        while start < header_len and header[start].isspace():
+            start += 1
+        if start == header_len:
+            return ""
+        end = start + 1
+        while end < header_len and not header[end].isspace():
+            end += 1
+        return header[start:end].lower()
 
     @classmethod
     def _legacy_pipe_channel_header_body(cls, header: str, channel_name: str) -> str | None:


### PR DESCRIPTION
## Summary
- Optimize `RequestStreamAssembler._pipe_channel_name(...)` by scanning the Harmony channel header token by index instead of allocating `strip().split(None, 1)` intermediates.
- Preserve channel parsing behavior for empty headers, leading whitespace, mixed-case names, tab-separated metadata, and headers without metadata.
- Document the indexed channel-name follow-up and local Linux probe comparison.

## Plan or Spec
- `docs/plans/2026-05-20-stream-assembler-channel-name-probe-coverage.md`
- Registered PR-scoped probe: `stream-assembler-parser-mode-cache` in `infra/perf/pr_scoped_probes.json` (already includes focused `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline probe on origin/main, 3 samples with MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512
elapsed_ms_mean: 3.8412028070524684, 3.7652363143934053, 3.956838053454703

# Head probe before final verification, 3 samples with MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512
elapsed_ms_mean: 3.64667875919622, 3.702656364566792, 3.761872156701429

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
# 97 passed in 0.28s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics
# 97 passed in 0.53s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
# Wrote JSON report to coverage.json

python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py
# TOTAL 10 0 100%

MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py
# {"channel_name_calls_mean": 13.0, "channel_name_checksum": 86.0, "chunk_count": 1200.0, "elapsed_ms_mean": 3.8358907499969064, "harmony_channel_count": 13.0, "raw_char_count": 14810.0, "sample_count": 512.0, "tool_call_count": 10.0}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 10 0 100%`.
- Local baseline mean: `3.8544257249668587` ms.
- Local head comparison mean: `3.7037357601548135` ms.
- Local delta: `-0.1506899648120452` ms (`3.910830471295034%` faster).
- Final registered local probe run: `elapsed_ms_mean=3.8358907499969064`, `channel_name_calls_mean=13.0`, `harmony_channel_count=13.0`.
- CI PR-scoped performance is required as the merge gate for the registered probe validation.

## Known Gaps
- Linux local validation covers the Python stream assembler behavior and registered probe workload only. CI PR-scoped performance remains the source for repository base-vs-head report validation.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via existing PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
