### PR TITLE
perf: bind matrix role probe phase lookup

### DIFF
--- a/docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md
+++ b/docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md
@@ -44,3 +44,15 @@ subclasses retain the existing behavior.
 
 Expected effect: lower `probe_phases_elapsed_ms_mean` in the registered probe, with
 the broader report evidence gate metrics non-regressive.
+
+## Follow-up: matrix role probe-phase lookup binding
+
+The 2026-07-21 matrix-role lookup follow-up remains inside
+`worker.productization.report_evidence_gate._report_matrix_roles` and keeps the
+same registered `report-evidence-gate-run-kind-set-membership` probe. The hot
+mixed-rule loop already binds `rule.get` for run-kind, metric-prefix, target-field,
+and rule dispatch checks; this slice reuses that same local binding for the lazy
+`probe_phases` materialization guard instead of performing one extra method lookup.
+
+Expected effect: lower `matrix_roles_elapsed_ms_mean` in the registered probe with
+unchanged emitted role counts and unchanged broader report evidence gate metrics.

--- a/services/mlx-worker-python/worker/productization/report_evidence_gate.py
+++ b/services/mlx-worker-python/worker/productization/report_evidence_gate.py
@@ -331,7 +331,7 @@ def _report_matrix_roles(
             targets = _dict_list(report.get("targets"))
         if metrics is None:
             metrics = _dict_list(report.get("metrics"))
-        if rule.get("probe_phases") and probe_phases is None:
+        if rule_get("probe_phases") and probe_phases is None:
             probe_phases = _probe_phases(report)
         if _rule_matches_report(
             rule=rule,


### PR DESCRIPTION
## Summary
- Bind the existing `rule.get` local in `_report_matrix_roles` for the lazy `probe_phases` guard.
- Update the report-evidence performance plan with this follow-up slice and expected metric.

## Plan or Spec
- Updated `docs/plans/2026-07-19-report-evidence-lazy-matrix-inputs.md`.
- Affected path is covered by registered PR-scoped probe `report-evidence-gate-run-kind-set-membership` in `infra/perf/pr_scoped_probes.json` with focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q ...test_report_evidence_gate... ...test_pr_scoped_performance...` → 34 passed.
- Registered coverage command for `report-evidence-gate-run-kind-set-membership` → changed line coverage 100.00% (`TOTAL 1 0 100%`).
- Registered probe command locally on Linux: `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_REPORT_EVIDENCE_GATE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/report_evidence_gate_run_kind_probe.py`.
- `git diff --check`.

## Coverage and Metrics
- Local Linux focused tests: 34 passed.
- Changed-scope coverage: 100.00% for the modified line in `report_evidence_gate.py`.
- Local registered probe baseline before change: `matrix_roles_elapsed_ms_mean=3.0418877955526114`, `matrix_roles_emitted_roles=40000.0`, `matrix_roles_role_count=32.0`.
- Local registered probe after change (3 runs): `matrix_roles_elapsed_ms_mean=2.956242812797427`, `3.0057047959417105`, `3.0134246684610844`; mean `2.991791`, delta `-0.050097 ms`, speedup `1.016745x` / `1.65%`.
- Registered PR-scoped performance CI is required for merge validation.

## Known Gaps
- This is a Python-only Linux-verifiable slice; no Swift runtime effect is claimed.
- CI PR-scoped probe report remains the final validation source before merge.

## Evidence Checklist
- [x] Registered PR-scoped probe exists for the affected path.
- [x] Focused test command passed locally.
- [x] Changed-scope coverage command passed locally.
- [x] Registered probe command ran locally and showed directional improvement.
- [ ] GitHub Actions and PR-scoped performance report completed successfully.
