### PR TITLE
perf: elide schema consistency fallback sort

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -232,6 +232,26 @@ Expected effect:
 - leave policy-aware selection, registry selection, OpenAI schema generation,
   and protobuf config materialization unchanged.
 
+## Follow-up Slice: Schema Consistency Ordered Fallback Elision
+
+The 2026-07-22 follow-up keeps `preflight_agentic_tool_schema_consistency(...)`
+receipt ordering unchanged, but removes the final sorted seen-affordance fallback.
+`known_tool_names` is constructed only from the catalog snapshot, selectable
+built-in names, and the callable registry snapshot, and the ordering pass already
+covers those same sources. The preflight can therefore avoid an unreachable sorted
+tuple allocation while preserving deterministic ordering for built-in, catalog,
+and registry-local tool names.
+
+Expected effect:
+
+- reduce the registered `tool-registry-select-name-index-cache`
+  `preflight_consistency_elapsed_ms_mean` workload for consistency preflight paths
+  that only reference built-in agentic tools;
+- preserve referenced-tool ordering, invalid-affordance counting, missing-tool
+  receipts, and sanitization behavior;
+- leave registry selection, OpenAI schema generation, and protobuf config
+  materialization unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.

--- a/infra/perf/pr_scoped_probes.json
+++ b/infra/perf/pr_scoped_probes.json
@@ -5095,6 +5095,7 @@
       "services/mlx-worker-python/tests/test_pr_scoped_performance.py",
       "scripts/tool_registry_select_probe.py",
       "infra/perf/pr_scoped_probes.json",
+      "docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md",
       "docs/plans/2026-07-20-tool-registry-policy-receipt-field-locals.md"
     ],
     "test_command": "PYTHONPATH=\"$PWD:$PWD/services/mlx-worker-python\" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs",
@@ -5224,6 +5225,17 @@
       {
         "key": "policy_selected_schema_bytes_mean",
         "unit": "bytes",
+        "direction": "informational"
+      },
+      {
+        "key": "preflight_consistency_elapsed_ms_mean",
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "warn_pct": 5.0
+      },
+      {
+        "key": "preflight_referenced_tools_mean",
+        "unit": "tools",
         "direction": "informational"
       }
     ]

--- a/scripts/tool_registry_select_probe.py
+++ b/scripts/tool_registry_select_probe.py
@@ -18,6 +18,7 @@ from worker.runtime.tool_registry import (  # noqa: E402
     ToolRegistryError,
     built_in_tool_config,
     built_in_tool_registry,
+    preflight_agentic_tool_schema_consistency,
     select_agentic_tools_for_turn,
 )
 
@@ -53,6 +54,8 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
     whitespace_turn_selected_schema_bytes_samples: list[float] = []
     policy_planning_elapsed_samples: list[float] = []
     policy_selected_schema_bytes_samples: list[float] = []
+    preflight_consistency_elapsed_samples: list[float] = []
+    preflight_referenced_tool_samples: list[float] = []
     checksum = 0
 
     for _ in range(sample_count):
@@ -257,6 +260,38 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         )
         checksum += policy_schema_bytes
 
