### PR TITLE
perf: cache tool registry preflight name sets

### DIFF
--- a/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
+++ b/docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md
@@ -252,6 +252,24 @@ Expected effect:
 - leave registry selection, OpenAI schema generation, and protobuf config
   materialization unchanged.
 
+## Follow-up Slice: Preflight Name Set Cache
+
+The 2026-07-22 preflight-name-set follow-up keeps
+`preflight_agentic_tool_schema_consistency(...)` receipts and referenced-tool
+ordering unchanged, but stores each `ToolRegistry` name snapshot as a cached
+`frozenset` during registry initialization. Consistency preflight can then reuse
+those cached membership sets instead of rebuilding `set(registry.names())` and
+`set(catalog.names())` on every call. The ordered tuple snapshots remain the
+source for receipt ordering.
+
+Expected effect:
+
+- reduce the registered `tool-registry-select-name-index-cache`
+  `preflight_consistency_elapsed_ms_mean` workload;
+- preserve callable/missing/referenced tool receipts and deterministic ordering;
+- leave registry selection, OpenAI schema generation, protobuf config handling,
+  and tool definitions unchanged.
+
 ## Validation Plan
 
 1. Run the registered focused test command locally on Linux.
@@ -261,7 +279,8 @@ Expected effect:
    compare the relevant registered metric (`schema_payload_elapsed_ms_mean` for
    schema-payload slices, `elapsed_ms_mean` for the OpenAI tool payload slice,
    `no_keyword_fallback_planning_elapsed_ms_mean` for the no-keyword fallback
-   slice, or `selector_planning_elapsed_ms_mean` and
+   slice, `preflight_consistency_elapsed_ms_mean` for preflight slices, or
+   `selector_planning_elapsed_ms_mean` and
    `current_capacity_planning_elapsed_ms_mean` for the local-compute seed slice)
    over repeated samples.
 4. Push only if local evidence is neutral-to-improved and rely on the GitHub

--- a/services/mlx-worker-python/tests/test_tool_registry.py
+++ b/services/mlx-worker-python/tests/test_tool_registry.py
@@ -173,6 +173,35 @@ def test_tool_schema_consistency_preflight_accepts_viewed_procedure_tool() -> No
     assert decision.receipt["corrective_action"] == ""
 
 
