### PR TITLE
perf: bind code eval assert prescan helpers

### DIFF
--- a/docs/plans/2026-07-21-code-eval-assert-prescan-local-bindings.md
+++ b/docs/plans/2026-07-21-code-eval-assert-prescan-local-bindings.md
@@ -1,0 +1,35 @@
+# Code Evaluation Assert Prescan Local Bindings
+
+## Scope
+
+This Python performance slice is limited to `worker.engine.code_eval_runner._may_contain_assert_statement()` in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+It does not change code-evaluation behavior, sandbox execution, payload parsing, protobuf artifacts, or external APIs.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance probe `code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json`.
+
+That probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_count_tests_probe.py`
+
+## Optimization Hypothesis
+
+The assertion pre-scan runs before AST parsing and is exercised repeatedly by the registered fallback test-count probe. Binding `str.find`, `str.isalnum`, and the small boundary sets as function defaults should avoid repeated global or bound-method lookups in the scan loop while preserving the existing token-boundary semantics.
+
+Expected effect:
+
+- reduce or keep neutral `code-eval-count-tests-line-scan` `elapsed_ms_mean` for syntax-error/no-assert fallback workloads;
+- keep `assert_elapsed_ms_mean` stable for assert-heavy payloads;
+- preserve behavior for comments, strings, identifier prefixes, inline assert statements, spacing, and boundary detection.
+
+## Validation Plan
+
+1. Run the registered focused pytest command locally on Linux.
+2. Run the registered changed-scope coverage command locally and require at least 95% coverage for touched scope.
+3. Run `scripts/code_eval_count_tests_probe.py` before and after the change and compare `elapsed_ms_mean`, `assert_elapsed_ms_mean`, and `peak_bytes_mean`.
+4. Use the GitHub PR-scoped performance workflow as the merge gate before squash merging.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -325,21 +325,28 @@ def _count_plain_assert_statement_lines(test_code: str) -> int:
     return count
 
 
-def _may_contain_assert_statement(test_code: str) -> bool:
-    cursor = test_code.find("assert")
+def _may_contain_assert_statement(
+    test_code: str,
+    *,
+    _find=str.find,
+    _isalnum=str.isalnum,
+    _line_spacing=_ASSERT_LINE_SPACING,
+    _preceding_boundaries=_ASSERT_PRECEDING_BOUNDARIES,
+) -> bool:
+    cursor = _find(test_code, "assert")
     if cursor < 0:
         return False
     text_length = len(test_code)
     while cursor >= 0:
         after_index = cursor + 6
         after = test_code[after_index] if after_index < text_length else "\n"
-        if after != "_" and not after.isalnum():
+        if after != "_" and not _isalnum(after):
             before_index = cursor - 1
-            while before_index >= 0 and test_code[before_index] in _ASSERT_LINE_SPACING:
+            while before_index >= 0 and test_code[before_index] in _line_spacing:
                 before_index -= 1
-            if before_index < 0 or test_code[before_index] in _ASSERT_PRECEDING_BOUNDARIES:
+            if before_index < 0 or test_code[before_index] in _preceding_boundaries:
                 return True
-        cursor = test_code.find("assert", after_index)
+        cursor = _find(test_code, "assert", after_index)
     return False
 
 


### PR DESCRIPTION
## Summary
- Bind `str.find`, `str.isalnum`, and assertion boundary sets as `_may_contain_assert_statement()` defaults.
- Keep the code-eval assert pre-scan semantics unchanged while reducing hot-loop lookup overhead.
- Add a focused plan for the registered performance slice.

## Plan or Spec
- `docs/plans/2026-07-21-code-eval-assert-prescan-local-bindings.md`
- Registered probe: `code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py` (baseline)
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py` (post-change)
- Registered `code-eval-count-tests-line-scan` test command from `infra/perf/pr_scoped_probes.json`
- Registered `code-eval-count-tests-line-scan` coverage command from `infra/perf/pr_scoped_probes.json`
- `git diff --check`

## Coverage and Metrics
- Focused tests: 18 passed in 1.45s.
- Changed-scope coverage: 100.00% (`TOTAL 6 0 100%`).
- Baseline probe: `elapsed_ms_mean=2.1607383553470885`, `assert_elapsed_ms_mean=3.525044968617814`, `peak_bytes_mean=25023.714285714286`.
- Post-change probe: `elapsed_ms_mean=1.8854844383895397`, `assert_elapsed_ms_mean=3.65905902747597`, `peak_bytes_mean=25023.714285714286`.
- Local delta: `elapsed_ms_mean` improved by ~12.74%; `assert_elapsed_ms_mean` regressed by ~3.80% (within the registered 5% warning threshold); peak bytes unchanged.

## Known Gaps
- Local validation is Linux/Python-only.
- The PR-scoped performance workflow remains the merge gate for registered probe validation in CI.

## Evidence Checklist
- [x] Affected path has a registered PR-scoped probe.
- [x] Focused tests passed locally.
- [x] Changed-scope coverage passed locally at >=95%.
- [x] Registered probe ran locally before and after the change.
- [ ] GitHub Actions PR-scoped performance report completed successfully.
