### PR TITLE
perf: bind event response JSON prefix checks

### DIFF
--- a/docs/plans/2026-07-21-event-response-startswith-bind.md
+++ b/docs/plans/2026-07-21-event-response-startswith-bind.md
@@ -1,0 +1,39 @@
+# Event extraction response JSON startswith binding
+
+## Scope
+
+This Python-only performance slice is limited to
+`worker.productization.event_extraction._parse_response_json`.
+
+The response parser checks the same response string for fenced and unfenced JSON
+prefixes while parsing high-volume event extraction responses. The slice keeps
+parsing behavior unchanged while preserving the direct-object fast path and then
+binding the response `startswith` method plus JSON fence constants once before
+the fenced/leading-whitespace branch checks.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`event-extraction-response-json-fence-trim` in
+`infra/perf/pr_scoped_probes.json`. The registry entry includes focused
+`test_command`, `coverage_command`, and `probe_command` fields and watches:
+
+- `services/mlx-worker-python/worker/productization/event_extraction.py`
+- `services/mlx-worker-python/tests/test_event_extraction.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/event_extraction_response_json_probe.py`
+
+## Verification plan
+
+1. Run the registered focused tests locally on Linux.
+2. Run the registered changed-scope coverage command locally on Linux.
+3. Run the registered response JSON probe locally on Linux and compare the
+   pre-change baseline against the head sample.
+4. Use GitHub Actions PR-scoped performance as the final registered probe report
+   and merge gate.
+
+## Expected metrics
+
+Expected direction is lower `elapsed_ms_mean` for fenced JSON responses and
+stable or lower `direct_elapsed_ms_mean` for direct JSON responses in
+`scripts/event_extraction_response_json_probe.py`.

--- a/services/mlx-worker-python/worker/productization/event_extraction.py
+++ b/services/mlx-worker-python/worker/productization/event_extraction.py
@@ -2897,10 +2897,13 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
-    if response_length and response_text[0] == "`" and response_text.startswith(_JSON_FENCE_PREFIX):
+    response_startswith = response_text.startswith
+    json_fence_prefix = _JSON_FENCE_PREFIX
+    json_fence_prefix_length = _JSON_FENCE_PREFIX_LENGTH
+    if response_length and response_text[0] == "`" and response_startswith(json_fence_prefix):
         parsed, end_index = raw_decode(
             response_text,
-            _JSON_FENCE_PREFIX_LENGTH,
+            json_fence_prefix_length,
         )
         if not has_only_optional_closing_fence(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
@@ -2916,10 +2919,10 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
             raise json.JSONDecodeError("Extra data", response_text, end_index)
         return parsed
 
-    if response_text.startswith(_JSON_FENCE_PREFIX, response_start):
+    if response_startswith(json_fence_prefix, response_start):
         parsed, end_index = raw_decode(
             response_text,
-            response_start + _JSON_FENCE_PREFIX_LENGTH,
+            response_start + json_fence_prefix_length,
         )
         if not has_only_optional_closing_fence(response_text, end_index, response_length):
             raise json.JSONDecodeError("Extra data", response_text, end_index)
@@ -2927,7 +2930,7 @@ def _parse_response_json(response_text: str) -> dict[str, object]:
             raise ValueError("LLM response must be a JSON object")
         return parsed
 
-    if response_text.startswith("```", response_start):
+    if response_startswith("```", response_start):
         newline_index = response_text.find("\n", response_start)
         if newline_index >= 0:
             parsed, end_index = raw_decode(response_text, newline_index + 1)


### PR DESCRIPTION
## Summary
- Bind the response `startswith` method and JSON fence constants after the direct-object fast path inside the event extraction response parser.
- Keep fenced, generic-fenced, leading-whitespace, and direct-object JSON parsing behavior unchanged.

## Plan or Spec
- `docs/plans/2026-07-21-event-response-startswith-bind.md`

## Commands Run
```text
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_EVENT_RESPONSE_JSON_PROBE_ITERATIONS=100 MELIX_EVENT_RESPONSE_JSON_PROBE_SAMPLES=5 python3 scripts/event_extraction_response_json_probe.py
# baseline before change: {"direct_elapsed_ms_mean": 1515.1243167929351, "elapsed_ms_mean": 1645.8583189174533, ...}
# head after direct-fast-path-preserving fix: {"direct_elapsed_ms_mean": 1423.4484815970063, "elapsed_ms_mean": 1479.9694021698087, ...}

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_direct_object_fast_path services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_object_fast_paths_skip_json_loads services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list
# 3 passed in 0.22s

PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_partial_fenced_json_without_line_list services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_trims_inline_closing_fence_with_trailing_space services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_leading_whitespace_before_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_generic_fence_after_fast_json_prefix services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_unfenced_json_without_pretrim_copy services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_object_skips_fence_prefix_checks services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_direct_object_subclass_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_object_subclass_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_object_rejects_trailing_text services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_leading_whitespace_rejects_non_object_payload services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_accepts_direct_object_fast_path services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_object_fast_paths_skip_json_loads services/mlx-worker-python/tests/test_event_extraction.py::test_skip_json_whitespace_preserves_ascii_control_boundary services/mlx-worker-python/tests/test_event_extraction.py::test_skip_json_whitespace_keeps_unicode_whitespace_fallback services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_unfenced_closing_fence services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_trailing_text_after_fenced_json services/mlx-worker-python/tests/test_event_extraction.py::test_parse_response_json_rejects_fenced_non_object_payload services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_event_extraction_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_event_extraction_response_json_probe_script_emits_metrics && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/productization/event_extraction.py services/mlx-worker-python/tests/test_event_extraction.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/event_extraction_response_json_probe.py
# 21 passed in 0.57s; TOTAL 3 0 100%

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 3 0 100%`.
- Local Linux probe (100 iterations/sample, 5 samples): fenced `elapsed_ms_mean` 1645.8583 ms -> 1479.9694 ms (`-165.8889 ms`, ~1.11x faster); direct JSON `direct_elapsed_ms_mean` 1515.1243 ms -> 1423.4485 ms (`-91.6758 ms`, ~1.06x faster).
- CI PR-scoped performance must rerun `event-extraction-response-json-fence-trim` on commit `c231ba2b` before merge.

## Known Gaps
- Linux local validation only; GitHub Actions PR-scoped performance is the final registered probe report and merge gate.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason.
- [x] Deferred work and known gaps are stated explicitly.