+def test_tool_schema_consistency_preflight_reuses_cached_name_sets() -> None:
+    class CountingNames(tuple[str, ...]):
+        iter_calls = 0
+
+        def __iter__(self):
+            type(self).iter_calls += 1
+            return super().__iter__()
+
+    registry = tool_registry_module.agentic_tool_catalog_registry().select(
+        ("local_compute",)
+    )
+    catalog = tool_registry_module.agentic_tool_catalog_registry()
+    object.__setattr__(catalog, "_tool_names", CountingNames(catalog.names()))
+
+    decision = tool_registry_module.preflight_agentic_tool_schema_consistency(
+        (
+            {"tool_id": "visit", "source": "viewed_procedure"},
+            {"tool_id": "local_compute", "source": "viewed_procedure"},
+        ),
+        registry=registry,
+        catalog=catalog,
+        source="viewed_procedure",
+    )
+
+    assert decision.referenced_tools == ("visit", "local_compute")
+    assert decision.missing_tools == ("visit",)
+    assert CountingNames.iter_calls == 1
+
+
 def test_tool_schema_consistency_preflight_reports_missing_catalog_custom_tool() -> None:
     custom_tool = ToolDescriptor(
         name="procedure_lookup",

--- a/services/mlx-worker-python/worker/runtime/tool_registry.py
+++ b/services/mlx-worker-python/worker/runtime/tool_registry.py
@@ -279,6 +279,7 @@ class ToolRegistry:
         "_schema_version",
         "_selection_cache",
         "_tool_by_name",
+        "_tool_name_set",
         "_tool_names",
         "_tool_names_list",
         "_tools",
@@ -304,6 +305,7 @@ class ToolRegistry:
         self._validate()
         self._tool_names = tuple(tool.name for tool in self._tools)
         self._tool_names_list = list(self._tool_names)
+        self._tool_name_set = frozenset(self._tool_names)
         self._tool_by_name = {tool.name: tool for tool in self._tools}
         self._openai_tool_templates: tuple[_OpenAIToolTemplate, ...] = tuple(
             (
@@ -553,9 +555,11 @@ def preflight_agentic_tool_schema_consistency(
     if catalog is None:
         catalog = agentic_tool_catalog_registry()
     callable_tools = registry.names()
-    callable_tool_set = set(callable_tools)
+    callable_tool_set = registry._tool_name_set
     catalog_tools = catalog.names()
-    known_tool_names = callable_tool_set | set(catalog_tools) | _BUILTIN_AGENTIC_TOOL_NAME_SET
+    known_tool_names = (
+        callable_tool_set | catalog._tool_name_set | _BUILTIN_AGENTIC_TOOL_NAME_SET
+    )
     referenced_tools, invalid_affordance_count = _referenced_tool_affordance_names(
         affordances,
         known_tool_names,


### PR DESCRIPTION
## Summary
- Cache each `ToolRegistry` name snapshot as a `frozenset` for consistency-preflight membership checks.
- Reuse cached registry/catalog name sets in `preflight_agentic_tool_schema_consistency(...)` while preserving ordered tuple snapshots for receipts.
- Add a regression test proving the catalog names snapshot is not re-iterated for set construction.

## Plan or Spec
- `docs/plans/2026-05-19-tool-registry-schema-payload-local-bindings.md` — added the "Preflight Name Set Cache" follow-up slice.
- Registered PR-scoped probe: `tool-registry-select-name-index-cache` in `infra/perf/pr_scoped_probes.json` covers `services/mlx-worker-python/worker/runtime/tool_registry.py` and includes focused `test_command`, `coverage_command`, and `probe_command` entries.

## Commands Run
```text
$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py::test_tool_schema_consistency_preflight_reuses_cached_name_sets services/mlx-worker-python/tests/test_tool_registry.py::test_tool_schema_consistency_preflight_reports_missing_workflow_tool_without_raw_text
2 passed in 0.30s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs
126 passed in 1.41s

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage run -m pytest -q services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_scope_report_selects_tool_registry_schema_bytes_probe services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_tool_registry_select_probe_script_emits_metrics services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probes_expose_focused_commands services/mlx-worker-python/tests/test_pr_scoped_performance.py::test_registered_probe_registry_entries_validate_commands_and_watch_globs && PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python coverage json -o coverage.json && python3 scripts/changed_scope_coverage.py --coverage-json coverage.json services/mlx-worker-python/worker/runtime/tool_registry.py services/mlx-worker-python/tests/test_tool_registry.py services/mlx-worker-python/tests/test_pr_scoped_performance.py scripts/tool_registry_select_probe.py
126 passed in 0.57s; TOTAL 16 0 100%

$ PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/tool_registry_select_probe.py
completed successfully; post-change sample: preflight_consistency_elapsed_ms_mean=67.39325136877596

$ git diff --check
exit 0
```

## Coverage and Metrics
- Changed-scope coverage: 100% (`TOTAL 16 0 100%`).
- Local Linux registered probe: `scripts/tool_registry_select_probe.py`.
- Three-run baseline vs head for `preflight_consistency_elapsed_ms_mean`:
  - baseline samples: 69.77976355701685, 66.13521915860474, 67.0446124393493 ms
  - head samples: 63.349001947790384, 64.38461295329034, 65.52078877575696 ms
  - old_mean=67.65319838499029 ms, new_mean=64.4181345589459 ms, delta=-3.235063826044396 ms, speedup=4.781834271359645%
- CI is required for the registered PR-scoped performance workflow and base-vs-head report before merge.

## Known Gaps
- Full repository `make bootstrap`, `make swift-test`, `make py-test`, and `make integration-test` were not run locally; this Python slice used the registered focused commands. GitHub Actions remains the merge gate.
- No protocol or dependency changes; no generated artifacts or lockfiles were touched.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: evidence via registered PR-scoped performance probe; no runtime observability changes.
- [x] Deferred work and known gaps are stated explicitly.
