### PR TITLE
perf: bind assert node len fast path

### DIFF
--- a/docs/plans/2026-07-22-code-eval-assert-node-len-binding.md
+++ b/docs/plans/2026-07-22-code-eval-assert-node-len-binding.md
@@ -1,0 +1,35 @@
+# Code Evaluation Assert Node Len Binding
+
+## Scope
+
+This Python performance slice is limited to `worker.engine.code_eval_runner._count_assert_nodes()` in `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
+
+It does not change code-evaluation behavior, sandbox execution, payload parsing, protobuf artifacts, or external APIs.
+
+## Registered Probe
+
+The affected path is already covered by the registered PR-scoped performance probe `code-eval-count-tests-line-scan` in `infra/perf/pr_scoped_probes.json`.
+
+That probe includes focused `test_command`, `coverage_command`, and `probe_command` entries and watches:
+
+- `services/mlx-worker-python/worker/engine/code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_code_eval_runner.py`
+- `services/mlx-worker-python/tests/test_pr_scoped_performance.py`
+- `scripts/code_eval_count_tests_probe.py`
+
+## Optimization Hypothesis
+
+The registered probe exercises the top-level assert-only AST fast path repeatedly through `_count_assert_nodes(...)`. Binding `len` as a function default lets the fast path return the already-validated module body length without a repeated global builtin lookup while preserving the existing exact-`ast.Assert` validation before the return.
+
+Expected effect:
+
+- reduce or keep neutral `code-eval-count-tests-line-scan` `assert_elapsed_ms_mean` for assert-heavy top-level payloads;
+- keep fallback `elapsed_ms_mean` and `peak_bytes_mean` stable;
+- preserve behavior for nested asserts, direct top-level asserts, AST subclasses, syntax-error fallback, no-assert fallback, and nonblank line counting.
+
+## Validation Plan
+
+1. Run the registered focused pytest command locally on Linux.
+2. Run the registered changed-scope coverage command locally and require at least 95% coverage for touched scope.
+3. Run `scripts/code_eval_count_tests_probe.py` before and after the change and compare `assert_elapsed_ms_mean`, `elapsed_ms_mean`, and `peak_bytes_mean`.
+4. Use the GitHub PR-scoped performance workflow as the merge gate before squash merging.

--- a/services/mlx-worker-python/worker/engine/code_eval_runner.py
+++ b/services/mlx-worker-python/worker/engine/code_eval_runner.py
@@ -357,6 +357,7 @@ def _count_assert_nodes(
     _assert_type=ast.Assert,
     _isinstance=isinstance,
     _type=type,
+    _len=len,
 ) -> int:
     module_body = getattr(module, "body", ())
     if module_body:
@@ -364,7 +365,7 @@ def _count_assert_nodes(
             if _type(node) is not _assert_type:
                 break
         else:
-            return len(module_body)
+            return _len(module_body)
 
     count = 0
     stack: list[ast.AST] = []


### PR DESCRIPTION
## Summary
- Bind `len` as a local default in `_count_assert_nodes(...)` for the top-level assert-only AST fast path.
- Keep code-evaluation behavior unchanged while avoiding the repeated builtin lookup after exact `ast.Assert` validation.

## Plan or Spec
- `docs/plans/2026-07-22-code-eval-assert-node-len-binding.md`

## Commands Run
```text
# Baseline sync / worktree
cd /root/.hermes/profiles/coder/workspace/melix && git fetch origin main && git reset --hard origin/main
cd /root/.hermes/profiles/coder/workspace/melix && git worktree add -b perf/code-eval-plain-assert-find-bind-20260722 /root/.hermes/profiles/coder/workspace/worktrees/melix-code-eval-plain-assert-find-bind-20260722 origin/main

# Baseline registered probe samples on origin/main
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
# 3 samples: assert_elapsed_ms_mean=[3.461479242624981, 3.6663885693997145, 3.5119674035481045], elapsed_ms_mean=[1.7708061994718653, 1.8809101477797543, 2.0050971569227323]

# Head registered probe samples
PYTHONPATH="$PWD:$PWD/services/mlx-worker-python" uv run --project services/mlx-worker-python python3 scripts/code_eval_count_tests_probe.py
# 3 samples: assert_elapsed_ms_mean=[3.450978913211397, 3.4578568302094936, 3.419376743425216], elapsed_ms_mean=[1.936350716277957, 1.8082457328481334, 1.7929287028631993]

# Registered focused test command for code-eval-count-tests-line-scan
bash /tmp/code_eval_test_command.sh
# 18 passed in 0.29s

# Registered changed-scope coverage command for code-eval-count-tests-line-scan
bash /tmp/code_eval_coverage_command.sh
# 18 passed in 4.70s; TOTAL 1 0 100%

# Registered probe command for code-eval-count-tests-line-scan
bash /tmp/code_eval_probe_command.sh
# {"assert_elapsed_ms_mean": 3.6967222445777486, "elapsed_ms_mean": 1.8084589059331588, "peak_bytes_mean": 25023.714285714286, ...}

git diff --check
# exit 0
```

## Coverage and Metrics
- Changed-scope coverage: `TOTAL 1 0 100%` for `services/mlx-worker-python/worker/engine/code_eval_runner.py`.
- Registered probe: `code-eval-count-tests-line-scan`.
- 3-sample local Linux comparison:
  - `assert_elapsed_ms_mean`: base mean `3.5466117385242666 ms`, head mean `3.442737495615369 ms`, delta `-0.10387424290889768 ms` (`-2.9288304039764843%`).
  - `elapsed_ms_mean`: base mean `1.8856045013914506 ms`, head mean `1.8458417173297634 ms`, delta `-0.039762784061687206 ms` (`-2.1087552576558295%`).
  - `peak_bytes_mean`: unchanged at `25023.714285714286 bytes`.
- GitHub Actions PR-scoped performance is required as the final registered probe validation before merge.

## Known Gaps
- Local validation is Linux/Python-only. No Swift runtime effect is claimed.
- The final base-vs-head registered probe decision is deferred to the PR-scoped performance CI report.

## Evidence Checklist
- [x] Relevant plan or spec is identified.
- [x] Behavior changes are reflected in the relevant docs.
- [x] Protocol changes include regenerated generated artifacts. N/A: no protocol changes.
- [x] Dependency changes include updated lockfiles. N/A: no dependency changes.
- [x] Relevant tests were run.
- [x] A metrics report is included, or `N/A` is stated explicitly with the reason.
- [x] Observability mode, probe overhead, and any deferred debug or evidence work are recorded, or `N/A` is stated explicitly with the reason. Observability mode: N/A; this uses existing PR-scoped performance evidence only.
- [x] Deferred work and known gaps are stated explicitly.
