### PR TITLE
perf: stream benchmark CSV row values

### DIFF
--- a/docs/plans/2026-07-21-benchmark-store-csv-row-generator.md
+++ b/docs/plans/2026-07-21-benchmark-store-csv-row-generator.md
@@ -1,0 +1,25 @@
+# Benchmark store CSV row generator slice
+
+## Scope
+
+This Python-only performance slice is limited to `BenchmarkStore._write_jsonl_and_csv` in `services/mlx-worker-python/worker/productization/benchmark_store.py`.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped performance probe `benchmark-store-matrix-streaming` in `infra/perf/pr_scoped_probes.json`. The probe includes focused `test_command`, `coverage_command`, and `probe_command` entries, and watches the benchmark store implementation, focused tests, PR-scoped performance tests, and `scripts/benchmark_store_probe.py`.
+
+## Change
+
+Avoid allocating a short-lived Python list for every CSV output row by passing a generator expression directly to `csv.writer.writerow`. JSONL serialization remains unchanged, and CSV field order continues to use the canonical field-name tuple.
+
+## Verification
+
+Run the registered focused tests, changed-scope coverage command, and registered probe locally on Linux before opening the PR. GitHub Actions PR-scoped performance remains the merge gate for the registered probe comparison.
+
+## Commands
+
+```bash
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/benchmark_store_probe.py
+PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
+```

--- a/services/mlx-worker-python/worker/productization/benchmark_store.py
+++ b/services/mlx-worker-python/worker/productization/benchmark_store.py
@@ -624,14 +624,11 @@ class BenchmarkStore:
             dump_json = json.JSONEncoder(separators=(",", ":")).encode
             normalize_csv_value = _csv_value
             write_csv_row = csv_writer.writerow
-            fieldnames_tuple = tuple(fieldnames)
             for row in rows:
                 payload = row.to_dict()
                 write_jsonl(dump_json(payload) + "\n")
                 payload_get = payload.get
-                write_csv_row(
-                    [normalize_csv_value(payload_get(field, "")) for field in fieldnames_tuple]
-                )
+                write_csv_row(normalize_csv_value(payload_get(field, "")) for field in fieldnames)
 
     @staticmethod
     def _attach_matrix_tool_turn_summary_fields(


### PR DESCRIPTION
## Summary
- Streams benchmark CSV row values directly into `csv.writer.writerow` instead of allocating a per-row list.
- Keeps JSONL serialization and canonical CSV field ordering unchanged.

## Plan or Spec
- `docs/plans/2026-07-21-benchmark-store-csv-row-generator.md`
- Registered probe: `benchmark-store-matrix-streaming` in `infra/perf/pr_scoped_probes.json` (has `test_command`, `coverage_command`, and `probe_command`).

## Commands Run
```text
# Baseline local registered probe on origin/main (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
base peak_bytes_mean samples: 178745.3, 178706.7, 178726.3

# Focused tests on head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
28 passed in 7.67s

# Changed-scope coverage on head
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_benchmark_store_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_counts_lines_without_read_text services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_benchmark_store_probe_script_emits_metrics
28 passed in 30.66s
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json
Wrote JSON report to coverage.json
python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/benchmark_store.py services/mlx-worker-python/tests/test_benchmark_store.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/benchmark_store_probe.py
TOTAL 1 0 100%

# Head local registered probe (3 runs)
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/benchmark_store_probe.py
head peak_bytes_mean samples: 178050.0, 178089.3, 178030.3

git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%`.
- Local registered probe metric (`peak_bytes_mean`, lower is better): base_mean=178726.1 bytes, head_mean=178056.5 bytes, delta=-669.6 bytes (-0.375%).
- Representative head probe output: `{"elapsed_ms_mean": 1832.54549, "peak_bytes_mean": 178030.3, "request_csv_line_count": 6001.0, "request_row_count": 6000.0, "sample_count": 3.0, "summary_row_count": 750.0}`.
- CI PR-scoped performance is required as the merge gate for the registered probe comparison.

## Known Gaps
- Full repository `make` gates were not run locally; this is a focused Python performance slice verified with the registered probe, focused tests, and changed-scope coverage on Linux.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no new runtime observability.
- [x] Deferred work and known gaps are stated explicitly.
