### PR TITLE
perf: reuse report probe phase constants

### DIFF
--- a/docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md
+++ b/docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md
@@ -32,3 +32,15 @@ GitHub Actions PR-scoped performance remains the final registered probe validati
 The 2026-07-19 follow-up remains inside `worker.productization.report_evidence_gate` and keeps the same registered `report-evidence-gate-run-kind-set-membership` probe. `_slowest_probe_phases()` now appends the first five candidate rows directly and heapifies once before replacement comparisons, instead of calling `heapq.heappush()` for each seed row. The top-five ordering, side labels, typed duration handling, and tie ordering remain unchanged.
 
 Expected effect: lower `slowest_probe_phase_elapsed_ms_mean` in the registered probe, with the broader gate metrics non-regressive.
+
+## Follow-up: probe phase bucket constants
+
+The 2026-07-21 follow-up remains inside `worker.productization.report_evidence_gate`
+and keeps the same registered `report-evidence-gate-run-kind-set-membership` probe.
+`_probe_phases()` now reuses module-level probe-side and bucket tuples instead of
+reallocating those constants on every scan. Clean string phases keep the duplicate-
+membership short circuit, while stripped strings, non-string phases, and dict
+subclasses retain the existing behavior.
+
+Expected effect: lower `probe_phases_elapsed_ms_mean` in the registered probe, with
+the broader report evidence gate metrics non-regressive.

--- a/services/mlx-worker-python/tests/test_report_evidence_gate.py
+++ b/services/mlx-worker-python/tests/test_report_evidence_gate.py
@@ -831,6 +831,26 @@ def test_report_evidence_gate_probe_phases_preserves_clean_string_fast_path() ->
     assert phases == {"runtime_prepare", "model_load", "decode", "42"}
 
 
+def test_report_evidence_gate_probe_phases_preserves_dict_subclass_rows() -> None:
+    class PhaseRow(dict[str, object]):
+        pass
+
+    phases = report_evidence_gate_module._probe_phases(
+        {
+            "probe_summary": {
+                "baseline": {
+                    "slowest_phases": [
+                        PhaseRow(phase=" runtime_prepare "),
+                        PhaseRow(phase="runtime_prepare"),
+                    ]
+                }
+            }
+        }
+    )
+
+    assert phases == {"runtime_prepare"}
+
+
 def test_report_evidence_gate_run_kind_list_rules_reflect_mutation() -> None:
     run_kinds = ["evaluation"]
     rule = {"run_kinds": run_kinds}

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -11,6 +11,8 @@ from worker.productization.benchmark_evaluation_report import validate_report_pa
 REPORT_EVIDENCE_GATE_SCHEMA_VERSION = "melix.report_evidence_gate.v1"
 _EMPTY_PROBE_PHASES: frozenset[str] = frozenset()
 _JSON_LOADS = json.loads
+_PROBE_PHASE_BUCKETS = ("slowest_phases", "failed_phases", "skipped_phases", "fallback_phases")
+_PROBE_PHASE_SIDES = ("baseline", "candidate")
 
 DEFAULT_RELEASE_EVIDENCE_MATRIX: dict[str, dict[str, object]] = {
     "serving_benchmark": {
@@ -627,13 +629,12 @@ def _probe_phases(report: dict[str, object]) -> set[str]:
         return phases
     phases_add = phases.add
     to_string = str
-    buckets = ("slowest_phases", "failed_phases", "skipped_phases", "fallback_phases")
-    for side in ("baseline", "candidate"):
+    for side in _PROBE_PHASE_SIDES:
         side_summary = probe_summary.get(side)
         if not isinstance(side_summary, dict):
             continue
         side_summary_get = side_summary.get
-        for bucket in buckets:
+        for bucket in _PROBE_PHASE_BUCKETS:
             rows = side_summary_get(bucket)
             if not isinstance(rows, list):
                 continue


### PR DESCRIPTION
## Summary
- Reuse module-level probe phase side/bucket tuples in `report_evidence_gate._probe_phases()` instead of allocating them for every scan.
- Add a regression guard for dict-subclass probe rows to preserve the existing fallback behavior.
- Update the report evidence performance plan with the 2026-07-21 slice and registered probe expectation.

## Plan or Spec
- Updated `docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md`.
- Registered PR-scoped probe: `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json`.
- The registered probe already includes focused `test_command`, `coverage_command`, and `probe_command` entries for this path.

## Commands Run
- `git fetch origin --prune && git reset --hard origin/main`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_report_evidence_gate.py services/mlx-worker-python/tests/test_pr_scoped_performance.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage report --include='*/services/mlx-worker-python/worker/productization/report_evidence_gate.py,*/services/mlx-worker-python/tests/test_report_evidence_gate.py,*/services/mlx-worker-python/tests/test_pr_scoped_performance.py'`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`
- `git diff --check`

## Coverage and Metrics
- Focused tests: `386 passed in 123.22s`.
- Changed-scope coverage: `TOTAL 4462 stmts, 30 missed, 99%`; `report_evidence_gate.py` stayed at `95%`.
- Baseline local registered probe (`origin/main`, Linux): `elapsed_ms_mean=964.9854477029294`, `probe_phases_elapsed_ms_mean=51.449760841205716`.
- Candidate local registered probe (Linux): `elapsed_ms_mean=956.1154015362263`, `probe_phases_elapsed_ms_mean=47.61071400716901`.
- Local delta: `elapsed_ms_mean -8.870046166703105 ms` (`~0.9%` faster), `probe_phases_elapsed_ms_mean -3.839046834036704 ms` (`~7.5%` faster).

## Known Gaps
- Local validation is Linux-only. GitHub Actions PR-scoped performance remains the merge gate for the registered probe report.
- This slice intentionally changes only the report evidence `_probe_phases()` constant allocation path.

## Evidence Checklist
- [x] Synced from `origin/main` before branching.
- [x] Confirmed the affected path has a registered PR-scoped performance probe with test, coverage, and probe commands.
- [x] Added/updated focused regression coverage before claiming the optimization.
- [x] Ran focused tests locally.
- [x] Ran changed-scope coverage locally.
- [x] Ran the registered probe locally on Linux.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