+        preflight_registry = registry.select(("local_compute",))
+        preflight_affordances = (
+            {"tool_name": "visit", "source": "workflow_selected"},
+            {"tool_name": "local_compute", "source": "workflow_selected"},
+            {"tool_name": "text_search", "source": "workflow_selected"},
+            {"tool_name": "bad tool", "source": "workflow_selected"},
+        )
+        preflight_referenced_tools = 0
+        preflight_started = time.perf_counter()
+        for _index in range(selector_iterations):
+            decision = preflight_agentic_tool_schema_consistency(
+                preflight_affordances,
+                registry=preflight_registry,
+                source="workflow_selected",
+            )
+            if decision.referenced_tools != ("text_search", "visit", "local_compute"):
+                raise RuntimeError(  # pragma: no cover
+                    f"unexpected preflight referenced tools: {decision.referenced_tools!r}"
+                )
+            if decision.missing_tools != ("text_search", "visit"):
+                raise RuntimeError(  # pragma: no cover
+                    f"unexpected preflight missing tools: {decision.missing_tools!r}"
+                )
+            preflight_referenced_tools += len(decision.referenced_tools)
+        preflight_consistency_elapsed_samples.append(
+            (time.perf_counter() - preflight_started) * 1000.0
+        )
+        preflight_referenced_tool_samples.append(
+            float(preflight_referenced_tools / selector_iterations)
+        )
+        checksum += preflight_referenced_tools
+
     return {
         "elapsed_ms_mean": statistics.fmean(elapsed_samples),
         "select_calls_mean": float(iterations),
@@ -309,6 +344,12 @@ def _measure(iterations: int, sample_count: int) -> dict[str, float]:
         "policy_planning_elapsed_ms_mean": statistics.fmean(policy_planning_elapsed_samples),
         "policy_selected_schema_bytes_mean": statistics.fmean(
             policy_selected_schema_bytes_samples
+        ),
+        "preflight_consistency_elapsed_ms_mean": statistics.fmean(
+            preflight_consistency_elapsed_samples
+        ),
+        "preflight_referenced_tools_mean": statistics.fmean(
+            preflight_referenced_tool_samples
         ),
         "checksum": float(checksum),
         "iterations": float(iterations),

--- a/services/mlx-worker-python/tests/test_pr_scoped_performance.py
+++ b/services/mlx-worker-python/tests/test_pr_scoped_performance.py
@@ -1111,6 +1111,8 @@ def test_tool_registry_select_probe_script_emits_metrics(
     assert metrics["always_only_selected_schema_bytes_mean"] > 0.0
     assert metrics["policy_planning_elapsed_ms_mean"] >= 0.0
     assert metrics["policy_selected_schema_bytes_mean"] > 0.0
+    assert metrics["preflight_consistency_elapsed_ms_mean"] >= 0.0
+    assert metrics["preflight_referenced_tools_mean"] == 3.0
 
 
 def test_tool_registry_names_probe_script_emits_metrics(

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -606,12 +606,7 @@ def _referenced_tool_affordance_names(
         return (), invalid_affordance_count
     ordered_names: list[str] = []
     ordered_name_set: set[str] = set()
-    for ordered_source_names in (
-        catalog_names,
-        SELECTABLE_AGENTIC_TOOL_NAMES,
-        registry_names,
-        tuple(sorted(seen_tool_names)),
-    ):
+    for ordered_source_names in (catalog_names, SELECTABLE_AGENTIC_TOOL_NAMES, registry_names):
         for tool_name in ordered_source_names:
             if tool_name in seen_tool_names and tool_name not in ordered_name_set:
                 ordered_names.append(tool_name)


### PR DESCRIPTION
## Summary
- Elide the final sorted seen-tool fallback in schema consistency preflight ordering; catalog, selectable built-in, and callable registry snapshots already cover all known names.
- Extend the registered `tool-registry-select-name-index-cache` probe with a focused schema-consistency preflight metric and add the governing plan doc to the probe watch scope.
- Preserve preflight ordering, missing-tool receipts, invalid-affordance counting, and sanitization behavior.

## Plan or Spec
- Updated `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` with the follow-up slice and expected registered probe metric.

## Commands Run
- `git fetch origin`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py`

## Coverage and Metrics
- Focused tests: 125 passed in 0.23s.
- Changed-scope coverage: TOTAL 17/17 covered, 100%.
- Registered local probe, baseline `origin/main` with updated probe harness: `preflight_consistency_elapsed_ms_mean=69.92418332956731` ms.
- Registered local probe, PR head: `preflight_consistency_elapsed_ms_mean=66.23810403980315` ms.
- Delta: -3.68607928976416 ms (-5.27%, lower is better). `preflight_referenced_tools_mean=3.0` in both runs.

## Known Gaps
- Python-only slice verified locally on Linux. No Swift runtime behavior changed.
- GitHub Actions PR-scoped performance report is required before merge.

## Evidence Checklist
- [x] Worktree synced to `origin/main` before the slice (`HEAD` and `origin/main` were both `1b1c9f77`).
- [x] Affected path has a registered PR-scoped probe with focused test, coverage, and probe commands.
- [x] Local focused tests passed.
- [x] Changed-scope coverage is at least 95%.
- [x] Local registered probe showed directional improvement.
- [ ] PR-scoped performance CI completed successfully.
