### PR TITLE
perf: inline retrieval public receipts

### DIFF
--- a/docs/plans/2026-07-22-retrieval-public-receipt-loop-inline.md
+++ b/docs/plans/2026-07-22-retrieval-public-receipt-loop-inline.md
@@ -1,0 +1,39 @@
+# Retrieval public receipt loop inline
+
+## Scope
+
+This Python performance slice is limited to retrieval-context projection in
+`services/mlx-worker-python/worker/runtime/retrieval_context.py`.
+
+The hot path handles complete `RetrievalContextEntry` objects and complete plain
+store-record dictionaries whose source IDs are already public. Prior slices moved
+these records away from generic admission and regex-heavy receipt construction;
+this slice removes the remaining private helper call from the per-record public
+receipt path by constructing the small receipt dictionary directly in the loop.
+
+## Registered probe
+
+The affected path is covered by the registered PR-scoped probe
+`retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.
+The registry entry already includes focused `test_command`, `coverage_command`,
+and `probe_command` entries for:
+
+- `services/mlx-worker-python/worker/runtime/retrieval_context.py`
+- `services/mlx-worker-python/tests/test_retrieval_context.py`
+- `scripts/retrieval_context_projection_probe.py`
+
+## Implementation plan
+
+1. Keep public and untrusted receipt payloads byte-for-byte equivalent.
+2. Inline public receipt dictionary construction inside the complete-entry and
+   complete-store-record projection loops.
+3. Extend regression guards so complete public entries and store records fail if
+   they re-enter either public receipt helper.
+4. Run the focused test command, changed-scope coverage, and registered probe
+   locally on Linux before opening the PR.
+
+## Metrics
+
+Expected direction: lower `optimized_elapsed_ms_mean` and
+`store_optimized_elapsed_ms_mean` in `scripts/retrieval_context_projection_probe.py`.
+The PR-scoped performance workflow remains the merge gate.

--- a/services/mlx-worker-python/tests/test_retrieval_context.py
+++ b/services/mlx-worker-python/tests/test_retrieval_context.py
@@ -659,6 +659,11 @@ def test_project_retrieval_contexts_inlines_public_receipts(
         "untrusted_context_receipt",
         fail_receipt_builder,
     )
+    monkeypatch.setattr(
+        retrieval_context_module,
+        "_public_untrusted_context_receipt",
+        fail_receipt_builder,
+    )
 
     projection = project_retrieval_contexts(
         [
@@ -959,6 +964,11 @@ def test_project_retrieval_store_records_fast_paths_complete_dict_records(
     monkeypatch.setattr(
         retrieval_context_module,
         "untrusted_context_receipt",
+        fail_receipt_builder,
+    )
+    monkeypatch.setattr(
+        retrieval_context_module,
+        "_public_untrusted_context_receipt",
         fail_receipt_builder,
     )
     monkeypatch.setattr(untrusted_context_module, "_PUBLIC_SOURCE_ID_RE", RegexGuard())

--- a/services/mlx-worker-python/worker/runtime/retrieval_context.py
+++ b/services/mlx-worker-python/worker/runtime/retrieval_context.py
@@ -131,7 +131,6 @@ def project_retrieval_contexts(
     admit_entry = _admit_entry
     duplicate_projection_receipt = _duplicate_projection_receipt
     build_untrusted_context_receipt = untrusted_context_receipt
-    build_public_context_receipt = _public_untrusted_context_receipt
     is_public_source_id = _is_public_source_id
     refusal_receipts_extend = refusal_receipts.extend
     refusal_receipts_append = refusal_receipts.append
@@ -190,15 +189,21 @@ def project_retrieval_contexts(
                     else:
                         source_is_public = is_public_source_id(normalized_source_id)
                     if source_is_public:
-                        receipt = build_public_context_receipt(
-                            segment_id=normalized_segment_id,
-                            source_type=context_kind,
-                            source_field=normalized_source_field,
-                            source_id=normalized_source_id,
-                            owner_scope_checked=owner_scope_checked,
-                            reason=normalized_reason,
-                            corrective_action=normalized_corrective_action,
-                        )
+                        receipt = {
+                            "schema_version": UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+                            "segment_id": normalized_segment_id,
+                            "source_type": context_kind,
+                            "source_field": normalized_source_field,
+                            "message_role": "user",
+                            "trust_level": "untrusted",
+                            "policy": "data_only",
+                            "boundary_checked": True,
+                            "included": True,
+                            "owner_scope_checked": owner_scope_checked,
+                            "reason": normalized_reason,
+                            "corrective_action": normalized_corrective_action,
+                            "source_id": normalized_source_id,
+                        }
                     else:
                         receipt = build_untrusted_context_receipt(
                             segment_id=normalized_segment_id,
@@ -302,7 +307,6 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
     entry_type = RetrievalContextEntry
     duplicate_projection_receipt = _duplicate_projection_receipt
     build_untrusted_context_receipt = untrusted_context_receipt
-    build_public_context_receipt = _public_untrusted_context_receipt
     is_public_source_id = _is_public_source_id
     projection_refusal_receipts_extend = projection_refusal_receipts.extend
     receipts_append = receipts.append
@@ -403,15 +407,21 @@ def project_retrieval_store_records(records: Any) -> RetrievalContextProjection:
                     else:
                         source_is_public = is_public_source_id(normalized_source_id)
                     if source_is_public:
-                        receipt = build_public_context_receipt(
-                            segment_id=normalized_segment_id,
-                            source_type=context_kind,
-                            source_field=normalized_source_field,
-                            source_id=normalized_source_id,
-                            owner_scope_checked=owner_scope_checked,
-                            reason=normalized_reason,
-                            corrective_action=normalized_corrective_action,
-                        )
+                        receipt = {
+                            "schema_version": UNTRUSTED_CONTEXT_RECEIPT_SCHEMA_VERSION,
+                            "segment_id": normalized_segment_id,
+                            "source_type": context_kind,
+                            "source_field": normalized_source_field,
+                            "message_role": "user",
+                            "trust_level": "untrusted",
+                            "policy": "data_only",
+                            "boundary_checked": True,
+                            "included": True,
+                            "owner_scope_checked": owner_scope_checked,
+                            "reason": normalized_reason,
+                            "corrective_action": normalized_corrective_action,
+                            "source_id": normalized_source_id,
+                        }
                     else:
                         receipt = build_untrusted_context_receipt(
                             segment_id=normalized_segment_id,


### PR DESCRIPTION
## Summary
- Inline public untrusted-context receipt dictionaries in the complete retrieval-entry and store-record projection loops.
- Extend regression guards so public fast paths fail if they re-enter either generic or public receipt helper.
- Add the slice plan and register it under the existing retrieval-context PR-scoped probe watch globs.

## Plan or Spec
- `docs/plans/2026-07-22-retrieval-public-receipt-loop-inline.md`
- Registered probe: `retrieval-context-projection-fastpath` in `infra/perf/pr_scoped_probes.json`.

## Commands Run
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python pytest -q services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_contexts_inlines_public_receipts services/mlx-worker-python/tests/test_retrieval_context.py::test_project_retrieval_store_records_fast_paths_complete_dict_records`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" MELIX_RETRIEVAL_CONTEXT_PROJECTION_REPO_ROOT="$PWD" uv run --project services/mlx-worker-python python3 scripts/retrieval_context_projection_probe.py`
- `PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" python3 scripts/pr_scoped_performance_run.py --registry infra/perf/pr_scoped_probes.json --probe-id retrieval-context-projection-fastpath --base-repo /root/.hermes/profiles/coder/workspace/melix --head-repo "$PWD" --output artifacts/local/retrieval-context-projection-fastpath.json --coverage-paths-json '["services/mlx-worker-python/worker/runtime/retrieval_context.py","services/mlx-worker-python/tests/test_retrieval_context.py","services/mlx-worker-python/tests/test_pr_scoped_performance.py","scripts/retrieval_context_projection_probe.py"]'`
- `git diff --check`

## Coverage and Metrics
- Focused regression tests: 2 passed.
- Registered local head verification: 39 passed; changed-scope coverage `TOTAL 4 0 100%`.
- Local registered probe comparison:
  - `optimized_elapsed_ms_mean`: base `0.0960122553` ms -> head `0.0879155208` ms (`-0.0080967344` ms, ~8.43% lower).
  - `store_optimized_elapsed_ms_mean`: base `0.1056953274` ms -> head `0.0928586533` ms (`-0.0128366742` ms, ~12.15% lower).
  - `speedup`: base `9.9028318362x` -> head `10.7198294114x`.
  - `store_speedup`: base `2.6971186774x` -> head `3.0928545267x`.

## Known Gaps
- Linux local validation covers the Python retrieval projection path only.
- GitHub Actions PR-scoped performance report is still required before merge.

## Evidence Checklist
- [x] Relevant path has a registered PR-scoped performance probe.
- [x] Probe entry has focused `test_command`, `coverage_command`, and `probe_command`.
- [x] Focused local tests passed.
- [x] Changed-scope coverage passed at or above 95%.
- [x] Local registered probe shows directional improvement.
- [ ] GitHub Actions PR-scoped performance workflow completed successfully.
