### PR TITLE
perf: bind swift binary resolution locals

### DIFF
--- a/docs/plans/2026-07-21-integration-swift-binary-resolution-local-binds.md
+++ b/docs/plans/2026-07-21-integration-swift-binary-resolution-local-binds.md
@@ -1,0 +1,36 @@
+# Integration Swift binary resolution local binds
+
+## Scope
+
+This Python-only performance slice is limited to `tests/integration/helpers.py` and the Swift product binary resolution helper used by integration tests.
+
+The implementation keeps the existing `os.scandir()` candidate scan and executable selection semantics, but hoists repeated lookup work in `_newest_executable_swift_product_binary()` into local bindings:
+
+- `os.path.join` is bound once per resolution call.
+- the executable mode bit mask is computed once per resolution call.
+
+No Swift runtime behavior changes are included.
+
+## Registered Probe
+
+The affected path is covered by the registered PR-scoped probe `integration-swift-binary-resolution-scandir` in `infra/perf/pr_scoped_probes.json`.
+
+The registered probe includes focused `test_command`, `coverage_command`, and `probe_command` entries covering:
+
+- `tests/integration/helpers.py`
+- `tests/integration/test_helper_binary_resolution.py`
+- the probe script `scripts/integration_swift_binary_resolution_probe.py`
+
+## Verification Plan
+
+Local Linux validation must run:
+
+1. Focused integration helper tests.
+2. Changed-scope coverage through the registered coverage command.
+3. The registered probe command and recorded metrics.
+
+GitHub Actions PR-scoped performance remains the merge gate for the registered probe report before merge.
+
+## Success Criteria
+
+Accept the slice only if focused tests pass, changed-scope coverage is at least 95 percent, the local registered probe shows non-regressing binary-resolution elapsed time, and CI's registered PR-scoped performance workflow completes successfully.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -553,6 +553,8 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
     flat_depth = 0
     scoped_depth = 1
     build_root_path = os.fspath(build_root)
+    join_path = os.path.join
+    executable_mask = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
 
     def consider(candidate: str, *, depth: int) -> None:
         nonlocal newest_candidate, newest_key
@@ -560,14 +562,14 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
             candidate_stat = os.stat(candidate)
         except OSError:
             return
-        if not (stat.S_ISREG(candidate_stat.st_mode) and (candidate_stat.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))):
+        if not (stat.S_ISREG(candidate_stat.st_mode) and (candidate_stat.st_mode & executable_mask)):
             return
         candidate_key = (candidate_stat.st_mtime, depth)
         if newest_key is None or candidate_key > newest_key:
             newest_candidate = candidate
             newest_key = candidate_key
 
-    consider(os.path.join(build_root_path, "debug", product_name), depth=flat_depth)
+    consider(join_path(build_root_path, "debug", product_name), depth=flat_depth)
     try:
         entries = os.scandir(build_root_path)
     except FileNotFoundError:
@@ -576,7 +578,7 @@ def _newest_executable_swift_product_binary(build_root: Path, product_name: str)
     with entries:
         for entry in entries:
             if entry.name != "debug" and entry.is_dir(follow_symlinks=False):
-                consider(os.path.join(entry.path, "debug", product_name), depth=scoped_depth)
+                consider(join_path(entry.path, "debug", product_name), depth=scoped_depth)
     return Path(newest_candidate) if newest_candidate is not None else None
 
 


### PR DESCRIPTION
## Summary
- Bound repeated `os.path.join` lookup and executable-mode mask construction inside Swift product binary resolution.
- Added a focused plan for the registered integration helper performance slice.

## Plan or Spec
- `docs/plans/2026-07-21-integration-swift-binary-resolution-local-binds.md`
- Registered probe: `integration-swift-binary-resolution-scandir`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py
# 10 passed in 0.13s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands
# 22 passed in 1.37s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_integration_swift_binary_resolution_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_swift_binary_resolution_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_integration_remove_tree_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json tests/integration/helpers.py tests/integration/test_helper_binary_resolution.py tests/integration/test_helper_remove_tree.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/integration_swift_binary_resolution_probe.py scripts/integration_remove_tree_probe.py
# 22 passed in 0.59s; TOTAL 5 0 100%

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_SWIFT_BINARY_RESOLUTION_REPO_ROOT="$PWD" MELIX_REMOVE_TREE_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/integration_swift_binary_resolution_probe.py
# {"candidate_count": 1501, "delta_ms_mean": -113.46187745220959, "elapsed_ms_mean": 23.605303559452295, "legacy_elapsed_ms_mean": 137.0671810116619, "peak_bytes_mean": 2194.2, "samples": 5, ...}

git diff --check
# passed
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 5 0 100%`.
- Local registered probe before change: `elapsed_ms_mean=24.23155722208321`, `legacy_elapsed_ms_mean=136.94415902718902`, `delta_ms_mean=-112.7126018051058`, `peak_bytes_mean=2111.0`.
- Local registered probe after change: `elapsed_ms_mean=23.605303559452295`, `legacy_elapsed_ms_mean=137.0671810116619`, `delta_ms_mean=-113.46187745220959`, `peak_bytes_mean=2194.2`.
- Local binary-resolution delta vs pre-change sample: `-0.626253662630915 ms` mean elapsed. Registered PR-scoped performance CI remains the merge gate.

## Known Gaps
- Linux local validation exercises Python integration helper logic and synthetic probe fixtures only; no Swift runtime effect is claimed locally.
- CI is required for the registered PR-scoped performance report before merge.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no production observability changes.
- [x] Deferred work and known gaps are stated explicitly.
