### PR TITLE
perf: fast-path stream assembler channel names

### DIFF
--- a/services/mlx-worker-python/tests/test_stream_assembler.py
+++ b/services/mlx-worker-python/tests/test_stream_assembler.py
@@ -21,13 +21,15 @@ def test_pipe_channel_name_caches_repeated_headers() -> None:
     assert RequestStreamAssembler._pipe_channel_name(" analysis metadata\n") == "analysis"
     assert RequestStreamAssembler._pipe_channel_name(" analysis metadata\n") == "analysis"
     assert RequestStreamAssembler._pipe_channel_name("FINAL metadata") == "final"
+    assert RequestStreamAssembler._pipe_channel_name("commentary metadata") == "commentary"
+    assert RequestStreamAssembler._pipe_channel_name("commentary\tmetadata other") == "commentary"
     assert RequestStreamAssembler._pipe_channel_name("commentary\tmetadata") == "commentary"
     assert RequestStreamAssembler._pipe_channel_name("analysis") == "analysis"
     assert RequestStreamAssembler._pipe_channel_name("   ") == ""
 
     cache_info = RequestStreamAssembler._pipe_channel_name.cache_info()
     assert cache_info.hits == 1
-    assert cache_info.misses == 5
+    assert cache_info.misses == 7
 
     RequestStreamAssembler._pipe_channel_name.cache_clear()
 

--- a/services/mlx-worker-python/worker/runtime/stream_assembler.py
+++ b/services/mlx-worker-python/worker/runtime/stream_assembler.py
@@ -1459,6 +1459,22 @@ class RequestStreamAssembler:
     @staticmethod
     @lru_cache(maxsize=16)
     def _pipe_channel_name(header: str) -> str:
+        if header and not header[0].isspace():
+            space_index = header.find(" ")
+            if space_index >= 0:
+                newline_index = header.find("\n", 0, space_index)
+                if newline_index >= 0:
+                    return header[:newline_index].lower()
+                tab_index = header.find("\t", 0, space_index)
+                if tab_index >= 0:
+                    return header[:tab_index].lower()
+                return header[:space_index].lower()
+            newline_index = header.find("\n")
+            if newline_index >= 0:
+                return header[:newline_index].lower()
+            tab_index = header.find("\t")
+            if tab_index >= 0:
+                return header[:tab_index].lower()
         start = 0
         header_len = len(header)
         while start < header_len and header[start].isspace():


### PR DESCRIPTION
## Summary
- Add a no-leading-whitespace fast path for stream assembler pipe channel header parsing.
- Preserve newline/tab precedence before a later space so hidden reasoning channel handling remains unchanged.
- Extend channel-name cache coverage for direct space and tab-before-space headers.

## Plan or Spec
- Registered probe already covers `services/mlx-worker-python/worker/runtime/stream_assembler.py` via `infra/perf/pr_scoped_probes.json` (`stream-assembler-parser-mode-cache`) with focused `test_command`, `coverage_command`, and `probe_command`.
- No behavior or workflow spec change; this is a scoped parser fast-path optimization with parity tests.

## Commands Run
- `git fetch origin && git merge-base --is-ancestor HEAD origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_stream_assembler_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_stream_assembler.py::test_pipe_channel_name_caches_repeated_headers services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_stream_assembler_parser_mode_probe_script_emits_metrics`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json`
- `python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/stream_assembler.py services/mlx-worker-python/tests/test_stream_assembler.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/stream_assembler_parser_mode_probe.py`
- `MELIX_STREAM_ASSEMBLER_PARSER_MODE_SAMPLES=512 PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/stream_assembler_parser_mode_probe.py`
- Old/new local probe comparison, 3 runs each, by temporarily restoring `HEAD` and reapplying the working patch.
- `git diff --check`

## Coverage and Metrics
- Focused tests: 97 passed.
- Changed-scope coverage: `TOTAL 19 0 100%`.
- Registered local probe (current): `elapsed_ms_mean=3.7621700121235335`, `channel_name_calls_mean=13.0`, `harmony_channel_count=13.0`, `tool_call_count=10.0`, `sample_count=512.0`.
- Old/new local registered probe comparison (`elapsed_ms_mean`, 3 runs each): old `[4.019022504962777, 3.968945019551029, 3.8456878623946977]`, new `[3.8016975595382974, 3.9290428226195218, 3.770147427530901]`; old_mean=`3.944552`, new_mean=`3.833629`, delta_ms=`-0.110923`, speedup=`1.0289`, improvement=`2.81%`.

## Known Gaps
- Local validation ran on Linux only. This slice is Python-only and locally verifiable; CI is still required for the registered PR-scoped performance workflow report before merge.

## Evidence Checklist
- [x] Synced from `origin/main` before starting; branch base matched `origin/main`.
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at 100%.
- [x] Registered probe ran locally and showed a stable directional improvement.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
