### PR TITLE
perf: elide empty engine media usage counters

### DIFF
--- a/docs/plans/2026-07-21-engine-generate-empty-media-usage-elision.md
+++ b/docs/plans/2026-07-21-engine-generate-empty-media-usage-elision.md
@@ -1,0 +1,28 @@
+# Engine generate empty media usage elision
+
+## Scope
+
+This Python-only performance slice is limited to `worker.engine.engine_core` generate/decode usage accounting for requests that do not have media-feature probe counters.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe `engine-generate-usage-token-elision` in `infra/perf/pr_scoped_probes.json`. The probe already has focused `test_command`, `coverage_command`, and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/engine/engine_core.py`
+- `services/mlx-worker-python/tests/test_generate_stream.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/engine_generate_usage_token_probe.py`
+
+## Plan
+
+1. Preserve protobuf usage defaults and media counter behavior for non-zero probe snapshots.
+2. Return `None` for absent or all-zero media-feature probe snapshots so text-only usage accounting can use the compact `UsageDelta` and `TextFinalizationUsage` paths.
+3. Add regression coverage for the all-zero probe snapshot elision.
+4. Run the registered focused tests, changed-scope coverage, and local registered probe on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate.
+
+## Acceptance
+
+- Focused generate-stream and registered-probe tests pass locally.
+- Changed-scope coverage for touched Python files remains at least 95%.
+- The local registered probe reports directionally lower `fallback_elapsed_ms_mean` for text-only usage requests.
+- The PR-scoped performance workflow completes successfully before merge.

--- a/services/mlx-worker-python/tests/test_generate_stream.py
+++ b/services/mlx-worker-python/tests/test_generate_stream.py
@@ -108,12 +108,18 @@ def test_text_native_mtp_parser_metrics_fast_paths_empty_events() -> None:
 
     assert engine_core_module._non_negative_int("invalid") == 0
     assert engine_core_module._cached_prompt_tokens_from_event(None) == 0
-    assert engine_core_module._media_feature_usage_from_probe(None) == {
-        "media_feature_cache_hits": 0,
-        "media_feature_cache_misses": 0,
-        "media_feature_encoder_calls_saved": 0,
-        "media_feature_work_saved_bytes": 0,
-    }
+    assert engine_core_module._media_feature_usage_from_probe(None) is None
+    assert (
+        engine_core_module._media_feature_usage_from_probe(
+            SimpleNamespace(
+                media_feature_cache_hits=0,
+                media_feature_cache_misses=0,
+                media_feature_encoder_calls_saved=0,
+                media_feature_work_saved_bytes=0,
+            )
+        )
+        is None
+    )
     assert engine_core_module._usage_delta(
         prompt_tokens=8,
         completion_tokens=2,

--- a/services/mlx-worker-python/worker/engine/engine_core.py
+++ b/services/mlx-worker-python/worker/engine/engine_core.py
@@ -194,9 +194,9 @@ def _probe_counter_value(probe: object, primary_key: str, legacy_key: str) -> in
     return _non_negative_int(value)
 
 
-def _media_feature_usage_from_probe(probe: object | None) -> dict[str, int]:
+def _media_feature_usage_from_probe(probe: object | None) -> dict[str, int] | None:
     if probe is None:
-        return _EMPTY_MEDIA_FEATURE_USAGE
+        return None
     usage = {
         "media_feature_cache_hits": 0,
         "media_feature_cache_misses": 0,
@@ -210,7 +210,9 @@ def _media_feature_usage_from_probe(probe: object | None) -> dict[str, int]:
             key,
             key.replace("media_feature_", "image_feature_"),
         )
-    return usage
+    if any(usage.values()):
+        return usage
+    return None
 
 
 def _last_media_feature_probe(runtime: object, runtime_kind: str) -> object | None:


### PR DESCRIPTION
## Summary
- Elide empty media-feature usage dictionaries in `engine_core` so text-only generate/decode usage paths use the compact protobuf/default usage path.
- Preserve non-zero media-feature counter propagation, including legacy `image_feature_*` fallback counters.
- Add focused regression coverage and a governing performance-slice plan.

## Plan or Spec
- `docs/plans/2026-07-21-engine-generate-empty-media-usage-elision.md`

## Commands Run
```text
# Baseline registered probe on origin/main before code changes
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS=300 MELIX_ENGINE_GENERATE_FALLBACK_PROBE_REQUESTS=80 MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES=5 MELIX_ENGINE_GENERATE_USAGE_PROBE_PROMPT_WORDS=4096 uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# exit 0; fallback_elapsed_ms_mean=167.20271506346762; elapsed_ms_mean=32.9024170525372; fallback_peak_bytes_mean=86644.4

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
# exit 0; 49 passed in 1.92s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_engine_generate_usage_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_engine_generate_usage_token_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/engine/engine_core.py services/mlx-worker-python/tests/test_generate_stream.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/engine_generate_usage_token_probe.py
# exit 0; 49 passed in 1.32s; TOTAL 7 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_ENGINE_GENERATE_USAGE_REPO_ROOT="$PWD" MELIX_ENGINE_GENERATE_USAGE_PROBE_REQUESTS=300 MELIX_ENGINE_GENERATE_FALLBACK_PROBE_REQUESTS=80 MELIX_ENGINE_GENERATE_USAGE_PROBE_SAMPLES=5 MELIX_ENGINE_GENERATE_USAGE_PROBE_PROMPT_WORDS=4096 uv run --project services/mlx-worker-python python3 scripts/engine_generate_usage_token_probe.py
# exit 0; fallback_elapsed_ms_mean=162.6478634774685; elapsed_ms_mean=31.230592261999846; fallback_peak_bytes_mean=86936.4

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 7 0 100%` for `engine_core.py`, `test_generate_stream.py`, `test_pr_scoped_performance.py`, and `engine_generate_usage_token_probe.py`.
- Local registered probe (`engine-generate-usage-token-elision`, Linux):
  - `fallback_elapsed_ms_mean`: 167.202715 -> 162.647863 ms (delta -4.554852 ms, ~2.72% faster).
  - `elapsed_ms_mean`: 32.902417 -> 31.230592 ms (delta -1.671825 ms, ~5.08% faster).
  - `fallback_peak_bytes_mean`: 86644.4 -> 86936.4 bytes (delta +292 bytes, ~0.34% higher; small tracemalloc noise / acceptable for the elapsed-time slice).
- Registered PR-scoped performance CI is required before merge and is the final validation source.

## Known Gaps
- Full repository `make py-test`, `make swift-test`, and `make integration-test` were not run locally; this is a focused Python performance slice on Linux.
- No Swift runtime effect is claimed.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A, no observability surface changes; probe overhead is the registered local/CI performance probe.
- [x] Deferred work and known gaps are stated explicitly.
